### PR TITLE
Fix roas calculator mdx syntax

### DIFF
--- a/src/content/docs/Tests/roas-calculator.mdx
+++ b/src/content/docs/Tests/roas-calculator.mdx
@@ -13,80 +13,72 @@ Use this tool to estimate profitability across different conversion rate scenari
 
 
 <div id="roas-root" class="carbon-container">
-  <form id="roas-form" class="bx--form">
+<form id="roas-form" class="bx--form">
 
-    <div class="bx--form-item">
-      <label for="aov" class="bx--label">AOV</label>
-      <input type="number" id="aov" value="100" step="0.01" class="bx--text-input" />
-    </div>
-    <div class="bx--form-item">
-      <label for="cogs" class="bx--label">COGS</label>
-      <input type="number" id="cogs" value="40" step="0.01" class="bx--text-input" />
-    </div>
-    <div class="bx--form-item">
-      <label for="spend" class="bx--label">Ad Spend</label>
-      <input type="number" id="spend" value="1000" step="0.01" class="bx--text-input" />
-    </div>
-    <div class="bx--form-item">
-      <label for="cpc" class="bx--label">CPC</label>
-      <input type="number" id="cpc" value="1" step="0.01" class="bx--text-input" />
-    </div>
-    <div class="bx--form-item">
-      <label for="cvr" class="bx--label">CVR (%)</label>
-      <input type="number" id="cvr" value="2" step="0.01" class="bx--text-input" />
-    </div>
+<div class="bx--form-item">
+  <label for="aov" class="bx--label">AOV</label>
+  <input type="number" id="aov" value="100" step="0.01" class="bx--text-input" />
+</div>
+<div class="bx--form-item">
+  <label for="cogs" class="bx--label">COGS</label>
+  <input type="number" id="cogs" value="40" step="0.01" class="bx--text-input" />
+</div>
+<div class="bx--form-item">
+  <label for="spend" class="bx--label">Ad Spend</label>
+  <input type="number" id="spend" value="1000" step="0.01" class="bx--text-input" />
+</div>
+<div class="bx--form-item">
+  <label for="cpc" class="bx--label">CPC</label>
+  <input type="number" id="cpc" value="1" step="0.01" class="bx--text-input" />
+</div>
+<div class="bx--form-item">
+  <label for="cvr" class="bx--label">CVR (%)</label>
+  <input type="number" id="cvr" value="2" step="0.01" class="bx--text-input" />
+</div>
 
-    <div class="bx--form-item">
-      <label class="bx--label"><input type="checkbox" id="subscription" /> Subscription</label>
-    </div>
-    <div class="bx--form-item sub-fields">
-      <label class="bx--label">Monthly Price
-        <input type="number" id="sub-price" value="30" step="0.01" class="bx--text-input" />
-      </label>
-      <label class="bx--label">Lifetime (mo)
-        <input type="number" id="sub-life" value="6" step="1" class="bx--text-input" />
-      </label>
-    </div>
+<div class="bx--form-item">
+  <label class="bx--label"><input type="checkbox" id="subscription" /> Subscription</label>
+</div>
+<div class="bx--form-item sub-fields">
+  <label class="bx--label">Monthly Price <input type="number" id="sub-price" value="30" step="0.01" class="bx--text-input" /></label>
+  <label class="bx--label">Lifetime (mo) <input type="number" id="sub-life" value="6" step="1" class="bx--text-input" /></label>
+</div>
 
-    <div class="bx--form-item">
-      <label class="bx--label"><input type="checkbox" id="service" /> Services</label>
-    </div>
-    <div class="bx--form-item svc-fields">
-      <label class="bx--label">Booking Price
-        <input type="number" id="svc-price" value="300" step="0.01" class="bx--text-input" />
-      </label>
-      <label class="bx--label">Contract Len (mo)
-        <input type="number" id="svc-len" value="1" step="1" class="bx--text-input" />
-      </label>
-    </div>
+<div class="bx--form-item">
+  <label class="bx--label"><input type="checkbox" id="service" /> Services</label>
+</div>
+<div class="bx--form-item svc-fields">
+  <label class="bx--label">Booking Price <input type="number" id="svc-price" value="300" step="0.01" class="bx--text-input" /></label>
+  <label class="bx--label">Contract Len (mo) <input type="number" id="svc-len" value="1" step="1" class="bx--text-input" /></label>
+</div>
 
-    <div class="bx--form-item">
-      <label for="ctr" class="bx--label">CTR (%)</label>
-      <input type="number" id="ctr" value="2" step="0.01" class="bx--text-input" />
-    </div>
-    <div class="bx--form-item">
-      <label for="l2c" class="bx--label">Lead→Close (%)</label>
-      <input type="number" id="l2c" value="30" step="0.1" class="bx--text-input" />
-    </div>
-    <div class="bx--form-item">
-      <label for="team" class="bx--label">Team Costs</label>
-      <input type="number" id="team" value="0" step="0.01" class="bx--text-input" />
-    </div>
-    <div class="bx--form-item">
-      <label for="tools" class="bx--label">Tools Cost</label>
-      <input type="number" id="tools" value="0" step="0.01" class="bx--text-input" />
-    </div>
-    <div class="bx--form-item">
-      <label for="fulfill" class="bx--label">Fulfillment Cost</label>
-      <input type="number" id="fulfill" value="0" step="0.01" class="bx--text-input" />
-    </div>
+<div class="bx--form-item">
+  <label for="ctr" class="bx--label">CTR (%)</label>
+  <input type="number" id="ctr" value="2" step="0.01" class="bx--text-input" />
+</div>
+<div class="bx--form-item">
+  <label for="l2c" class="bx--label">Lead→Close (%)</label>
+  <input type="number" id="l2c" value="30" step="0.1" class="bx--text-input" />
+</div>
+<div class="bx--form-item">
+  <label for="team" class="bx--label">Team Costs</label>
+  <input type="number" id="team" value="0" step="0.01" class="bx--text-input" />
+</div>
+<div class="bx--form-item">
+  <label for="tools" class="bx--label">Tools Cost</label>
+  <input type="number" id="tools" value="0" step="0.01" class="bx--text-input" />
+</div>
+<div class="bx--form-item">
+  <label for="fulfill" class="bx--label">Fulfillment Cost</label>
+  <input type="number" id="fulfill" value="0" step="0.01" class="bx--text-input" />
+</div>
 
 
-    <button type="submit" class="bx--btn bx--btn--primary">Calculate</button>
-    <button id="export" type="button" class="bx--btn">Download CSV</button>
-  </form>
-  <div id="roas-results"></div>
-  <svg id="roas-chart" width="600" height="300"></svg>
+<button type="submit" class="bx--btn bx--btn--primary">Calculate</button>
+<button id="export" type="button" class="bx--btn">Download CSV</button>
+</form>
+<div id="roas-results"></div>
+<svg id="roas-chart" width="600" height="300"></svg>
 </div>
 
 


### PR DESCRIPTION
## Summary
- collapse multiline labels in roas-calculator.mdx to avoid parse errors

## Testing
- `npm run build` *(fails: astro not found)*