### PR TITLE
Fix header usability

### DIFF
--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -73,13 +73,29 @@ main {
   border-color: #f4f4f4;
 }
 
+/* Ensure header actions and links are visible */
+.bx--header,
+.bx--header a,
+.bx--header button {
+  color: #f5f5f5;
+}
+
+.bx--header__name {
+  color: #f5f5f5;
+}
+
+.bx--header__action svg {
+  fill: #f5f5f5;
+  color: #f5f5f5;
+}
+
 @media (max-width: 800px) {
   .bx--header__nav {
     display: none;
     position: absolute;
     top: var(--cds--ui-shell--header-height);
     left: 0;
-    width: 100%;
+    width: 100vw; /* Fill entire viewport width */
     background: #161616;
     flex-direction: column;
     padding: 0.5rem 1rem;
@@ -97,5 +113,6 @@ main {
   .bx--header__menu-item {
     padding: 0.5rem 0;
     width: 100%;
+    color: #f5f5f5;
   }
 }

--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -3,8 +3,6 @@ import config from 'virtual:starlight/user-config';
 
 import LanguageSelect from 'virtual:starlight/components/LanguageSelect';
 import Search from 'virtual:starlight/components/Search';
-import SiteTitle from 'virtual:starlight/components/SiteTitle';
-import SocialIcons from 'virtual:starlight/components/SocialIcons';
 import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 
 const mainNav = [
@@ -21,9 +19,8 @@ const shouldRenderSearch =
 <!-- 1. Skip link for accessibility -->
 <a href="#main-content" class="bx--skip-to-content">Skip to main content</a>
 
-<!-- 2. Wrap in bx--content for Carbon’s gutters and theme class for dark -->
-<div class="bx--content bx--theme--dark">
-  <header class="bx--header" role="banner" aria-label="Blue Frog Analytics">
+<!-- 2. Carbon header -->
+<header class="bx--header bx--theme--dark" role="banner" aria-label="Blue Frog Analytics">
     <!-- 3. (Optional) hamburger menu trigger if you have a side-nav -->
     <button class="bx--header__menu-trigger bx--header__action" aria-label="Open menu">
       <!-- You can use your own SVG or Carbon’s menu icon -->
@@ -52,18 +49,11 @@ const shouldRenderSearch =
     <!-- 6. Global utilities, in Carbon’s prescribed order -->
     <div class="bx--header__global">
       {shouldRenderSearch && (
-        <button class="bx--header__action bx--header__search" aria-label="Search">
-          <Search size="md" />
-        </button>
+        <Search class="bx--header__action bx--header__search" size="md" />
       )}
-    
-      <button class="bx--header__action bx--btn bx--btn--ghost" aria-label="Toggle theme">
-        <ThemeSelect />
-      </button>
-      <button class="bx--header__action bx--header__app-switcher" aria-label="Language selector">
-        <LanguageSelect />
-      </button>
+
+      <ThemeSelect class="bx--header__action bx--btn bx--btn--ghost" />
+      <LanguageSelect class="bx--header__action bx--header__app-switcher" />
     </div>
-  </header>
-</div>
+</header>
 <script type="module" src="/js/header.js"></script>


### PR DESCRIPTION
## Summary
- clean up custom header markup
- make Starlight search, theme, and language buttons interactive again
- ensure mobile nav fills the viewport
- improve header contrast

## Testing
- `npm run build` *(fails: astro not found)*