### PR TITLE
Optimize loading to reduce blocking

### DIFF
--- a/public/js/analytics-doctor.js
+++ b/public/js/analytics-doctor.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('load', () => {
   const API_BASE_URL = 'https://66f4-24-20-99-62.ngrok-free.app';
   const ANALYTICS_KEYS = [
     'google_analytics',

--- a/public/js/header.js
+++ b/public/js/header.js
@@ -18,5 +18,5 @@ function initHeaderMenu() {
 if (document.readyState !== 'loading') {
   initHeaderMenu();
 } else {
-  document.addEventListener('DOMContentLoaded', initHeaderMenu);
+  window.addEventListener('load', initHeaderMenu);
 }

--- a/public/js/roas-calculator.js
+++ b/public/js/roas-calculator.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('load', () => {
   const form = document.getElementById('roas-form');
   const exportBtn = document.getElementById('export');
   const resultsEl = document.getElementById('roas-results');

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -5,17 +5,19 @@ import '../styles/global.scss';
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<!-- IBM Carbon CSS -->
-<link rel="stylesheet" href="https://unpkg.com/carbon-components/css/carbon-components.min.css" />
+<!-- IBM Carbon CSS (loaded asynchronously to avoid render blocking) -->
+<link rel="preload" as="style" href="https://unpkg.com/carbon-components/css/carbon-components.min.css" onload="this.onload=null;this.rel='stylesheet'" />
+<noscript><link rel="stylesheet" href="https://unpkg.com/carbon-components/css/carbon-components.min.css" /></noscript>
 <!-- IBM Plex Sans font -->
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" />
+<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
+<noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" /></noscript>
 
 <!-- Carbon JS (for interactive components) -->
 <script src="https://unpkg.com/carbon-components/scripts/carbon-components.min.js" defer></script>
 <script>
-  window.addEventListener("DOMContentLoaded", () => {
+  window.addEventListener("load", () => {
     if (window.CarbonComponents) {
       window.CarbonComponents.watch();
     }

--- a/src/pages/carbon-components/index.astro
+++ b/src/pages/carbon-components/index.astro
@@ -7,14 +7,17 @@
     <title>Carbon Components Examples</title>
     <meta name="robots" content="noindex,nofollow" />
 
-    <link rel="stylesheet" href="https://unpkg.com/carbon-components/css/carbon-components.min.css" />
+    <link rel="preload" as="style" href="https://unpkg.com/carbon-components/css/carbon-components.min.css" onload="this.onload=null;this.rel='stylesheet'" />
+    <noscript><link rel="stylesheet" href="https://unpkg.com/carbon-components/css/carbon-components.min.css" /></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" />
-    <link rel="stylesheet" href="/css/carbon.css" />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" /></noscript>
+    <link rel="preload" as="style" href="/css/carbon.css" onload="this.onload=null;this.rel='stylesheet'" />
+    <noscript><link rel="stylesheet" href="/css/carbon.css" /></noscript>
     <script src="https://unpkg.com/carbon-components/scripts/carbon-components.min.js" defer></script>
     <script>
-      window.addEventListener('DOMContentLoaded', () => {
+      window.addEventListener('load', () => {
         if (window.CarbonComponents) {
           window.CarbonComponents.watch();
         }


### PR DESCRIPTION
## Summary
- load Carbon CSS and fonts asynchronously
- defer Carbon initialization until window load
- load demo page resources asynchronously
- delay script initialization until window `load`

## Testing
- `npm run build` *(fails: astro not found)*