### PR TITLE
Highlight current doc link

### DIFF
--- a/src/components/DocsLayout.astro
+++ b/src/components/DocsLayout.astro
@@ -61,7 +61,7 @@ const docTree = buildTree();
                 <div id={`acc-${i}`} class="bx--accordion__content">
                   <ul class="bx--list--unordered">
                     {flattenLeaves(cat).map(page => (
-                      <li key={page.path}><a href={page.path}>{page.label}</a></li>
+                      <li class="doc-link-item" key={page.path}><a href={page.path}>{page.label}</a></li>
                     ))}
                   </ul>
                 </div>
@@ -97,6 +97,23 @@ const docTree = buildTree();
           item.style.display = visible ? '' : 'none';
         });
       });
+
+      // Keep current page link highlighted and its folder open
+      const current = window.location.pathname.replace(/\/$/, '').toLowerCase();
+      const link = Array.from(document.querySelectorAll('.sidebar-left a')).find(a => {
+        const href = a.getAttribute('href');
+        if (!href) return false;
+        return href.replace(/\/$/, '').toLowerCase() === current;
+      });
+      if (link) {
+        link.classList.add('active');
+        const item = link.closest('.bx--accordion__item');
+        if (item) {
+          item.classList.add('bx--accordion__item--active');
+          const heading = item.querySelector('.bx--accordion__heading');
+          if (heading) heading.setAttribute('aria-expanded', 'true');
+        }
+      }
     </script>
   </body>
 </html>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -255,6 +255,12 @@ main#main-content > * {
   text-decoration: underline;
 }
 
+// Docs sidebar: highlight active article link
+.sidebar-left a.active {
+  color: var(--sl-color-primary);
+  text-decoration: underline;
+}
+
 // Desktop header: add separator between logo and nav
 @media (min-width: 768px) {
   .site-logo {


### PR DESCRIPTION
## Summary
- keep doc folder expanded
- highlight active doc article in the sidebar

## Testing
- `npm run build` *(fails: astro not found)*