### PR TITLE
Improve blog layout and carousel

### DIFF
--- a/public/js/hero-carousel.js
+++ b/public/js/hero-carousel.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const carousel = document.querySelector('.blog-carousel');
+  if (!carousel) return;
+  const slides = carousel.querySelectorAll('.carousel-slide');
+  let index = 0;
+  function show(n) {
+    slides.forEach((s, i) => { s.hidden = i !== n; });
+  }
+  show(index);
+  const prev = carousel.querySelector('.carousel-prev');
+  const next = carousel.querySelector('.carousel-next');
+  prev && prev.addEventListener('click', () => {
+    index = (index - 1 + slides.length) % slides.length;
+    show(index);
+  });
+  next && next.addEventListener('click', () => {
+    index = (index + 1) % slides.length;
+    show(index);
+  });
+});

--- a/src/components/BlogCarousel.astro
+++ b/src/components/BlogCarousel.astro
@@ -1,0 +1,34 @@
+---
+const { posts = [] } = Astro.props;
+---
+<div class="blog-carousel" data-carousel>
+  {posts.map((post, idx) => (
+    <div class="carousel-slide" data-index={idx} hidden={idx !== 0}>
+      <h2 class="carousel-title"><a href={post.url}>{post.data.title}</a></h2>
+      {post.data.description && <p class="carousel-desc">{post.data.description}</p>}
+    </div>
+  ))}
+  {posts.length > 1 && (
+    <>
+      <button class="carousel-prev bx--btn bx--btn--ghost" aria-label="Previous slide">&#8592;</button>
+      <button class="carousel-next bx--btn bx--btn--ghost" aria-label="Next slide">&#8594;</button>
+    </>
+  )}
+</div>
+<style>
+.blog-carousel {
+  position: relative;
+  overflow: hidden;
+}
+.carousel-slide {
+  text-align: left;
+}
+.carousel-prev,
+.carousel-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.carousel-prev { left: 0.5rem; }
+.carousel-next { right: 0.5rem; }
+</style>

--- a/src/components/CategoryTabs.astro
+++ b/src/components/CategoryTabs.astro
@@ -1,0 +1,20 @@
+---
+import BlogPostCard from './BlogPostCard.astro';
+const { categories = {} } = Astro.props;
+const names = Object.keys(categories);
+---
+<div data-tabs class="bx--tabs">
+  <ul class="bx--tabs__nav" role="tablist">
+    {names.map((name, i) => (
+      <li class={`bx--tabs__nav-item${i === 0 ? ' bx--tabs__nav-item--selected' : ''}`} data-target={`#tab-${name}`} role="tab">{name.charAt(0).toUpperCase() + name.slice(1)}</li>
+    ))}
+  </ul>
+  {names.map((name, i) => (
+    <div id={`tab-${name}`} class="bx--tab-content" role="tabpanel" hidden={i !== 0}>
+      {categories[name].length ? categories[name].map(p => <BlogPostCard post={p} />) : <p>No articles found.</p>}
+    </div>
+  ))}
+</div>
+<style>
+.bx--tab-content { padding-top: 1rem; }
+</style>

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -1,0 +1,15 @@
+---
+const { posts = [] } = Astro.props;
+---
+<aside class="recent-posts">
+  <h3>Recent Posts</h3>
+  <ul class="recent-posts-list">
+    {posts.map(p => (
+      <li><a href={p.url}>{p.data.title}</a></li>
+    ))}
+  </ul>
+</aside>
+<style>
+.recent-posts-list { list-style: none; padding: 0; }
+.recent-posts-list li { margin-bottom: 0.5rem; }
+</style>

--- a/src/content/blog/fifth-post.mdx
+++ b/src/content/blog/fifth-post.mdx
@@ -1,0 +1,9 @@
+---
+title: "Analyzing Visitor Behavior"
+description: "Using Blue Frog to understand your audience."
+pubDate: 2024-07-20
+author: Jordan Brown
+tags: [analytics, seo]
+---
+
+This article shows how visitor insights can guide your SEO strategy.

--- a/src/content/blog/fourth-post.mdx
+++ b/src/content/blog/fourth-post.mdx
@@ -1,0 +1,9 @@
+---
+title: "Improving Site Search"
+description: "Best practices for search optimization."
+pubDate: 2024-06-15
+author: Sam Lee
+tags: [search, tips]
+---
+
+Discover how to optimize your website search using Blue Frog Analytics.

--- a/src/content/blog/third-post.mdx
+++ b/src/content/blog/third-post.mdx
@@ -1,0 +1,9 @@
+---
+title: "Advanced Analytics with Blue Frog"
+description: "Dive deeper into analytics features."
+pubDate: 2024-05-05
+author: Alex Smith
+tags: [analytics]
+---
+
+Learn how to use advanced analytics in Blue Frog to monitor performance.

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,23 +1,39 @@
 ---
 import { getCollection } from 'astro:content';
 import BlogLayout from '../../components/BlogLayout.astro';
-import BlogPostCard from '../../components/BlogPostCard.astro';
+import BlogCarousel from '../../components/BlogCarousel.astro';
+import RecentPosts from '../../components/RecentPosts.astro';
+import CategoryTabs from '../../components/CategoryTabs.astro';
 
 const posts = await getCollection('blog');
 const sorted = posts.sort((a,b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
+const featured = sorted.slice(0,3);
+const categories = {
+  analytics: sorted.filter(p => (p.data.tags || []).includes('analytics')),
+  seo: sorted.filter(p => (p.data.tags || []).includes('seo')),
+  search: sorted.filter(p => (p.data.tags || []).includes('search')),
+};
 ---
 <BlogLayout>
   <h1>Blog</h1>
   <input id="blog-search" type="search" placeholder="Search posts..." />
-  <div class="tag-cloud">
-    {tags.map(t => <a href={`/blog/tags/${t}/`}>{t}</a>)}
-  </div>
-  <div id="posts-list">
-    {sorted.map(post => <BlogPostCard post={post} />)}
-  </div>
+  <section class="blog-hero bx--grid">
+    <div class="bx--row">
+      <div class="bx--col-sm-4 bx--col-md-6 bx--col-lg-12">
+        <BlogCarousel posts={featured} />
+      </div>
+      <div class="bx--col-sm-4 bx--col-md-2 bx--col-lg-4">
+        <RecentPosts posts={sorted.slice(0,5)} />
+      </div>
+    </div>
+  </section>
+  <section class="blog-tabs bx--grid">
+    <CategoryTabs categories={categories} />
+  </section>
   <script src="/js/blog-search.js" defer></script>
+  <script src="/js/hero-carousel.js" defer></script>
   <style>
-    .tag-cloud a { margin-right: 0.5rem; }
+    .blog-hero { margin-bottom: 2rem; }
+    .blog-tabs .bx--tab-content { padding-top: 1rem; }
   </style>
 </BlogLayout>


### PR DESCRIPTION
## Summary
- generate three additional blog posts for carousel content
- add `RecentPosts` and `CategoryTabs` components
- update blog index page to use new components and Carbon grid
- show first slide when carousel script loads

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*