### PR TITLE
Adjust blog search and layout

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -14,14 +14,23 @@ const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
 ---
 <BlogLayout>
   <div class="blog-page">
-    <h1>Blog</h1>
-    <section class="blog-search bx--grid">
+    <section class="blog-hero bx--grid">
       <div class="bx--row">
         <div class="bx--col-lg-16">
+          <BlogCarousel posts={featured} />
+        </div>
+      </div>
+    </section>
+
+    <section class="blog-search bx--grid">
+      <div class="bx--row">
+        <div class="bx--col-lg-12">
           <div data-search class="bx--search bx--search--lg" role="search">
             <label for="blog-search" class="bx--label bx--visually-hidden">Search posts</label>
             <input id="blog-search" type="text" class="bx--search-input" placeholder="Search posts..." />
           </div>
+        </div>
+        <div class="bx--col-lg-4 tags-col">
           <div class="tag-filter">
             {tags.map(t => <span class="bx--tag" data-tag={t}>{t}</span>)}
           </div>
@@ -29,36 +38,32 @@ const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
       </div>
     </section>
 
-    <section class="blog-hero bx--grid">
+    <section class="blog-posts bx--grid">
       <div class="bx--row">
-        <div class="bx--col-sm-4 bx--col-md-6 bx--col-lg-12">
-          <BlogCarousel posts={featured} />
+        <div class="bx--col-lg-12">
+          <div class="bx--row" id="posts-list">
+            {sorted.map(post => (
+              <div class="bx--col-lg-4 bx--col-md-8 bx--col-sm-4">
+                <BlogPostCard post={post} />
+              </div>
+            ))}
+          </div>
         </div>
-
-        <div class="bx--col-sm-4 bx--col-md-2 bx--col-lg-4">
+        <div class="bx--col-lg-4">
           <RecentPosts posts={sorted.slice(0,5)} />
         </div>
-      </div>
-    </section>
-
-    <section class="blog-posts bx--grid">
-      <div class="bx--row" id="posts-list">
-        {sorted.map(post => (
-          <div class="bx--col-lg-4 bx--col-md-8 bx--col-sm-4">
-            <BlogPostCard post={post} />
-          </div>
-        ))}
       </div>
     </section>
     <script src="/js/blog-search.js" defer></script>
     <script src="/js/hero-carousel.js" defer></script>
     <style>
       #main-content > .blog-page { max-width: none; padding: 0; }
-      .blog-search { margin-bottom: 1rem; }
+      .blog-hero { margin-bottom: 1rem; }
+      .blog-search { margin-bottom: 2rem; }
+      .tags-col { display: flex; align-items: center; justify-content: flex-end; }
       .tag-filter { margin-top: 0.5rem; }
-      .tag-filter .bx--tag { margin-right: 0.5rem; cursor: pointer; }
+      .tag-filter .bx--tag { margin-left: 0.5rem; cursor: pointer; }
       .tag-filter .bx--tag.active { background: #0f62fe; color: #fff; }
-      .blog-hero { margin-bottom: 2rem; }
     </style>
   </div>
 </BlogLayout>


### PR DESCRIPTION
## Summary
- tweak blog page structure
- put search under featured articles with tags to the right
- show posts results in 3/4 column and recent posts in 1/4 column
- drop the "Blog" heading

## Testing
- `npm run build`