### PR TITLE
Enable Starlight page template

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -2,11 +2,11 @@ import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
-const extendedDocsSchema = docsSchema({
-  extend: z.object({
+// Extend the default Starlight docs schema to allow the `page` template
+const extendedDocsSchema = docsSchema()
+  .extend({
     template: z.enum(['doc', 'splash', 'page']).default('doc'),
-  }),
-});
+  });
 
 export const collections = {
   docs: defineCollection({ loader: docsLoader(), schema: extendedDocsSchema }),


### PR DESCRIPTION
## Summary
- extend Starlight docs schema directly so the `page` template is valid
- restore the `page` template on the Analytics Doctor test page

## Testing
- `npm run build` *(fails: astro not found)*