### PR TITLE
Defer analytics and test scripts

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -21,11 +21,13 @@
   });
 </script>
 
-<!-- Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-4N0P7Z1VJ8"></script>
+<!-- Google Analytics (load after page) -->
+<script defer src="https://www.googletagmanager.com/gtag/js?id=G-4N0P7Z1VJ8"></script>
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-4N0P7Z1VJ8');
+  window.addEventListener('load', () => {
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-4N0P7Z1VJ8');
+  });
 </script>

--- a/src/content/docs/Tests/analytics-doctor.mdx
+++ b/src/content/docs/Tests/analytics-doctor.mdx
@@ -40,7 +40,7 @@ template: splash
   </div>
 </div>
 
-<script type="module" src="/js/analytics-doctor.js"></script>
+<script type="module" src="/js/analytics-doctor.js" defer></script>
 
 <style>{`
 

--- a/src/content/docs/Tests/roas-calculator.mdx
+++ b/src/content/docs/Tests/roas-calculator.mdx
@@ -147,5 +147,5 @@ hero:
 `}</style>
 
 
-<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
-<script type="module" src="/js/roas-calculator.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3@7" defer></script>
+<script type="module" src="/js/roas-calculator.js" defer></script>


### PR DESCRIPTION
## Summary
- load Google Analytics after page load
- defer scripts on ROAS calculator and analytics doctor pages

## Testing
- `npm run build` *(fails: astro not found)*