### PR TITLE
Fix header nav on large screens

### DIFF
--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -186,7 +186,8 @@ main {
   position: absolute;
   top: var(--cds--ui-shell--header-height);
   left: 0;
-  width: 100vw; /* Fill entire viewport width */
+  right: 0;
+  width: 100%;
   background: #161616;
   flex-direction: column;
   padding: 0.5rem 1rem;
@@ -206,4 +207,30 @@ main {
   padding: 0.5rem 0;
   width: 100%;
   color: #f5f5f5;
+}
+
+@media (min-width: 768px) {
+  /* Show nav links inline on larger screens */
+  .bx--header__menu-trigger {
+    display: none;
+  }
+  .bx--header__nav {
+    display: flex;
+    position: static;
+    width: auto;
+    background: none;
+    flex-direction: row;
+    padding: 0;
+    align-items: center;
+    height: var(--cds--ui-shell--header-height);
+  }
+  .bx--header__menu-bar {
+    flex-direction: row;
+    width: auto;
+    gap: 1rem;
+  }
+  .bx--header__menu-item {
+    width: auto;
+    padding: 0 0.5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- improve Carbon header nav styling so menu items show on large screens
- ensure dropdown nav covers full width on mobile

## Testing
- `npm run build` *(fails: astro not found)*