### PR TITLE
Migrate doc list to native Carbon styles

### DIFF
--- a/public/css/carbon.css
+++ b/public/css/carbon.css
@@ -1,16 +1,3 @@
-.doc-accordion {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.doc-accordion ul {
-  list-style: none;
-  margin: 0;
-  padding-left: 1rem;
-}
-.doc-link-item {
-  margin: 0.25rem 0;
-}
 :root {
   --sl-font-sans: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
   --sl-color-primary: #0f62fe; /* Carbon blue */

--- a/src/components/DocsLayout.astro
+++ b/src/components/DocsLayout.astro
@@ -43,7 +43,7 @@ const docTree = buildTree();
     <div class="docs-container">
       <aside class="sidebar-left">
         <input id="doc-search" type="search" placeholder="Search docs..." />
-        <ul data-accordion class="bx--accordion doc-accordion">
+        <ul data-accordion class="bx--accordion">
           {(() => {
             function flattenLeaves(node, arr = []) {
               if (node.path) arr.push({ label: node.label, path: node.path });
@@ -59,9 +59,9 @@ const docTree = buildTree();
                   <div class="bx--accordion__title">{cat.label}</div>
                 </button>
                 <div id={`acc-${i}`} class="bx--accordion__content">
-                  <ul>
+                  <ul class="bx--list--unordered">
                     {flattenLeaves(cat).map(page => (
-                      <li class="doc-link-item" key={page.path}><a href={page.path}>{page.label}</a></li>
+                      <li key={page.path}><a href={page.path}>{page.label}</a></li>
                     ))}
                   </ul>
                 </div>


### PR DESCRIPTION
## Summary
- clean up `public/css/carbon.css`
- use Carbon list component inside Docs sidebar

## Testing
- `npm run build` *(fails: `astro` not found)*