### PR TITLE
Unify layout across main pages

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -7,7 +7,7 @@ template: splash
 
 
 {/* Hero Section */}
-<div className="bx--grid hero-section bx--theme--g100">
+<div className="bx--grid hero-section carbon-hero bx--theme--g100">
   <div className="bx--row">
     <div className="bx--col-lg-8 bx--offset-lg-2 text-center hero-content">
       <h1 className="bx--type-expressive-heading-05">Precision analytics for the modern web.</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,20 +1,9 @@
 ---
 // Homepage structured with Carbon sections
-import BaseHead from '../components/BaseHead.astro';
-import CustomHeader from '../components/CustomHeader.astro';
-import CustomFooter from '../components/CustomFooter.astro';
+import DocLayout from '../components/DocLayout.astro';
 import IndexPage from '../content/docs/index.mdx';
 ---
 
-<html lang="en">
-  <head>
-    <BaseHead />
-  </head>
-  <body>
-    <CustomHeader />
-    <main id="main-content">
-      <IndexPage />
-    </main>
-    <CustomFooter />
-  </body>
-</html>
+<DocLayout>
+  <IndexPage />
+</DocLayout>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -167,6 +167,22 @@ main#main-content > * {
   padding-bottom: 1.2rem;
 }
 
+/* Unified layout wrappers for MDX pages */
+.carbon-container,
+.section {
+  max-width: var(--sl-content-width);
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.carbon-hero,
+.hero-section {
+  max-width: var(--sl-content-width);
+  margin: 0 auto 2rem;
+  padding: 2rem 1rem;
+  text-align: center;
+}
+
 .bx--dropdown-item > .bx--dropdown-link,
 .bx--list-box__menu-item {
   color: #f5f5f5;


### PR DESCRIPTION
## Summary
- use `DocLayout` on the home page
- style reusable `.carbon-container`, `.carbon-hero`, and `.section` wrappers
- update hero section markup

## Testing
- `npm run build` *(fails: astro not found)*