### PR TITLE
Fix missing docs content

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -104,7 +104,6 @@ export default defineConfig({
     components: {
       Header: './src/components/CustomHeader.astro',
       Footer: './src/components/CustomFooter.astro',
-      ContentPanel: './src/components/EmptyContentPanel.astro',
     },
           head: [
       { tag: 'link', attrs: { rel: 'stylesheet', href: 'https://unpkg.com/carbon-components/css/carbon-components.min.css' } },

--- a/src/components/EmptyContentPanel.astro
+++ b/src/components/EmptyContentPanel.astro
@@ -1,6 +1,0 @@
----
-/**
- * Empty component to disable the default Starlight content panel.
- */
----
-


### PR DESCRIPTION
## Summary
- remove the custom empty content panel that hid all docs
- restore Starlight's default content panel

## Testing
- `npm run build` *(fails: astro not found)*