### PR TITLE
Improve header dropdown behavior

### DIFF
--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -181,30 +181,29 @@ main {
   justify-content: center;
 }
 
-@media (max-width: 800px) {
-  .bx--header__nav {
-    display: none;
-    position: absolute;
-    top: var(--cds--ui-shell--header-height);
-    left: 0;
-    width: 100vw; /* Fill entire viewport width */
-    background: #161616;
-    flex-direction: column;
-    padding: 0.5rem 1rem;
-  }
+.bx--header__nav {
+  display: none;
+  position: absolute;
+  top: var(--cds--ui-shell--header-height);
+  left: 0;
+  width: 100vw; /* Fill entire viewport width */
+  background: #161616;
+  flex-direction: column;
+  padding: 0.5rem 1rem;
+  z-index: 1000;
+}
 
-  .bx--header__nav.nav-open {
-    display: flex;
-  }
+.bx--header__nav.nav-open {
+  display: flex;
+}
 
-  .bx--header__menu-bar {
-    flex-direction: column;
-    width: 100%;
-  }
+.bx--header__menu-bar {
+  flex-direction: column;
+  width: 100%;
+}
 
-  .bx--header__menu-item {
-    padding: 0.5rem 0;
-    width: 100%;
-    color: #f5f5f5;
-  }
+.bx--header__menu-item {
+  padding: 0.5rem 0;
+  width: 100%;
+  color: #f5f5f5;
 }

--- a/public/js/header.js
+++ b/public/js/header.js
@@ -1,9 +1,16 @@
-document.addEventListener('DOMContentLoaded', () => {
+function initHeaderMenu() {
   const menuButton = document.querySelector('.bx--header__menu-trigger');
   const nav = document.querySelector('.bx--header__nav');
   if (menuButton && nav) {
     menuButton.addEventListener('click', () => {
       nav.classList.toggle('nav-open');
+      menuButton.setAttribute('aria-expanded', nav.classList.contains('nav-open'));
     });
   }
-});
+}
+
+if (document.readyState !== 'loading') {
+  initHeaderMenu();
+} else {
+  document.addEventListener('DOMContentLoaded', initHeaderMenu);
+}

--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -37,4 +37,4 @@ const mainNav = [
 
   <!-- 6. Global utilities (search, theme, language) removed -->
 </header>
-<!-- Removed starlight mobile menu toggle script -->
+<script src="/js/header.js" defer></script>


### PR DESCRIPTION
## Summary
- make header script load earlier and toggle `aria-expanded`
- update header template to include script
- remove mobile-only restriction from dropdown nav CSS

## Testing
- `npm run build` *(fails: astro not found)*