### PR TITLE
Add blog section with search and tags

### DIFF
--- a/public/js/blog-search.js
+++ b/public/js/blog-search.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('blog-search');
+  if (!input) return;
+  input.addEventListener('input', () => {
+    const filter = input.value.toLowerCase();
+    document.querySelectorAll('.blog-card').forEach(card => {
+      const text = card.textContent.toLowerCase();
+      card.style.display = text.includes(filter) ? '' : 'none';
+    });
+  });
+});

--- a/src/components/BlogLayout.astro
+++ b/src/components/BlogLayout.astro
@@ -1,0 +1,17 @@
+---
+import BaseHead from './BaseHead.astro';
+import CustomHeader from './CustomHeader.astro';
+import CustomFooter from './CustomFooter.astro';
+---
+<html lang="en">
+  <head>
+    <BaseHead />
+  </head>
+  <body>
+    <CustomHeader />
+    <main id="main-content">
+      <slot />
+    </main>
+    <CustomFooter />
+  </body>
+</html>

--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -1,0 +1,17 @@
+---
+const { post } = Astro.props;
+---
+<article class="blog-card">
+  <h2 class="blog-card-title"><a href={post.url}>{post.data.title}</a></h2>
+  {post.data.pubDate && <p class="blog-card-date">{post.data.pubDate.toLocaleDateString()}</p>}
+  {post.data.description && <p class="blog-card-desc">{post.data.description}</p>}
+  {post.data.tags?.length ? (
+    <p class="blog-card-tags">{post.data.tags.map(t => <a href={`/blog/tags/${t}/`}>{t}</a>).join(', ')}</p>
+  ) : null}
+</article>
+<style>
+.blog-card { margin-bottom: 2rem; }
+.blog-card-title { margin: 0 0 0.25rem; }
+.blog-card-date { margin: 0 0 0.5rem; color: #6f6f6f; }
+.blog-card-tags a { margin-right: 0.5rem; text-decoration: none; font-size: 0.85rem; }
+</style>

--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -5,6 +5,7 @@ const mainNav = [
   { label: 'About', link: '/about/' },
   { label: 'Services', link: '/services/' },
   { label: 'Tests', link: '/testing/' },
+  { label: 'Blog', link: '/blog/' },
   { label: 'Docs', link: '/introduction/how-blue-frog-analytics-works' },
 ];
 ---

--- a/src/content/blog/first-post.mdx
+++ b/src/content/blog/first-post.mdx
@@ -1,0 +1,9 @@
+---
+title: "Introducing Our Blog"
+description: "Welcome to the Blue Frog Analytics blog."
+pubDate: 2024-04-01
+author: John Wiedeman
+tags: [announcement, welcome]
+---
+
+We are excited to launch our new blog. Stay tuned for updates!

--- a/src/content/blog/second-post.mdx
+++ b/src/content/blog/second-post.mdx
@@ -1,0 +1,9 @@
+---
+title: "Using Blue Frog Analytics for SEO"
+description: "Tips on leveraging our platform to improve SEO."
+pubDate: 2024-04-10
+author: Jane Doe
+tags: [seo, tips]
+---
+
+In this post we explore ways to maximize your search visibility with Blue Frog Analytics.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,2 +1,14 @@
-// Placeholder content config: no collections defined
-export const collections = {};
+import { z, defineCollection } from 'astro:content';
+
+export const collections = {
+  blog: defineCollection({
+    type: 'content',
+    schema: z.object({
+      title: z.string(),
+      description: z.string().optional(),
+      pubDate: z.date(),
+      author: z.string().optional(),
+      tags: z.array(z.string()).default([]),
+    })
+  })
+};

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,24 @@
+---
+import { getCollection, getEntryBySlug } from 'astro:content';
+import BlogLayout from '../../components/BlogLayout.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map(p => ({ params: { slug: p.slug } }));
+}
+
+const { slug } = Astro.params;
+const post = await getEntryBySlug('blog', slug);
+if (!post) throw new Error('Post not found');
+const Content = post.render().Content;
+---
+<BlogLayout>
+  <article>
+    <h1>{post.data.title}</h1>
+    {post.data.pubDate && <p>{post.data.pubDate.toLocaleDateString()}</p>}
+    <Content />
+    {post.data.tags?.length ? (
+      <p>Tags: {post.data.tags.map(t => <a href={`/blog/tags/${t}/`}>{t}</a>).join(', ')}</p>
+    ) : null}
+  </article>
+</BlogLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,23 @@
+---
+import { getCollection } from 'astro:content';
+import BlogLayout from '../../components/BlogLayout.astro';
+import BlogPostCard from '../../components/BlogPostCard.astro';
+
+const posts = await getCollection('blog');
+const sorted = posts.sort((a,b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
+---
+<BlogLayout>
+  <h1>Blog</h1>
+  <input id="blog-search" type="search" placeholder="Search posts..." />
+  <div class="tag-cloud">
+    {tags.map(t => <a href={`/blog/tags/${t}/`}>{t}</a>)}
+  </div>
+  <div id="posts-list">
+    {sorted.map(post => <BlogPostCard post={post} />)}
+  </div>
+  <script src="/js/blog-search.js" defer></script>
+  <style>
+    .tag-cloud a { margin-right: 0.5rem; }
+  </style>
+</BlogLayout>

--- a/src/pages/blog/tags/[tag].astro
+++ b/src/pages/blog/tags/[tag].astro
@@ -1,0 +1,18 @@
+---
+import { getCollection } from 'astro:content';
+import BlogLayout from '../../../components/BlogLayout.astro';
+import BlogPostCard from '../../../components/BlogPostCard.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  const tags = new Set(posts.flatMap(p => p.data.tags || []));
+  return Array.from(tags).map(tag => ({ params: { tag } }));
+}
+
+const { tag } = Astro.params;
+const posts = (await getCollection('blog')).filter(p => p.data.tags?.includes(tag));
+---
+<BlogLayout>
+  <h1>Posts tagged {tag}</h1>
+  {posts.map(post => <BlogPostCard post={post} />)}
+</BlogLayout>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,0 +1,20 @@
+---
+import { getCollection } from 'astro:content';
+import BlogLayout from '../../../components/BlogLayout.astro';
+
+const posts = await getCollection('blog');
+const tagMap = new Map();
+for (const post of posts) {
+  (post.data.tags || []).forEach(tag => {
+    tagMap.set(tag, (tagMap.get(tag) || 0) + 1);
+  });
+}
+---
+<BlogLayout>
+  <h1>Tags</h1>
+  <ul>
+    {Array.from(tagMap.entries()).map(([tag, count]) => (
+      <li key={tag}><a href={`/blog/tags/${tag}/`}>{tag} ({count})</a></li>
+    ))}
+  </ul>
+</BlogLayout>


### PR DESCRIPTION
## Summary
- define a `blog` content collection
- add Blog layout and card components
- create blog index, post, and tag pages
- implement search for posts and add tag cloud
- link the blog in the global header
- provide two example posts

## Testing
- `npm run build` *(fails: astro not found)*