### PR TITLE
Improve analytics pill colors and FAQ linking

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -129,6 +129,25 @@ export default defineConfig({
           }
         `,
       },
+      {
+        tag: 'script',
+        content: `
+          document.addEventListener('DOMContentLoaded', () => {
+            function openHashDetails() {
+              const id = location.hash.slice(1);
+              if (!id) return;
+              const el = document.getElementById(id) ||
+                          document.getElementById(id.replace(/-/g, '_')) ||
+                          document.getElementById(id.replace(/_/g, '-'));
+              if (el && el.tagName.toLowerCase() === 'details') {
+                el.open = true;
+              }
+            }
+            openHashDetails();
+            window.addEventListener('hashchange', openHashDetails);
+          });
+        `,
+      },
     ],
   })],
   markdown: {

--- a/public/js/analytics-doctor.js
+++ b/public/js/analytics-doctor.js
@@ -159,7 +159,7 @@ document.addEventListener('DOMContentLoaded', () => {
             td.className = 'analytics-cell';
             td.innerHTML =
               `<a href="#${idSlug}" class="${pillClass}">${ids}</a>` +
-              ` <a href="#${methodSlug}" class="analytics-pill">via ${method}</a>`;
+              ` <a href="#${methodSlug}" class="analytics-pill method-${slugify(method)}">via ${method}</a>`;
           } else {
             td.textContent = '';
           }
@@ -211,7 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
         li.innerHTML =
           `${formatName(name)} ` +
           `<a href="#${idSlug}" class="${pillClass}">${ids}</a>` +
-          ` <a href="#${methodSlug}" class="analytics-pill">via ${method}</a>`;
+          ` <a href="#${methodSlug}" class="analytics-pill method-${slugify(method)}">via ${method}</a>`;
         ul.appendChild(li);
       }
     }

--- a/src/content/docs/Tests/analytics-doctor.mdx
+++ b/src/content/docs/Tests/analytics-doctor.mdx
@@ -74,7 +74,7 @@ hero:
   padding: 0.1rem 0.4rem;
   margin-right: 0.25rem;
   border-radius: 0.5rem;
-  background: var(--sl-color-gray-3);
+  background: whitesmoke;
   color: black;
   font-size: 0.75rem;
   text-decoration: none;
@@ -89,6 +89,10 @@ hero:
 .analytics-pill.mixpanel { background: #f3e6ff; }
 .analytics-pill.hotjar { background: #ffe8e8; }
 .analytics-pill.amplitude { background: #e8ecff; }
+
+.analytics-pill.method-native { background: #f7f7f7; }
+.analytics-pill.method-gtm { background: #f0f0f0; }
+.analytics-pill.method-segment { background: #e9e9e9; }
 
 /* Table styling */
 #table-wrapper {


### PR DESCRIPTION
## Summary
- lighten implementation method pills and differentiate by method type
- link method pills with new classes
- auto-open FAQ details based on URL fragment

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*