### PR TITLE
Add footer and legal pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -101,6 +101,7 @@ export default defineConfig({
     sidebar,
     components: {
       Header: './src/components/CustomHeader.astro',
+      Footer: './src/components/CustomFooter.astro',
     },
 	  head: [
       // Adding google analytics

--- a/src/components/CustomFooter.astro
+++ b/src/components/CustomFooter.astro
@@ -1,0 +1,45 @@
+---
+import SocialIcons from 'virtual:starlight/components/SocialIcons';
+const year = new Date().getFullYear();
+---
+<footer class="footer">
+  <div class="footer-content">
+    <p class="copy">© {year} Blue Frog Analytics</p>
+    <nav class="footer-nav">
+      <a href="/about/">About</a>
+      <a href="/privacy-policy/">Privacy Policy</a>
+      <a href="/terms-of-service/">Terms of Service</a>
+      <a href="/community/contact/">Contact</a>
+    </nav>
+    <SocialIcons />
+  </div>
+</footer>
+
+<style>
+.footer {
+  padding: 2rem 1rem;
+  border-top: 1px solid var(--sl-color-gray-6);
+  margin-top: 4rem;
+}
+.footer-content {
+  max-width: var(--sl-content-width);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+.footer-nav {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.footer-nav a {
+  text-decoration: none;
+  color: var(--sl-color-text);
+}
+.copy {
+  margin: 0;
+}
+</style>

--- a/src/content/docs/privacy-policy.mdx
+++ b/src/content/docs/privacy-policy.mdx
@@ -1,0 +1,20 @@
+---
+title: Privacy Policy
+description: Learn how Blue Frog Analytics collects, uses, and protects your data.
+template: page
+---
+
+# Privacy Policy
+
+Blue Frog Analytics values your privacy. This page explains what personal data we collect and how we use it. We only gather information necessary to provide our services and never sell your data.
+
+**Data Collection**
+- Information you provide when creating an account or contacting us
+- Usage data for improving our platform
+
+**Use of Information**
+- To operate and maintain the website
+- To respond to your inquiries and provide customer support
+- To analyze usage and improve our services
+
+If you have questions about this policy, please [contact us](/community/contact/).

--- a/src/content/docs/terms-of-service.mdx
+++ b/src/content/docs/terms-of-service.mdx
@@ -1,0 +1,15 @@
+---
+title: Terms of Service
+description: The legal terms that govern your use of Blue Frog Analytics.
+template: page
+---
+
+# Terms of Service
+
+By using Blue Frog Analytics, you agree to the following terms:
+
+1. You will comply with all applicable laws and regulations.
+2. You will not misuse the platform or attempt to disrupt our services.
+3. We reserve the right to update these terms at any time.
+
+For questions about these terms, please [contact us](/community/contact/).


### PR DESCRIPTION
## Summary
- add custom `CustomFooter` component
- register footer in `astro.config.mjs`
- add Privacy Policy and Terms of Service pages

## Testing
- `npm run build` *(fails: astro not found)*