### PR TITLE
Fix style syntax in ROAS calculator MDX

### DIFF
--- a/src/content/docs/Tests/roas-calculator.mdx
+++ b/src/content/docs/Tests/roas-calculator.mdx
@@ -10,19 +10,48 @@ Use this tool to estimate profitability across different conversion rate scenari
 
 <div id="roas-root">
   <form id="roas-form">
-
-    <label>AOV: <input type="number" id="aov" value="100" step="0.01" /></label>
-    <label>COGS: <input type="number" id="cogs" value="40" step="0.01" /></label>
-    <label>Ad Spend: <input type="number" id="spend" value="1000" step="0.01" /></label>
-    <label>CPC: <input type="number" id="cpc" value="1" step="0.01" /></label>
-    <label>CVR (%): <input type="number" id="cvr" value="2" step="0.01" /></label>
-
+    <label>AOV<input type="number" id="aov" value="100" step="0.01" /></label>
+    <label>COGS<input type="number" id="cogs" value="40" step="0.01" /></label>
+    <label>Ad Spend<input type="number" id="spend" value="1000" step="0.01" /></label>
+    <label>CPC<input type="number" id="cpc" value="1" step="0.01" /></label>
+    <label>CVR (%)<input type="number" id="cvr" value="2" step="0.01" /></label>
     <button type="submit">Calculate</button>
   </form>
   <div id="roas-results"></div>
   <svg id="roas-chart" width="600" height="300"></svg>
 </div>
 
+<style>{`
+  #roas-form {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+  #roas-form label {
+    display: flex;
+    flex-direction: column;
+    font-weight: bold;
+  }
+  #roas-results table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+  }
+  #roas-results th,
+  #roas-results td {
+    border: 1px solid #ccc;
+    padding: 4px;
+    text-align: right;
+  }
+  #roas-results th:first-child,
+  #roas-results td:first-child {
+    text-align: left;
+  }
+  #roas-chart {
+    margin-top: 1rem;
+  }
+`}</style>
+
 <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
 <script type="module" src="/js/roas-calculator.js"></script>
-


### PR DESCRIPTION
## Summary
- wrap ROAS calculator CSS in `<style>{` template `}` block so MDX parses correctly

## Testing
- `npm run build` *(fails: astro not found)*