### PR TITLE
Convert docs pages to Carbon markup

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -107,7 +107,12 @@ export default defineConfig({
     },
           head: [
       { tag: 'link', attrs: { rel: 'stylesheet', href: 'https://unpkg.com/carbon-components/css/carbon-components.min.css' } },
+      { tag: 'link', attrs: { rel: 'preconnect', href: 'https://fonts.googleapis.com' } },
+      { tag: 'link', attrs: { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' } },
+      { tag: 'link', attrs: { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap' } },
       { tag: 'link', attrs: { rel: 'stylesheet', href: '/css/carbon.css' } },
+      { tag: 'script', attrs: { src: 'https://unpkg.com/carbon-components/scripts/carbon-components.min.js', defer: true } },
+      { tag: 'script', content: 'window.addEventListener("DOMContentLoaded",()=>{if(window.CarbonComponents){window.CarbonComponents.watch();}});' },
       // Adding google analytics
       {
         tag: 'script',

--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -3,6 +3,8 @@
   --sl-color-primary: #0f62fe; /* Carbon blue */
   --sl-color-accent: #ff832b; /* Carbon orange */
   --sl-border-radius: 0;
+  --cds-text: #161616;
+  --cds-background: #f4f4f4;
 }
 
 /* Ensure header and footer adhere to Carbon spacing */
@@ -24,5 +26,11 @@
   max-width: 80rem;
   margin: 0 auto;
   padding: 0 1rem;
+}
+
+body {
+  font-family: var(--sl-font-sans);
+  background: var(--cds-background);
+  color: var(--cds-text);
 }
 

--- a/src/content/docs/about.mdx
+++ b/src/content/docs/about.mdx
@@ -9,6 +9,8 @@ hero:
     file: ../../assets/houston.webp
 ---
 
+<div class="carbon-container">
+
 About Blue Frog Analytics
 ===============
 
@@ -52,5 +54,7 @@ Join the Journey
 
 I invite you to explore Blue Frog Analytics and see how this integrated approach can transform the way you manage your digital presence. Together, let's throw grease on those gears and keep your business running like a well-oiled machine.
 
-[Get Started with Blue Frog Analytics](/introduction/how-blue-frog-analytics-works)\
-[Learn More About Our Features](/introduction/use-cases)
+<a href="/introduction/how-blue-frog-analytics-works" class="bx--btn bx--btn--primary">Get Started with Blue Frog Analytics</a>
+<a href="/introduction/use-cases" class="bx--btn bx--btn--secondary">Learn More About Our Features</a>
+
+</div>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -20,7 +20,7 @@ hero:
       variant: minimal
 ---
 
-import { Card, CardGrid, LinkButton, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+<div class="carbon-container">
 
 ## Mission Overview
 
@@ -37,94 +37,123 @@ It delivers **precise insights** into tracking, SEO, and performance—so issues
 
 ## Launch Sequence
 
-<CardGrid stagger>
-  <Card title=" Scan Your Website" icon="search">
-    Enter your domain, and Blue Frog Analytics performs a deep audit, identifying tracking, SEO, and performance issues.
-  </Card>
-  <Card title=" Get Actionable Reports" icon="chart-line">
-    Receive **detailed breakdowns** of your site’s analytics gaps, SEO weaknesses, and compliance risks.
-  </Card>
-  <Card title=" Implement Fixes" icon="tools">
-    Follow **step-by-step optimization guides** tailored to your site’s unique needs.
-  </Card>
-  <Card title=" Monitor & Improve" icon="repeat">
-    Run **scheduled scans** and track improvements over time to ensure ongoing performance and compliance.
-  </Card>
-</CardGrid>
+<div class="bx--grid bx--grid--condensed">
+  <div class="bx--row">
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Scan Your Website</h3>
+        <p>Enter your domain, and Blue Frog Analytics performs a deep audit, identifying tracking, SEO, and performance issues.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Get Actionable Reports</h3>
+        <p>Receive <strong>detailed breakdowns</strong> of your site’s analytics gaps, SEO weaknesses, and compliance risks.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Implement Fixes</h3>
+        <p>Follow <strong>step-by-step optimization guides</strong> tailored to your site’s unique needs.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Monitor &amp; Improve</h3>
+        <p>Run <strong>scheduled scans</strong> and track improvements over time to ensure ongoing performance and compliance.</p>
+      </div>
+    </div>
+  </div>
+</div>
 
 ---
 
 ##  Why Choose Blue Frog Analytics?
 
-<CardGrid>
-  <Card title=" Data Accuracy & Validation" icon="check-circle">
-    Ensure tracking pixels, tags, and events fire correctly—no more lost data.
-  </Card>
-  <Card title=" Performance Optimization" icon="speedometer">
-    Identify bottlenecks and boost site speed with AI-driven suggestions.
-  </Card>
-  <Card title=" SEO & Compliance Insights" icon="shield-check">
-    Uncover metadata issues, accessibility problems, and compliance gaps.
-  </Card>
-  <Card title="Custom Reporting & Integrations" icon="layers">
-    Export reports, track historical data, and integrate insights into your workflow.
-  </Card>
-</CardGrid>
+<div class="bx--grid bx--grid--condensed">
+  <div class="bx--row">
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Data Accuracy &amp; Validation</h3>
+        <p>Ensure tracking pixels, tags, and events fire correctly—no more lost data.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Performance Optimization</h3>
+        <p>Identify bottlenecks and boost site speed with AI-driven suggestions.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>SEO &amp; Compliance Insights</h3>
+        <p>Uncover metadata issues, accessibility problems, and compliance gaps.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Custom Reporting &amp; Integrations</h3>
+        <p>Export reports, track historical data, and integrate insights into your workflow.</p>
+      </div>
+    </div>
+  </div>
+</div>
 
 ---
 
 ## **Mission Steps to Optimize Your Website**
 
-<Steps>
-1. **Enter Your Domain**  
-   Get started by inputting your website URL into **Blue Frog Analytics**.
-
-2. **Run a Full Website Audit**  
-   Our system will scan for **tracking issues, SEO gaps, and performance bottlenecks**.
-
-3. **Receive Actionable Reports**  
-   Instantly get a **detailed breakdown** of errors and optimization opportunities.
-
-4. **Fix & Monitor Performance**  
-   Implement fixes, then **re-scan periodically** to maintain peak site health.
-</Steps>
+<ol class="bx--list--ordered">
+  <li><strong>Enter Your Domain</strong><br />
+  Get started by inputting your website URL into <strong>Blue Frog Analytics</strong>.</li>
+  <li><strong>Run a Full Website Audit</strong><br />
+  Our system will scan for <strong>tracking issues, SEO gaps, and performance bottlenecks</strong>.</li>
+  <li><strong>Receive Actionable Reports</strong><br />
+  Instantly get a <strong>detailed breakdown</strong> of errors and optimization opportunities.</li>
+  <li><strong>Fix &amp; Monitor Performance</strong><br />
+  Implement fixes, then <strong>re-scan periodically</strong> to maintain peak site health.</li>
+</ol>
 
 ---
 
 ##  **Use Blue Frog Analytics for Your Needs**
 
-<Tabs>
-  <TabItem label="Developers" icon="code">
-    - Ensure all tracking scripts fire correctly  
-    - Debug **Google Analytics & Meta Pixel**  
-    - Optimize **Core Web Vitals & Page Speed**
-  </TabItem>
-  
-  <TabItem label="Marketers" icon="chart-line">
-    - Validate conversions & **attribution tracking**  
-    - Ensure **SEO best practices**  
-    - Detect lost **UTM parameters** in paid ads
-  </TabItem>
-  
-  <TabItem label="Compliance Teams" icon="shield-check">
-    - Audit **GDPR, CPRA, & accessibility (WCAG)**  
-    - Verify **cookie consent tracking**  
-    - Identify **data privacy risks** before they escalate
-  </TabItem>
-</Tabs>
+<div class="bx--grid bx--grid--condensed">
+  <div class="bx--row">
+    <div class="bx--col-sm-12 bx--col-md-4">
+      <h3>Developers</h3>
+      <ul class="bx--list--unordered">
+        <li>Ensure all tracking scripts fire correctly</li>
+        <li>Debug <strong>Google Analytics &amp; Meta Pixel</strong></li>
+        <li>Optimize <strong>Core Web Vitals &amp; Page Speed</strong></li>
+      </ul>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-4">
+      <h3>Marketers</h3>
+      <ul class="bx--list--unordered">
+        <li>Validate conversions &amp; <strong>attribution tracking</strong></li>
+        <li>Ensure <strong>SEO best practices</strong></li>
+        <li>Detect lost <strong>UTM parameters</strong> in paid ads</li>
+      </ul>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-4">
+      <h3>Compliance Teams</h3>
+      <ul class="bx--list--unordered">
+        <li>Audit <strong>GDPR, CPRA, &amp; accessibility (WCAG)</strong></li>
+        <li>Verify <strong>cookie consent tracking</strong></li>
+        <li>Identify <strong>data privacy risks</strong> before they escalate</li>
+      </ul>
+    </div>
+  </div>
+</div>
 
 ---
 
 ## Ignite Your Mission
 
-<LinkButton href="/introduction/how-blue-frog-analytics-works" variant="primary" icon="right-arrow">
-  Begin Your Launch
-</LinkButton>
+<a href="/introduction/how-blue-frog-analytics-works" class="bx--btn bx--btn--primary">Begin Your Launch</a>
 
-<LinkButton href="/introduction/how-blue-frog-analytics-works" variant="secondary" icon="open-book">
-  Review Flight Plan
-</LinkButton>
+<a href="/introduction/how-blue-frog-analytics-works" class="bx--btn bx--btn--secondary">Review Flight Plan</a>
 
-<LinkButton href="/introduction/how-blue-frog-analytics-works" variant="minimal" icon="external">
-  View Documentation
-</LinkButton>
+<a href="/introduction/how-blue-frog-analytics-works" class="bx--btn bx--btn--ghost">View Documentation</a>
+</div>

--- a/src/content/docs/privacy-policy.mdx
+++ b/src/content/docs/privacy-policy.mdx
@@ -4,6 +4,8 @@ description: Learn how Blue Frog Analytics collects, uses, and protects your dat
 template: splash
 ---
 
+<div class="carbon-container">
+
 # Privacy Policy
 
 Blue Frog Analytics values your privacy. This page explains what personal data we collect and how we use it. We only gather information necessary to provide our services and never sell your data.
@@ -18,3 +20,5 @@ Blue Frog Analytics values your privacy. This page explains what personal data w
 - To analyze usage and improve our services
 
 If you have questions about this policy, please [contact us](/community/contact/).
+</div>
+

--- a/src/content/docs/services.mdx
+++ b/src/content/docs/services.mdx
@@ -15,92 +15,117 @@ hero:
       variant: primary
 ---
 
-import { Card, CardGrid, Tabs, TabItem, LinkButton } from '@astrojs/starlight/components';
+<div class="carbon-container">
 
 # Services & Features
 
-<CardGrid>
-  <Card title="Micro Audit" icon="search">
-    2-hour rapid assessment with concise action items and a 30-minute follow-up.<br />
-    **$300/month** – Team size: 1 advisor – Premium support: 2 weeks – Free updates: One-time.
-  </Card>
-  <Card title="Analytics Health Check" icon="heart">
-    Quick review of your analytics setup with actionable recommendations and a 1-hour call.<br />
-    **$500/month** – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.
-  </Card>
-  <Card title="Quick Tech & Growth Audit" icon="clipboard-check">
-    8-hour in-depth audit, evaluation report, and a 1-hour follow-up session.<br />
-    **$1000/month** – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.
-  </Card>
-  <Card title="Growth Accelerator Workshop" icon="rocket">
-    Full-day intensive workshop with a custom strategic roadmap and 60-minute follow-up.<br />
-    **$5000/month** – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.
-  </Card>
-  <Card title="Starter Advisory" icon="lightbulb">
-    4 hours/month with a monthly strategy call and limited email support.<br />
-    **$1500/month** – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.
-  </Card>
-  <Card title="SMB Advisory" icon="briefcase">
-    8 hours/month, monthly strategy call, priority email & Slack support.<br />
-    **$3000/month** – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.
-  </Card>
-  <Card title="Professional Advisory" icon="chart-line">
-    20 hours/month with bi-weekly strategy meetings and dedicated Slack/email support plus KPI analysis.<br />
-    **$7500/month** – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.
-  </Card>
-  <Card title="Premium Advisory" icon="trophy">
-    40 hours/month, weekly sessions, comprehensive dashboards, and on-call support.<br />
-    **$12000/month** – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.
-  </Card>
-  <Card title="Embedded Growth Officer" icon="user">
-    2–3 days/week fractional executive presence with tech strategy oversight.<br />
-    **$20000/month** – Team size: 1 fractional executive – Premium support: Monthly – Free updates: Monthly.
-  </Card>
-  <Card title="Flexible Hours Block" icon="clock">
-    Prepaid block of 10 hours for strategic support or troubleshooting (valid 3 months).<br />
-    **$2500/month** – Team size: 1 advisor – Premium support: 3 months – Free updates: One-time.
-  </Card>
-  <Card title="DIY Growth Toolkit" icon="tools">
-    Templates, guides, and quarterly educational webinars with lifetime access.<br />
-    **$500/month** – Team size: Unlimited access – Premium support: Lifetime – Free updates: Quarterly.
-  </Card>
-  <Card title="Analytics Mastery Course" icon="graduation-cap">
-    Complete self-paced analytics training with lifetime updates and monthly live Q&A sessions.<br />
-    **$1000/month** – Team size: Unlimited access – Premium support: Lifetime – Free updates: Monthly.
-  </Card>
-</CardGrid>
+<div class="bx--grid bx--grid--condensed">
+  <div class="bx--row">
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Micro Audit</h3>
+        <p>2-hour rapid assessment with concise action items and a 30-minute follow-up.<br />
+        <strong>$300/month</strong> – Team size: 1 advisor – Premium support: 2 weeks – Free updates: One-time.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Analytics Health Check</h3>
+        <p>Quick review of your analytics setup with actionable recommendations and a 1-hour call.<br />
+        <strong>$500/month</strong> – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Quick Tech &amp; Growth Audit</h3>
+        <p>8-hour in-depth audit, evaluation report, and a 1-hour follow-up session.<br />
+        <strong>$1000/month</strong> – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Growth Accelerator Workshop</h3>
+        <p>Full-day intensive workshop with a custom strategic roadmap and 60-minute follow-up.<br />
+        <strong>$5000/month</strong> – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Starter Advisory</h3>
+        <p>4 hours/month with a monthly strategy call and limited email support.<br />
+        <strong>$1500/month</strong> – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>SMB Advisory</h3>
+        <p>8 hours/month, monthly strategy call, priority email &amp; Slack support.<br />
+        <strong>$3000/month</strong> – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Professional Advisory</h3>
+        <p>20 hours/month with bi-weekly strategy meetings and dedicated Slack/email support plus KPI analysis.<br />
+        <strong>$7500/month</strong> – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Premium Advisory</h3>
+        <p>40 hours/month, weekly sessions, comprehensive dashboards, and on-call support.<br />
+        <strong>$12000/month</strong> – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Embedded Growth Officer</h3>
+        <p>2–3 days/week fractional executive presence with tech strategy oversight.<br />
+        <strong>$20000/month</strong> – Team size: 1 fractional executive – Premium support: Monthly – Free updates: Monthly.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Flexible Hours Block</h3>
+        <p>Prepaid block of 10 hours for strategic support or troubleshooting (valid 3 months).<br />
+        <strong>$2500/month</strong> – Team size: 1 advisor – Premium support: 3 months – Free updates: One-time.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>DIY Growth Toolkit</h3>
+        <p>Templates, guides, and quarterly educational webinars with lifetime access.<br />
+        <strong>$500/month</strong> – Team size: Unlimited access – Premium support: Lifetime – Free updates: Quarterly.</p>
+      </div>
+    </div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4">
+      <div class="bx--tile">
+        <h3>Analytics Mastery Course</h3>
+        <p>Complete self-paced analytics training with lifetime updates and monthly live Q&amp;A sessions.<br />
+        <strong>$1000/month</strong> – Team size: Unlimited access – Premium support: Lifetime – Free updates: Monthly.</p>
+      </div>
+    </div>
+  </div>
+</div>
 
 ## Services
 
 Explore my refined service pillars and how I can help your business.
 
-<Tabs>
-  <TabItem label="Strategy & Architecture" icon="puzzle-piece">
-    Service Info
-  </TabItem>
-  <TabItem label="Implementation & Engineering" icon="hammer">
-    Service Info
-  </TabItem>
-  <TabItem label="Quality Assurance & Compliance" icon="shield-check">
-    Service Info
-  </TabItem>
-  <TabItem label="Growth & Optimization" icon="chart-bar">
-    Service Info
-  </TabItem>
-  <TabItem label="Training & Enablement" icon="book">
-    Service Info
-  </TabItem>
-  <TabItem label="Innovation & R&D" icon="flask">
-    Service Info
-  </TabItem>
-  <TabItem label="Brand Influence & Propaganda" icon="megaphone">
-    Service Info
-  </TabItem>
-  <TabItem label="Creative Direction & Coordination" icon="paint-brush">
-    Service Info
-  </TabItem>
-</Tabs>
+<div class="bx--grid bx--grid--condensed">
+  <div class="bx--row">
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4"><h3>Strategy &amp; Architecture</h3><p>Service Info</p></div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4"><h3>Implementation &amp; Engineering</h3><p>Service Info</p></div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4"><h3>Quality Assurance &amp; Compliance</h3><p>Service Info</p></div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4"><h3>Growth &amp; Optimization</h3><p>Service Info</p></div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4"><h3>Training &amp; Enablement</h3><p>Service Info</p></div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4"><h3>Innovation &amp; R&amp;D</h3><p>Service Info</p></div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4"><h3>Brand Influence &amp; Propaganda</h3><p>Service Info</p></div>
+    <div class="bx--col-sm-12 bx--col-md-6 bx--col-lg-4"><h3>Creative Direction &amp; Coordination</h3><p>Service Info</p></div>
+  </div>
+</div>
 
-<LinkButton href="/community/contact/" variant="primary" icon="right-arrow">
-  Claim Your Complimentary Growth Blueprint
-</LinkButton>
+<a href="/community/contact/" class="bx--btn bx--btn--primary">Claim Your Complimentary Growth Blueprint</a>
+
+</div>
+

--- a/src/content/docs/terms-of-service.mdx
+++ b/src/content/docs/terms-of-service.mdx
@@ -4,6 +4,8 @@ description: The legal terms that govern your use of Blue Frog Analytics.
 template: splash
 ---
 
+<div class="carbon-container">
+
 # Terms of Service
 
 By using Blue Frog Analytics, you agree to the following terms:
@@ -13,3 +15,5 @@ By using Blue Frog Analytics, you agree to the following terms:
 3. We reserve the right to update these terms at any time.
 
 For questions about these terms, please [contact us](/community/contact/).
+</div>
+


### PR DESCRIPTION
## Summary
- wrap main docs pages in Carbon container divs
- replace Starlight card and tab components with Carbon CSS markup
- convert link buttons to Carbon buttons

## Testing
- `npm run build` *(fails: astro not found)*