### PR TITLE
Restore full-width splash templates

### DIFF
--- a/src/content/docs/Tests/analytics-doctor.mdx
+++ b/src/content/docs/Tests/analytics-doctor.mdx
@@ -1,6 +1,7 @@
 ---
 title: Analytics Doctor
 description: Scan a domain for analytics implementations.
+template: splash
 ---
 <div id="analytics-root" class="carbon-container">
 <div class="carbon-hero">

--- a/src/content/docs/about.mdx
+++ b/src/content/docs/about.mdx
@@ -1,6 +1,7 @@
 ---
 title: About Blue Frog Analytics
 description: Learn about Blue Frog Analytics, its visionary mission, and the personal journey that sparked its creation.
+template: splash
 ---
 
 <div class="carbon-hero">

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,6 +1,7 @@
 ---
 title: Welcome to Blue Frog Analytics
 description: Advanced website auditing, SEO optimization, and compliance monitoring in one powerful tool.
+template: splash
 ---
 
 <div class="carbon-hero">

--- a/src/content/docs/privacy-policy.mdx
+++ b/src/content/docs/privacy-policy.mdx
@@ -1,6 +1,7 @@
 ---
 title: Privacy Policy
 description: Learn how Blue Frog Analytics collects, uses, and protects your data.
+template: splash
 ---
 
 <div class="carbon-container">

--- a/src/content/docs/services.mdx
+++ b/src/content/docs/services.mdx
@@ -1,6 +1,7 @@
 ---
 title: Services & Features
 description: Explore advisory packages and service pillars to accelerate your growth.
+template: splash
 ---
 <div class="carbon-container">
 <div class="carbon-hero">

--- a/src/content/docs/terms-of-service.mdx
+++ b/src/content/docs/terms-of-service.mdx
@@ -1,6 +1,7 @@
 ---
 title: Terms of Service
 description: The legal terms that govern your use of Blue Frog Analytics.
+template: splash
 ---
 
 <div class="carbon-container">

--- a/src/content/docs/testing.mdx
+++ b/src/content/docs/testing.mdx
@@ -1,6 +1,7 @@
 ---
 title: Testing Tools
 description: Interactive tools for validating analytics implementations.
+template: splash
 ---
 
 <div class="carbon-hero">


### PR DESCRIPTION
## Summary
- bring back `template: splash` frontmatter on main pages

## Testing
- `npm run build` *(fails: astro not found)*