### PR TITLE
Fix tests pages layout

### DIFF
--- a/src/content/docs/Tests/example-test.mdx
+++ b/src/content/docs/Tests/example-test.mdx
@@ -1,12 +1,19 @@
 ---
 title: Example Test
 description: Placeholder for an interactive test tool.
-
-template: doc
+template: splash
 
 ---
+
+<div class="carbon-hero">
+  <h1>Example Test Tool</h1>
+  <p>Demo placeholder for interactive test tools.</p>
+</div>
+<div class="carbon-container">
 
 # Example Test
 
 This page will host the UI and JavaScript for the example test tool.
+
+</div>
 

--- a/src/content/docs/testing.mdx
+++ b/src/content/docs/testing.mdx
@@ -8,6 +8,7 @@ template: splash
   <h1>Validate your tracking setup.</h1>
   <p>Explore Blue Frog Analytics's testing utilities in full-screen mode.</p>
 </div>
+<div class="carbon-container">
 # Testing Tools
 
 A collection of free tools for validating and exploring different aspects of web development.
@@ -15,4 +16,6 @@ A collection of free tools for validating and exploring different aspects of web
 - [Analytics Doctor](/tests/analytics-doctor)
 - [Example Test](/tests/example-test)
 - [ROAS & Reality Check Calculator](/tests/roas-calculator)
+
+</div>
 

--- a/src/pages/tests/analytics-doctor.astro
+++ b/src/pages/tests/analytics-doctor.astro
@@ -1,0 +1,8 @@
+---
+import DocLayout from '../../components/DocLayout.astro';
+import PageContent from '../../content/docs/Tests/analytics-doctor.mdx';
+---
+<DocLayout>
+  <PageContent />
+</DocLayout>
+

--- a/src/pages/tests/example-test.astro
+++ b/src/pages/tests/example-test.astro
@@ -1,0 +1,8 @@
+---
+import DocLayout from '../../components/DocLayout.astro';
+import PageContent from '../../content/docs/Tests/example-test.mdx';
+---
+<DocLayout>
+  <PageContent />
+</DocLayout>
+

--- a/src/pages/tests/roas-calculator.astro
+++ b/src/pages/tests/roas-calculator.astro
@@ -1,0 +1,8 @@
+---
+import DocLayout from '../../components/DocLayout.astro';
+import PageContent from '../../content/docs/Tests/roas-calculator.mdx';
+---
+<DocLayout>
+  <PageContent />
+</DocLayout>
+


### PR DESCRIPTION
## Summary
- use `splash` template for `example-test` and add Carbon hero/container
- wrap testing index content in Carbon container
- create Astro pages for each test so they use DocLayout instead of DocsLayout

## Testing
- `npm run build` *(fails: astro not found)*