### PR TITLE
Fix outer header padding

### DIFF
--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -14,6 +14,12 @@
   z-index: 1100;
 }
 
+/* Remove default margin/padding from the outer header wrapper */
+header {
+  margin: 0;
+  padding: 0;
+}
+
 .bx--footer {
   padding: 2rem 1rem;
   border-top: 1px solid #e0e0e0;

--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -61,6 +61,12 @@ const shouldRenderSearch =
     background: var(--cds-background);
   }
 
+  /* Remove default padding or margin on the outer <header> wrapper */
+  :global(header) {
+    margin: 0;
+    padding: 0;
+  }
+
   .bx--header__container.header-content {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- remove default padding from the `<header>` wrapper

## Testing
- `npm run build` *(fails: `astro` not found)*