### PR TITLE
Fix Starlight schema extension syntax

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -3,10 +3,11 @@ import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 // Extend the default Starlight docs schema to allow the `page` template
-const extendedDocsSchema = docsSchema()
-  .extend({
+const extendedDocsSchema = docsSchema({
+  extend: z.object({
     template: z.enum(['doc', 'splash', 'page']).default('doc'),
-  });
+  }),
+});
 
 export const collections = {
   docs: defineCollection({ loader: docsLoader(), schema: extendedDocsSchema }),


### PR DESCRIPTION
## Summary
- adjust docsSchema extension in content config

## Testing
- `npm run build` *(fails: astro not found)*