### PR TITLE
Expand analytics doctor table

### DIFF
--- a/src/content/docs/Tests/analytics-doctor.mdx
+++ b/src/content/docs/Tests/analytics-doctor.mdx
@@ -48,7 +48,7 @@ template: splash
   margin: 0;
   margin-top: 0;
   max-width: none;
-  padding: 0 5vw;
+  padding: 0 5%;
 }
 #scan-form {
   display: flex;
@@ -126,6 +126,11 @@ template: splash
 #table-wrapper.boxed {
   width: 100%;
   margin: 0;
+}
+
+#pages-table {
+  width: 100%;
+  table-layout: fixed;
 }
 
 


### PR DESCRIPTION
## Summary
- ensure analytics doctor page uses full page width
- enforce 5% page padding
- make results table fill available space

## Testing
- `npm run build` *(fails: astro not found)*