### PR TITLE
Switch default theme to light

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -120,6 +120,15 @@ export default defineConfig({
         gtag('config', '${googleAnalyticsId}');
         `,
       },
+      {
+        tag: 'script',
+        content: `
+          if (!localStorage.getItem('starlight-theme')) {
+            document.documentElement.setAttribute('data-theme', 'light');
+            localStorage.setItem('starlight-theme', 'light');
+          }
+        `,
+      },
     ],
   })],
   markdown: {


### PR DESCRIPTION
## Summary
- default Starlight site to light theme by setting `data-theme="light"` if no prior user preference

## Testing
- `git status --short`