### PR TITLE
Adopt Carbon styling, drop Starlight splash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,22 @@
-# Starlight Starter Kit: Basics
+# Blue Frog Analytics Docs
 
-[![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
+This repository hosts the documentation site for **Blue Frog Analytics**. It uses [Astro](https://astro.build) with Starlight for documentation features and is styled with IBM's [Carbon Design System](https://carbondesignsystem.com).
 
-```
-npm create astro@latest -- --template starlight
-```
+## Getting Started
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/basics)
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/withastro/starlight&create_from_path=examples/basics)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Fbasics&project-name=my-starlight-docs&repository-name=my-starlight-docs)
+Install dependencies and start the local development server:
 
-**Seasoned astronaut?** Delete this file. Have fun!
-
-##  Project Structure
-
-Inside of your Astro + Starlight project, you'll see the following folders and files:
-
-```
-.
-├── public/
-├── src/
-│   ├── assets/
-│   ├── content/
-│   │   ├── docs/
-│   └── content/config.ts
-├── astro.config.mjs
-├── package.json
-└── tsconfig.json
+```bash
+npm install
+npm run dev
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
+## Building
 
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
+Generate the production build:
 
-Static assets, like favicons, can be placed in the `public/` directory.
+```bash
+npm run build
+```
 
-## Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## Want to learn more?
-
-Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).
+Documentation content lives in `src/content/docs` and static assets live in `public`.

--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -34,3 +34,19 @@ body {
   color: var(--cds-text);
 }
 
+
+/* Hero section styling */
+.carbon-hero {
+  background: var(--cds-background);
+  padding: 4rem 1rem;
+  text-align: center;
+}
+.carbon-hero h1 {
+  margin: 0 0 1rem;
+}
+.hero-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}

--- a/readme.md
+++ b/readme.md
@@ -1,54 +1,22 @@
-# Starlight Starter Kit: Basics
+# Blue Frog Analytics Docs
 
-[![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
+This repository hosts the documentation site for **Blue Frog Analytics**. It uses [Astro](https://astro.build) with Starlight for documentation features and is styled with IBM's [Carbon Design System](https://carbondesignsystem.com).
 
-```
-npm create astro@latest -- --template starlight
-```
+## Getting Started
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/basics)
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/withastro/starlight&create_from_path=examples/basics)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Fbasics&project-name=my-starlight-docs&repository-name=my-starlight-docs)
+Install dependencies and start the local development server:
 
-**Seasoned astronaut?** Delete this file. Have fun!
-
-##  Project Structure
-
-Inside of your Astro + Starlight project, you'll see the following folders and files:
-
-```
-.
-├── public/
-├── src/
-│   ├── assets/
-│   ├── content/
-│   │   ├── docs/
-│   └── content/config.ts
-├── astro.config.mjs
-├── package.json
-└── tsconfig.json
+```bash
+npm install
+npm run dev
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
+## Building
 
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
+Generate the production build:
 
-Static assets, like favicons, can be placed in the `public/` directory.
+```bash
+npm run build
+```
 
-## Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## Want to learn more?
-
-Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).
+Documentation content lives in `src/content/docs` and static assets live in `public`.

--- a/src/content/docs/Tests/analytics-doctor.mdx
+++ b/src/content/docs/Tests/analytics-doctor.mdx
@@ -1,13 +1,11 @@
 ---
 title: Analytics Doctor
 description: Scan a domain for analytics implementations.
-template: splash
-hero:
-  tagline: |
-    Scan your website for common analytics tags.
-
 ---
 <div id="analytics-root" class="carbon-container">
+<div class="carbon-hero">
+  <h1>Scan your website for common analytics tags.</h1>
+</div>
   <form id="scan-form" class="bx--form">
     <div class="bx--form-item">
       <label for="domain" class="bx--label">Enter domain:</label>

--- a/src/content/docs/about.mdx
+++ b/src/content/docs/about.mdx
@@ -1,14 +1,11 @@
 ---
 title: About Blue Frog Analytics
 description: Learn about Blue Frog Analytics, its visionary mission, and the personal journey that sparked its creation.
-template: splash
-hero:
-  tagline: |
-    A One-Stop Solution to Smooth Out the Gears of Business
-  image:
-    file: ../../assets/houston.webp
 ---
 
+<div class="carbon-hero">
+  <h1>A One-Stop Solution to Smooth Out the Gears of Business</h1>
+</div>
 <div class="carbon-container">
 
 About Blue Frog Analytics

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,25 +1,16 @@
 ---
 title: Welcome to Blue Frog Analytics
 description: Advanced website auditing, SEO optimization, and compliance monitoring in one powerful tool.
-template: splash
-hero:
-  tagline: |
-    Precision analytics for the modern web.
-    Inspired by IBM's Carbon design principles, Blue Frog Analytics audits and optimizes every metric.
-    Launch with confidence and keep your site performing at its peak.
-  image:
-    file: ../../assets/houston.webp
-  actions:
-    - text: Get Started
-      link: /introduction/how-blue-frog-analytics-works
-      icon: right-arrow
-      variant: primary
-    - text: Learn More
-      link: /introduction/use-cases
-      icon: external
-      variant: minimal
 ---
 
+<div class="carbon-hero">
+  <h1>Precision analytics for the modern web.</h1>
+  <p>Inspired by IBM's Carbon design principles, Blue Frog Analytics audits and optimizes every metric. Launch with confidence and keep your site performing at its peak.</p>
+  <div class="hero-actions">
+    <a href="/introduction/how-blue-frog-analytics-works" class="bx--btn bx--btn--primary">Get Started</a>
+    <a href="/introduction/use-cases" class="bx--btn bx--btn--secondary">Learn More</a>
+  </div>
+</div>
 <div class="carbon-container">
 
 ## Mission Overview

--- a/src/content/docs/privacy-policy.mdx
+++ b/src/content/docs/privacy-policy.mdx
@@ -1,7 +1,6 @@
 ---
 title: Privacy Policy
 description: Learn how Blue Frog Analytics collects, uses, and protects your data.
-template: splash
 ---
 
 <div class="carbon-container">

--- a/src/content/docs/services.mdx
+++ b/src/content/docs/services.mdx
@@ -1,21 +1,13 @@
 ---
 title: Services & Features
 description: Explore advisory packages and service pillars to accelerate your growth.
-template: splash
-hero:
-  tagline: |
-    Lead the Pack in Digital Innovation
-    Don’t settle for second place—uncover the data-driven tactics powering industry frontrunners.
-  image:
-    file: ../../assets/houston.webp
-  actions:
-    - text: Claim Your Complimentary Growth Blueprint
-      link: /community/contact/
-      icon: right-arrow
-      variant: primary
 ---
-
 <div class="carbon-container">
+<div class="carbon-hero">
+  <h1>Lead the Pack in Digital Innovation</h1>
+  <p>Don’t settle for second place—uncover the data-driven tactics powering industry frontrunners.</p>
+  <a href="/community/contact/" class="bx--btn bx--btn--primary">Claim Your Complimentary Growth Blueprint</a>
+</div>
 
 # Services & Features
 

--- a/src/content/docs/terms-of-service.mdx
+++ b/src/content/docs/terms-of-service.mdx
@@ -1,7 +1,6 @@
 ---
 title: Terms of Service
 description: The legal terms that govern your use of Blue Frog Analytics.
-template: splash
 ---
 
 <div class="carbon-container">

--- a/src/content/docs/testing.mdx
+++ b/src/content/docs/testing.mdx
@@ -1,15 +1,12 @@
 ---
 title: Testing Tools
 description: Interactive tools for validating analytics implementations.
-template: splash
-hero:
-  tagline: |
-    Validate your tracking setup.
-    Explore Blue Frog Analytics's testing utilities in full-screen mode.
-  image:
-    file: ../../assets/houston.webp
 ---
 
+<div class="carbon-hero">
+  <h1>Validate your tracking setup.</h1>
+  <p>Explore Blue Frog Analytics's testing utilities in full-screen mode.</p>
+</div>
 # Testing Tools
 
 A collection of free tools for validating and exploring different aspects of web development.


### PR DESCRIPTION
## Summary
- remove Starlight splash pages
- add Carbon-styled hero sections
- clean up README docs
- style hero in `carbon.css`

## Testing
- `npm run build` *(fails: astro not found)*