### PR TITLE
Add Documentation link to header

### DIFF
--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -13,6 +13,7 @@ const mainNav = [
   { label: 'About', link: '/about/' },
   { label: 'Roadmap', link: '/roadmap/' },
   { label: 'Tests', link: '/testing/' },
+  { label: 'Documentation', link: '/introduction/how-blue-frog-analytics-works' },
 ];
 
 // Check if search should be displayed


### PR DESCRIPTION
## Summary
- add navigation link for documentation in CustomHeader

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: Exit handler never called)*
- `npm run build` *(fails: astro not found)*