### PR TITLE
Enhance blog layout with Carbon components

### DIFF
--- a/public/js/blog-search.js
+++ b/public/js/blog-search.js
@@ -1,11 +1,32 @@
 document.addEventListener('DOMContentLoaded', () => {
   const input = document.getElementById('blog-search');
-  if (!input) return;
-  input.addEventListener('input', () => {
-    const filter = input.value.toLowerCase();
+  const tags = document.querySelectorAll('.tag-filter .bx--tag');
+  let activeTag = '';
+
+  function filterPosts() {
+    const filter = input ? input.value.toLowerCase() : '';
     document.querySelectorAll('.blog-card').forEach(card => {
       const text = card.textContent.toLowerCase();
-      card.style.display = text.includes(filter) ? '' : 'none';
+      const tagMatch = !activeTag || (card.dataset.tags || '').includes(activeTag);
+      card.style.display = text.includes(filter) && tagMatch ? '' : 'none';
+    });
+  }
+
+  if (input) {
+    input.addEventListener('input', filterPosts);
+  }
+
+  tags.forEach(tag => {
+    tag.addEventListener('click', () => {
+      if (activeTag === tag.dataset.tag) {
+        activeTag = '';
+        tag.classList.remove('active');
+      } else {
+        activeTag = tag.dataset.tag;
+        tags.forEach(t => t.classList.remove('active'));
+        tag.classList.add('active');
+      }
+      filterPosts();
     });
   });
 });

--- a/src/components/BlogCarousel.astro
+++ b/src/components/BlogCarousel.astro
@@ -22,6 +22,14 @@ const { posts = [] } = Astro.props;
 }
 .carousel-slide {
   text-align: left;
+  padding: 2rem;
+  min-height: 200px;
+  background: #e0e0e0;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 .carousel-prev,
 .carousel-next {

--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -1,7 +1,7 @@
 ---
 const { post } = Astro.props;
 ---
-<article class="blog-card">
+<article class="blog-card" data-tags={(post.data.tags || []).join(' ')}>
   <h2 class="blog-card-title"><a href={post.url}>{post.data.title}</a></h2>
   {post.data.pubDate && <p class="blog-card-date">{post.data.pubDate.toLocaleDateString()}</p>}
   {post.data.description && <p class="blog-card-desc">{post.data.description}</p>}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,41 +4,61 @@ import BlogLayout from '../../components/BlogLayout.astro';
 
 import BlogCarousel from '../../components/BlogCarousel.astro';
 import RecentPosts from '../../components/RecentPosts.astro';
-import CategoryTabs from '../../components/CategoryTabs.astro';
+import BlogPostCard from '../../components/BlogPostCard.astro';
 
 
 const posts = await getCollection('blog');
 const sorted = posts.sort((a,b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 const featured = sorted.slice(0,3);
-const categories = {
-  analytics: sorted.filter(p => (p.data.tags || []).includes('analytics')),
-  seo: sorted.filter(p => (p.data.tags || []).includes('seo')),
-  search: sorted.filter(p => (p.data.tags || []).includes('search')),
-};
+const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
 ---
 <BlogLayout>
-  <h1>Blog</h1>
-  <input id="blog-search" type="search" placeholder="Search posts..." />
-  <section class="blog-hero bx--grid">
-    <div class="bx--row">
-      <div class="bx--col-sm-4 bx--col-md-6 bx--col-lg-12">
-        <BlogCarousel posts={featured} />
+  <div class="blog-page">
+    <h1>Blog</h1>
+    <section class="blog-search bx--grid">
+      <div class="bx--row">
+        <div class="bx--col-lg-16">
+          <div data-search class="bx--search bx--search--lg" role="search">
+            <label for="blog-search" class="bx--label bx--visually-hidden">Search posts</label>
+            <input id="blog-search" type="text" class="bx--search-input" placeholder="Search posts..." />
+          </div>
+          <div class="tag-filter">
+            {tags.map(t => <span class="bx--tag" data-tag={t}>{t}</span>)}
+          </div>
+        </div>
       </div>
+    </section>
 
-      <div class="bx--col-sm-4 bx--col-md-2 bx--col-lg-4">
-        <RecentPosts posts={sorted.slice(0,5)} />
+    <section class="blog-hero bx--grid">
+      <div class="bx--row">
+        <div class="bx--col-sm-4 bx--col-md-6 bx--col-lg-12">
+          <BlogCarousel posts={featured} />
+        </div>
+
+        <div class="bx--col-sm-4 bx--col-md-2 bx--col-lg-4">
+          <RecentPosts posts={sorted.slice(0,5)} />
+        </div>
       </div>
-    </div>
-  </section>
-  <section class="blog-tabs bx--grid">
-    <CategoryTabs categories={categories} />
+    </section>
 
-  </section>
-  <script src="/js/blog-search.js" defer></script>
-  <script src="/js/hero-carousel.js" defer></script>
-  <style>
-    .blog-hero { margin-bottom: 2rem; }
-
-    .blog-tabs .bx--tab-content { padding-top: 1rem; }
-  </style>
+    <section class="blog-posts bx--grid">
+      <div class="bx--row" id="posts-list">
+        {sorted.map(post => (
+          <div class="bx--col-lg-4 bx--col-md-8 bx--col-sm-4">
+            <BlogPostCard post={post} />
+          </div>
+        ))}
+      </div>
+    </section>
+    <script src="/js/blog-search.js" defer></script>
+    <script src="/js/hero-carousel.js" defer></script>
+    <style>
+      #main-content > .blog-page { max-width: none; padding: 0; }
+      .blog-search { margin-bottom: 1rem; }
+      .tag-filter { margin-top: 0.5rem; }
+      .tag-filter .bx--tag { margin-right: 0.5rem; cursor: pointer; }
+      .tag-filter .bx--tag.active { background: #0f62fe; color: #fff; }
+      .blog-hero { margin-bottom: 2rem; }
+    </style>
+  </div>
 </BlogLayout>


### PR DESCRIPTION
## Summary
- enlarge hero carousel panels
- allow blog posts to be filtered with a Carbon search bar and clickable tags
- render posts in a full-width grid

## Testing
- `git status --short`