### PR TITLE
Enable sitemap and robots

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -73,11 +73,11 @@ const sidebar = [
 
 const googleAnalyticsId = 'G-4N0P7Z1VJ8'
 export default defineConfig({
-  site: isDev ? 'http://localhost:3000' : 'https://jwiedeman.github.io',
+  site: isDev ? 'http://localhost:3000' : 'https://bluefroganalytics.com',
   base: `/`,
   output: 'static',
   buildOptions: {
-    site: `https://jwiedeman.github.io/`,
+    site: `https://bluefroganalytics.com/`,
     trailingSlash: false,
   },
   vite: {
@@ -93,7 +93,7 @@ export default defineConfig({
       },
     ],
   },
-  integrations: [astroExpressiveCode(), mdx(), sitemap(), starlight({
+  integrations: [astroExpressiveCode(), mdx(), starlight({
     title: 'Blue Frog Analytics',
     social: {
       github: 'https://github.com/jwiedeman',
@@ -150,7 +150,7 @@ export default defineConfig({
         `,
       },
     ],
-  })],
+  }), sitemap()],
   markdown: {
         remarkPlugins: [remarkMath,remarkMermaid],
         rehypePlugins: [rehypeKatex]

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = true;
+
+const getRobotsTxt = (sitemapURL: URL) => `
+User-agent: *
+Allow: /
+
+Sitemap: ${sitemapURL.href}
+`;
+
+export const GET: APIRoute = ({ site }) => {
+  const sitemapURL = new URL('sitemap-index.xml', site);
+  return new Response(getRobotsTxt(sitemapURL));
+};


### PR DESCRIPTION
## Summary
- prerender the dynamic `robots.txt` page
- update site URL for `bluefroganalytics.com`
- run sitemap after Starlight

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: astro not found)*