### PR TITLE
Fix docsSchema extend usage

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,10 +3,9 @@ import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 const extendedDocsSchema = docsSchema({
-  extend: (schema) =>
-    schema.extend({
-      template: z.enum(['doc', 'splash', 'page']).default('doc'),
-    }),
+  extend: z.object({
+    template: z.enum(['doc', 'splash', 'page']).default('doc'),
+  }),
 });
 
 export const collections = {


### PR DESCRIPTION
## Summary
- use `docsSchema` extension object instead of function

## Testing
- `npm run build` *(fails: astro not found)*