### PR TITLE
Remove Starlight CSS post-load script and strip CSS during build

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -91,6 +91,13 @@ export default defineConfig({
           });
         },
       },
+      {
+        name: "remove-starlight-css",
+        enforce: "post",
+        transformIndexHtml(html) {
+          return html.replace(/<link[^>]*href="[^"]*starlight[^"]*"[^>]*>/gi, "");
+        },
+      },
     ],
   },
 


### PR DESCRIPTION
## Summary
- remove runtime script that deleted starlight stylesheets
- add vite plugin to strip any starlight CSS link from generated HTML

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*