### PR TITLE
Enhance Carbon CSS integration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -107,7 +107,12 @@ export default defineConfig({
     },
           head: [
       { tag: 'link', attrs: { rel: 'stylesheet', href: 'https://unpkg.com/carbon-components/css/carbon-components.min.css' } },
+      { tag: 'link', attrs: { rel: 'preconnect', href: 'https://fonts.googleapis.com' } },
+      { tag: 'link', attrs: { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' } },
+      { tag: 'link', attrs: { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap' } },
       { tag: 'link', attrs: { rel: 'stylesheet', href: '/css/carbon.css' } },
+      { tag: 'script', attrs: { src: 'https://unpkg.com/carbon-components/scripts/carbon-components.min.js', defer: true } },
+      { tag: 'script', content: 'window.addEventListener("DOMContentLoaded",()=>{if(window.CarbonComponents){window.CarbonComponents.watch();}});' },
       // Adding google analytics
       {
         tag: 'script',

--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -3,6 +3,8 @@
   --sl-color-primary: #0f62fe; /* Carbon blue */
   --sl-color-accent: #ff832b; /* Carbon orange */
   --sl-border-radius: 0;
+  --cds-text: #161616;
+  --cds-background: #f4f4f4;
 }
 
 /* Ensure header and footer adhere to Carbon spacing */
@@ -24,5 +26,11 @@
   max-width: 80rem;
   margin: 0 auto;
   padding: 0 1rem;
+}
+
+body {
+  font-family: var(--sl-font-sans);
+  background: var(--cds-background);
+  color: var(--cds-text);
 }
 


### PR DESCRIPTION
## Summary
- add IBM Plex Sans fonts and Carbon JS in `astro.config.mjs`
- extend Carbon CSS variables and apply global body styling

## Testing
- `npm run build` *(fails: astro not found)*