### PR TITLE
Fix sitemap setup

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -93,7 +93,10 @@ export default defineConfig({
       },
     ],
   },
-  integrations: [astroExpressiveCode(), mdx(), sitemap(), starlight({
+  integrations: [
+    astroExpressiveCode(),
+    mdx(),
+    starlight({
     title: 'Blue Frog Analytics',
     social: {
       github: 'https://github.com/jwiedeman',
@@ -149,8 +152,10 @@ export default defineConfig({
           });
         `,
       },
-    ],
-  })],
+      ],
+    }),
+    sitemap(),
+  ],
   markdown: {
         remarkPlugins: [remarkMath,remarkMermaid],
         rehypePlugins: [rehypeKatex]

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from 'astro';
+
+const getRobotsTxt = (sitemapURL: URL) => `
+User-agent: *
+Allow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+
+export const GET: APIRoute = ({ site }) => {
+  const sitemapURL = new URL('sitemap-index.xml', site);
+  return new Response(getRobotsTxt(sitemapURL));
+};
+
+export const prerender = true;


### PR DESCRIPTION
## Summary
- reorder integrations so `@astrojs/sitemap` runs after Starlight
- prerender dynamic `robots.txt`

## Testing
- `npm run build` *(fails: astro not found)*