### PR TITLE
Fix header padding issue

### DIFF
--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -32,6 +32,7 @@ body {
   font-family: var(--sl-font-sans);
   background: var(--cds-background);
   color: var(--cds-text);
+  margin: 0; /* Remove default body margin */
 }
 
 


### PR DESCRIPTION
## Summary
- remove default margin from `body` style

## Testing
- `npm run build` *(fails: `astro` not found)*