### PR TITLE
Remove Starlight header styles

### DIFF
--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -21,10 +21,10 @@ const shouldRenderSearch =
   config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 ---
 
-<div class="bx--header header">
+<div class="bx--header custom-header">
   <link rel="sitemap" href="/sitemap-index.xml" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.15.1/dist/katex.css" integrity="sha384-WsHMgfkABRyG494OmuiNmkAOk8nhO1qE+Y6wns6v+EoNoTNxrWxYpl5ZYWFOLPCM" crossorigin="anonymous">
-  <div class="bx--header__container header-content">
+  <div class="bx--header__container custom-header-content">
     <!-- Left: Logo -->
     <div class="title-wrapper">
       <SiteTitle />
@@ -51,14 +51,14 @@ const shouldRenderSearch =
 
 <style>
   /* Ensure Header is Properly Aligned in Starlight Layout */
-  .bx--header.header {
+  .bx--header.custom-header {
     width: 100%;
     position: sticky;
     top: 0;
     z-index: 50;
     margin: 0;
     padding: 0;
-    background: var(--cds-background);
+    background: black;
   }
 
   /* Remove default padding or margin on the outer <header> wrapper */
@@ -67,7 +67,7 @@ const shouldRenderSearch =
     padding: 0;
   }
 
-  .bx--header__container.header-content {
+  .bx--header__container.custom-header-content {
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -119,13 +119,13 @@ const shouldRenderSearch =
 
   /* Keep Header Within the Starlight Grid */
   @media (min-width: 50rem) {
-    :global(:root[data-has-sidebar]) .header {
+    :global(:root[data-has-sidebar]) .custom-header {
       position: relative;
     }
   }
 
   /* Ensure It Doesn't Expand on Doc Pages */
-  :global(:root[data-has-sidebar]) .header-content {
+  :global(:root[data-has-sidebar]) .custom-header-content {
     width: calc(100% - var(--sl-sidebar-width));
   }
 


### PR DESCRIPTION
## Summary
- drop Starlight's default `header` class
- rename internal classes so global styles can't override our custom header

## Testing
- `npm run build` *(fails: astro not found)*
- `npm test` *(fails: missing script)*