### PR TITLE
Improve ROAS calculator docs

### DIFF
--- a/src/content/docs/Tests/roas-calculator.mdx
+++ b/src/content/docs/Tests/roas-calculator.mdx
@@ -14,60 +14,76 @@ hero:
 <div class="bx--form-item">
   <label for="aov" class="bx--label">AOV</label>
   <input type="number" id="aov" value="100" step="0.01" class="bx--text-input" />
+  <small>Average order value per initial purchase. Added to customer LTV.</small>
 </div>
 <div class="bx--form-item">
   <label for="cogs" class="bx--label">COGS</label>
   <input type="number" id="cogs" value="40" step="0.01" class="bx--text-input" />
+  <small>Cost of goods sold per unit. Deducted from revenue and used in breakeven.</small>
 </div>
 <div class="bx--form-item">
   <label for="spend" class="bx--label">Ad Spend</label>
   <input type="number" id="spend" value="1000" step="0.01" class="bx--text-input" />
+  <small>Total advertising budget for the scenario.</small>
 </div>
 <div class="bx--form-item">
   <label for="cpc" class="bx--label">CPC</label>
   <input type="number" id="cpc" value="1" step="0.01" class="bx--text-input" />
+  <small>Cost per click used to estimate traffic from spend.</small>
 </div>
 <div class="bx--form-item">
   <label for="cvr" class="bx--label">CVR (%)</label>
   <input type="number" id="cvr" value="2" step="0.01" class="bx--text-input" />
+  <small>Conversion rate from lead to customer. Adjusted by scenario.</small>
 </div>
 
 <div class="bx--form-item">
   <label class="bx--label"><input type="checkbox" id="subscription" /> Subscription</label>
+  <small>Include subscription revenue in lifetime value.</small>
 </div>
 <div class="bx--form-item sub-fields">
   <label class="bx--label">Monthly Price <input type="number" id="sub-price" value="30" step="0.01" class="bx--text-input" /></label>
+    <small>Recurring subscription fee charged each month.</small>
   <label class="bx--label">Lifetime (mo) <input type="number" id="sub-life" value="6" step="1" class="bx--text-input" /></label>
+    <small>Expected months a subscriber remains active.</small>
 </div>
 
 <div class="bx--form-item">
   <label class="bx--label"><input type="checkbox" id="service" /> Services</label>
+  <small>Enable if you sell services that close after a lead.</small>
 </div>
 <div class="bx--form-item svc-fields">
   <label class="bx--label">Booking Price <input type="number" id="svc-price" value="300" step="0.01" class="bx--text-input" /></label>
+    <small>Revenue from an initial service booking.</small>
   <label class="bx--label">Contract Len (mo) <input type="number" id="svc-len" value="1" step="1" class="bx--text-input" /></label>
+    <small>Contract length in months to project service revenue.</small>
 
 </div>
 
 <div class="bx--form-item">
   <label for="ctr" class="bx--label">CTR (%)</label>
   <input type="number" id="ctr" value="2" step="0.01" class="bx--text-input" />
+  <small>Percent of clicks that turn into leads.</small>
 </div>
 <div class="bx--form-item">
   <label for="l2c" class="bx--label">Lead→Close (%)</label>
   <input type="number" id="l2c" value="30" step="0.1" class="bx--text-input" />
+  <small>Percent of leads that become clients when services are on.</small>
 </div>
 <div class="bx--form-item">
   <label for="team" class="bx--label">Team Costs</label>
   <input type="number" id="team" value="0" step="0.01" class="bx--text-input" />
+  <small>Fixed team costs included in profit calculations.</small>
 </div>
 <div class="bx--form-item">
   <label for="tools" class="bx--label">Tools Cost</label>
   <input type="number" id="tools" value="0" step="0.01" class="bx--text-input" />
+  <small>Ongoing tool expenses included in profit.</small>
 </div>
 <div class="bx--form-item">
   <label for="fulfill" class="bx--label">Fulfillment Cost</label>
   <input type="number" id="fulfill" value="0" step="0.01" class="bx--text-input" />
+  <small>Other fulfillment costs factored into profit.</small>
 </div>
 
 


### PR DESCRIPTION
## Summary
- document each ROAS calculator field with inline help text
- validate the math used for ROAS, CAC, breakeven, and profit calculations

## Testing
- `npm run build` *(fails: astro not found)*