### PR TITLE
Implement Carbon global header

### DIFF
--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -247,3 +247,36 @@ main {
   color: #f5f5f5;
 }
 
+/* Side navigation styles */
+#side-nav {
+  display: none;
+  position: fixed;
+  top: var(--cds--ui-shell--header-height);
+  bottom: 0;
+  left: 0;
+  width: 16rem;
+  background: #161616;
+  padding: 1rem;
+  z-index: 1100;
+}
+#side-nav.bx--side-nav--expanded {
+  display: block;
+}
+#side-nav .bx--side-nav__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+#side-nav .bx--side-nav__item {
+  margin: 0.5rem 0;
+}
+#side-nav .bx--side-nav__link {
+  color: #f5f5f5;
+  text-decoration: none;
+}
+@media (min-width: 768px) {
+  #side-nav {
+    display: none !important;
+  }
+}
+

--- a/public/js/header.js
+++ b/public/js/header.js
@@ -1,10 +1,16 @@
 function initHeaderMenu() {
   const menuButton = document.querySelector('.bx--header__menu-trigger');
-  const nav = document.querySelector('.bx--header__nav');
-  if (menuButton && nav) {
+  const sideNav = document.getElementById('side-nav');
+  if (menuButton && sideNav) {
     menuButton.addEventListener('click', () => {
-      nav.classList.toggle('nav-open');
-      menuButton.setAttribute('aria-expanded', nav.classList.contains('nav-open'));
+      const expanded = sideNav.classList.toggle('bx--side-nav--expanded');
+      menuButton.setAttribute('aria-expanded', expanded);
+    });
+    sideNav.querySelectorAll('.bx--side-nav__link').forEach((link) => {
+      link.addEventListener('click', () => {
+        sideNav.classList.remove('bx--side-nav--expanded');
+        menuButton.setAttribute('aria-expanded', 'false');
+      });
     });
   }
 }

--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -1,5 +1,5 @@
 ---
-// Simplified Carbon header without any Starlight dependencies
+// Carbon global header with responsive side navigation
 const mainNav = [
   { label: 'Home', link: '/' },
   { label: 'About', link: '/about/' },
@@ -13,9 +13,8 @@ const mainNav = [
 <!-- Carbon header -->
 <header class="bx--header bx--theme--dark" role="banner" aria-label="Blue Frog Analytics">
   <!-- Hamburger menu trigger -->
-  <button class="bx--header__menu-trigger bx--header__action" aria-label="Open menu">
-    <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg"
-      class="bx--header__menu-trigger__icon" width="20" height="20" viewBox="0 0 32 32">
+  <button class="bx--header__action bx--header__menu-trigger" aria-label="Open menu" data-target="#side-nav">
+    <svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" class="bx--header__menu-trigger__icon" width="20" height="20" viewBox="0 0 32 32">
       <path d="M4 23h24v2H4zm0-8h24v2H4zm0-8h24v2H4z" />
     </svg>
   </button>
@@ -36,6 +35,16 @@ const mainNav = [
 
   <!-- 6. Global utilities (search, theme, language) removed -->
 </header>
+<!-- Side navigation for mobile -->
+<nav id="side-nav" class="bx--side-nav" aria-label="Side navigation">
+  <ul class="bx--side-nav__items">
+    {mainNav.map(item => (
+      <li class="bx--side-nav__item" key={item.link}>
+        <a class="bx--side-nav__link" href={item.link}>{item.label}</a>
+      </li>
+    ))}
+  </ul>
+</nav>
 <script src="/js/header.js" defer></script>
 <style>
   .site-logo-prefix {


### PR DESCRIPTION
## Summary
- implement Carbon side nav in `CustomHeader`
- add JS to toggle responsive side nav
- style the new side navigation

## Testing
- `npm test` *(fails: Missing script)*