### PR TITLE
Remove login from header

### DIFF
--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -13,7 +13,6 @@ const mainNav = [
   { label: 'About', link: '/about/' },
   { label: 'Roadmap', link: '/roadmap/' },
   { label: 'Tests', link: '/testing/' },
-  { label: 'Login', link: '#' },
 ];
 
 // Check if search should be displayed


### PR DESCRIPTION
## Summary
- remove the `Login` link from the navigation bar

## Testing
- `npm run build` *(fails: `astro` not found)*