### PR TITLE
Color full header width

### DIFF
--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -58,7 +58,7 @@ const shouldRenderSearch =
     z-index: 50;
     margin: 0;
     padding: 0;
-
+    background: var(--cds-background);
   }
 
   .bx--header__container.header-content {


### PR DESCRIPTION
## Summary
- ensure the entire header has a background color

## Testing
- `npm run build` *(fails: astro not found)*