### PR TITLE
Fix analytics doctor table overflow

### DIFF
--- a/src/content/docs/Tests/analytics-doctor.mdx
+++ b/src/content/docs/Tests/analytics-doctor.mdx
@@ -65,23 +65,29 @@ hero:
   padding-left: 1.5rem;
 }
 .analytics-cell {
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-word;
 }
 
 /* Table styling */
 #table-wrapper {
-  overflow-x: auto;
+  width: 100%;
+  max-height: 70vh;
+  overflow: auto;
 }
 
 #pages-table {
-  width: 100%;
   border-collapse: collapse;
+  width: max-content;
+  min-width: 100%;
+  table-layout: fixed;
 }
 
 #pages-table th,
 #pages-table td {
   padding: 0.25rem 0.5rem;
   border: 1px solid var(--sl-color-gray-4);
+  color: var(--sl-color-text);
 }
 
 #pages-table th {


### PR DESCRIPTION
## Summary
- make analytics doctor table wrapper scrollable and limit height
- allow analytics doctor cells to wrap
- ensure table text uses theme colors

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm run build` *(fails: astro not found)*