### PR TITLE
Fix hero overflow issue

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -16,6 +16,8 @@ body {
   font-family: var(--sl-font-sans);
   background: var(--cds-background);
   color: var(--cds-text);
+  /* Prevent horizontal scrollbars from full-width sections */
+  overflow-x: hidden;
   /* Offset all pages below the fixed header */
   padding-top: 7rem;
   padding-bottom: 1rem;


### PR DESCRIPTION
## Summary
- prevent page overflow when using full-width hero sections

## Testing
- `npm test` *(fails: Missing script)*