### PR TITLE
Fix Tests nav link path

### DIFF
--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -12,7 +12,7 @@ const mainNav = [
   { label: 'Home', link: '/' },
   { label: 'About', link: '/about/' },
   { label: 'Roadmap', link: '/roadmap/' },
-  { label: 'Tests', link: '/tests/' },
+  { label: 'Tests', link: '/testing/' },
   { label: 'Login', link: '#' },
 ];
 


### PR DESCRIPTION
## Summary
- fix path for Tests in header navigation

## Testing
- `npm run build` *(fails: astro not found)*