### PR TITLE
Add ASCII hero background

### DIFF
--- a/public/js/ascii-hero.js
+++ b/public/js/ascii-hero.js
@@ -1,0 +1,38 @@
+// Simple ASCII art generator for the hero section
+const asciiEl = document.getElementById('ascii-art');
+if (asciiEl) {
+  // Use the poison dart frog image for the hero background
+  const imgUrl =
+    'https://media.istockphoto.com/id/93218208/photo/blue-poison-dart-frog-against-white-background.jpg?b=1&s=612x612&w=0&k=20&c=5o7sCMfedFx3TQ16JDbl0jAQLTo5UTfogcFCVwz7bmI=';
+  const chars = ' .:-=+*#%@';
+  const img = new Image();
+  img.crossOrigin = 'Anonymous';
+  img.onload = () => {
+    // Shrink slightly so the frog fits the right side of the hero
+    const width = 60;
+    const ratio = img.height / img.width;
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = Math.floor(width * ratio);
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    let html = '';
+    for (let y = 0; y < canvas.height; y++) {
+      let row = '';
+      for (let x = 0; x < canvas.width; x++) {
+        const i = (y * canvas.width + x) * 4;
+        const r = data[i];
+        const g = data[i + 1];
+        const b = data[i + 2];
+        const brightness = (r + g + b) / 765;
+        const index = Math.floor((1 - brightness) * (chars.length - 1));
+        const ch = chars[index];
+        row += `<span style="color:rgb(${r},${g},${b})">${ch}</span>`;
+      }
+      html += `<div>${row}</div>`;
+    }
+    asciiEl.innerHTML = html;
+  };
+  img.src = imgUrl;
+}

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ template: splash
 {/* Hero Section */}
 <div className="bx--grid hero-section bx--theme--g100">
   <div className="bx--row">
-    <div className="bx--col-lg-8 bx--offset-lg-2 text-center">
+    <div className="bx--col-lg-8 bx--offset-lg-2 text-center hero-content">
       <h1 className="bx--type-expressive-heading-05">Precision analytics for the modern web.</h1>
       <p className="bx--type-body-long-02">
         Inspired by Carbon’s design principles, Blue Frog Analytics audits and optimizes every metric. Launch with confidence—and keep your site performing at its peak.
@@ -20,6 +20,7 @@ template: splash
       </div>
     </div>
   </div>
+  <div id="ascii-art" aria-hidden="true"></div>
 </div>
 
 {/* Mission Overview - Enhanced Visual Layout */}
@@ -136,3 +137,5 @@ template: splash
     </div>
   </div>
 </div>
+
+<script type="module" src="/js/ascii-hero.js" defer></script>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -68,6 +68,34 @@ body {
   text-align: center;
 }
 
+// Hero ASCII background
+.hero-section {
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+}
+
+#ascii-art {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 25%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 8px;
+  line-height: 8px;
+  pointer-events: none;
+  white-space: pre;
+}
+
 // Button group for calls to action
 .bx--btn-set {
   display: flex;


### PR DESCRIPTION
## Summary
- add ASCII art hero generator script
- style hero section for ASCII overlay
- place ASCII container on the homepage
- use poison dart frog image for ASCII hero
- tweak hero layout to fit frog artwork

## Testing
- `npm run build` *(fails: astro not found)*