### PR TITLE
Remove default Starlight content header

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -104,6 +104,7 @@ export default defineConfig({
     components: {
       Header: './src/components/CustomHeader.astro',
       Footer: './src/components/CustomFooter.astro',
+      ContentPanel: './src/components/EmptyContentPanel.astro',
     },
           head: [
       { tag: 'link', attrs: { rel: 'stylesheet', href: 'https://unpkg.com/carbon-components/css/carbon-components.min.css' } },

--- a/src/components/EmptyContentPanel.astro
+++ b/src/components/EmptyContentPanel.astro
@@ -1,0 +1,6 @@
+---
+/**
+ * Empty component to disable the default Starlight content panel.
+ */
+---
+


### PR DESCRIPTION
## Summary
- disable Starlight's default ContentPanel component
- hook EmptyContentPanel into the config

## Testing
- `npm run build` *(fails: astro not found)*