### PR TITLE
Add more carbon component examples

### DIFF
--- a/src/pages/carbon-components/index.astro
+++ b/src/pages/carbon-components/index.astro
@@ -161,6 +161,68 @@
         <span class="bx--tag bx--tag--green">Green tag</span>
       </section>
 
+      <section>
+        <h2>Checkbox</h2>
+        <div class="bx--form-item">
+          <input id="checkbox-1" type="checkbox" class="bx--checkbox" />
+          <label for="checkbox-1" class="bx--checkbox-label">Check me</label>
+        </div>
+      </section>
+
+      <section>
+        <h2>Radio Buttons</h2>
+        <div class="bx--form-item bx--radio-button-group" data-radio>
+          <input id="radio-1" class="bx--radio-button" type="radio" name="radio-group" checked />
+          <label for="radio-1" class="bx--radio-button__label">
+            <span class="bx--radio-button__appearance"></span>
+            Option 1
+          </label>
+          <input id="radio-2" class="bx--radio-button" type="radio" name="radio-group" />
+          <label for="radio-2" class="bx--radio-button__label">
+            <span class="bx--radio-button__appearance"></span>
+            Option 2
+          </label>
+        </div>
+      </section>
+
+      <section>
+        <h2>Text Area</h2>
+        <div class="bx--form-item">
+          <label for="textarea-1" class="bx--label">Text Area</label>
+          <textarea id="textarea-1" class="bx--text-area" rows="4" placeholder="Enter text"></textarea>
+        </div>
+      </section>
+
+      <section>
+        <h2>Search</h2>
+        <div class="bx--form-item">
+          <label for="search-1" class="bx--label">Search</label>
+          <input id="search-1" type="text" class="bx--search-input" placeholder="Search" />
+        </div>
+      </section>
+
+      <section>
+        <h2>Data Table</h2>
+        <table class="bx--data-table bx--data-table--compact">
+          <thead>
+            <tr>
+              <th>Column A</th>
+              <th>Column B</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>A1</td>
+              <td>B1</td>
+            </tr>
+            <tr>
+              <td>A2</td>
+              <td>B2</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
     </main>
 
   </body>


### PR DESCRIPTION
## Summary
- extend the `carbon-components` page with more sample components
  - added checkbox, radio buttons, text area, search, and data table sections

## Testing
- `npm run build` *(fails: astro not found)*