### PR TITLE
Revamp ROAS calculator layout

### DIFF
--- a/src/content/pages/Tests/roas-calculator.mdx
+++ b/src/content/pages/Tests/roas-calculator.mdx
@@ -8,118 +8,140 @@ hero:
 ---
 
 
-<div id="roas-root" class="carbon-container">
-<form id="roas-form" class="bx--form">
+<div id="roas-root" class="carbon-container bx--grid bx--grid--condensed">
+  <div class="bx--row">
+    <div class="bx--col-lg-8 bx--offset-lg-2">
+      <div class="carbon-hero">
+        <h1>ROAS &amp; Reality Check Calculator</h1>
+        <p>Estimate advertising outcomes across multiple scenarios.</p>
+      </div>
+      <form id="roas-form" class="bx--form">
+        <div class="bx--row">
+          <div class="bx--col-lg-6">
+            <fieldset class="bx--fieldset bx--tile">
+              <legend class="bx--label">Product</legend>
+              <div class="bx--form-item">
+                <label for="aov" class="bx--label">AOV</label>
+                <input type="number" id="aov" value="100" step="0.01" class="bx--text-input" />
+                <small>Average order value per initial purchase. Added to customer LTV.</small>
+              </div>
+              <div class="bx--form-item">
+                <label for="cogs" class="bx--label">COGS</label>
+                <input type="number" id="cogs" value="40" step="0.01" class="bx--text-input" />
+                <small>Cost of goods sold per unit. Deducted from revenue.</small>
+              </div>
+            </fieldset>
+          </div>
+          <div class="bx--col-lg-6">
+            <fieldset class="bx--fieldset bx--tile">
+              <legend class="bx--label">Advertising</legend>
+              <div class="bx--form-item">
+                <label for="spend" class="bx--label">Ad Spend</label>
+                <input type="number" id="spend" value="1000" step="0.01" class="bx--text-input" />
+                <small>Total advertising budget for the scenario.</small>
+              </div>
+              <div class="bx--form-item">
+                <label for="cpc" class="bx--label">CPC</label>
+                <input type="number" id="cpc" value="1" step="0.01" class="bx--text-input" />
+                <small>Cost per click used to estimate traffic from spend.</small>
+              </div>
+              <div class="bx--form-item">
+                <label for="ctr" class="bx--label">CTR (%)</label>
+                <input type="number" id="ctr" value="2" step="0.01" class="bx--text-input" />
+                <small>Percent of clicks that turn into leads.</small>
+              </div>
+              <div class="bx--form-item">
+                <label for="cvr" class="bx--label">CVR (%)</label>
+                <input type="number" id="cvr" value="2" step="0.01" class="bx--text-input" />
+                <small>Conversion rate from lead to customer.</small>
+              </div>
+            </fieldset>
+          </div>
+        </div>
 
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Product</legend>
-  <div class="bx--form-item">
-    <label for="aov" class="bx--label">AOV</label>
-    <input type="number" id="aov" value="100" step="0.01" class="bx--text-input" />
-    <small>Average order value per initial purchase. Added to customer LTV.</small>
-  </div>
-  <div class="bx--form-item">
-    <label for="cogs" class="bx--label">COGS</label>
-    <input type="number" id="cogs" value="40" step="0.01" class="bx--text-input" />
-    <small>Cost of goods sold per unit. Deducted from revenue.</small>
-  </div>
-</fieldset>
+        <div class="bx--row">
+          <div class="bx--col-lg-6">
+            <fieldset class="bx--fieldset bx--tile">
+              <legend class="bx--label">Subscription</legend>
+              <div class="bx--form-item">
+                <input type="checkbox" id="subscription" class="bx--checkbox" />
+                <label for="subscription" class="bx--checkbox-label">Enable subscription revenue</label>
+                <small>Include subscription revenue in lifetime value.</small>
+              </div>
+              <div id="subscription-fields" class="sub-fields" style="display:none">
+                <div class="bx--form-item">
+                  <label for="sub-price" class="bx--label">Monthly Price</label>
+                  <input type="number" id="sub-price" value="30" step="0.01" class="bx--text-input" />
+                  <small>Recurring subscription fee per month.</small>
+                </div>
+                <div class="bx--form-item">
+                  <label for="sub-life" class="bx--label">Lifetime (mo)</label>
+                  <input type="number" id="sub-life" value="6" step="1" class="bx--text-input" />
+                  <small>Expected months a subscriber remains active.</small>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <div class="bx--col-lg-6">
+            <fieldset class="bx--fieldset bx--tile">
+              <legend class="bx--label">Services</legend>
+              <div class="bx--form-item">
+                <input type="checkbox" id="service" class="bx--checkbox" />
+                <label for="service" class="bx--checkbox-label">Enable services</label>
+                <small>Enable if you sell services that close after a lead.</small>
+              </div>
+              <div id="service-fields" class="svc-fields" style="display:none">
+                <div class="bx--form-item">
+                  <label for="svc-price" class="bx--label">Booking Price</label>
+                  <input type="number" id="svc-price" value="300" step="0.01" class="bx--text-input" />
+                  <small>Revenue from an initial service booking.</small>
+                </div>
+                <div class="bx--form-item">
+                  <label for="svc-len" class="bx--label">Contract Len (mo)</label>
+                  <input type="number" id="svc-len" value="1" step="1" class="bx--text-input" />
+                  <small>Contract length in months.</small>
+                </div>
+                <div class="bx--form-item">
+                  <label for="l2c" class="bx--label">Lead→Close (%)</label>
+                  <input type="number" id="l2c" value="30" step="0.1" class="bx--text-input" />
+                  <small>Percent of leads that become clients.</small>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+        </div>
 
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Advertising</legend>
-  <div class="bx--form-item">
-    <label for="spend" class="bx--label">Ad Spend</label>
-    <input type="number" id="spend" value="1000" step="0.01" class="bx--text-input" />
-    <small>Total advertising budget for the scenario.</small>
-  </div>
-  <div class="bx--form-item">
-    <label for="cpc" class="bx--label">CPC</label>
-    <input type="number" id="cpc" value="1" step="0.01" class="bx--text-input" />
-    <small>Cost per click used to estimate traffic from spend.</small>
-  </div>
-  <div class="bx--form-item">
-    <label for="ctr" class="bx--label">CTR (%)</label>
-    <input type="number" id="ctr" value="2" step="0.01" class="bx--text-input" />
-    <small>Percent of clicks that turn into leads.</small>
-  </div>
-  <div class="bx--form-item">
-    <label for="cvr" class="bx--label">CVR (%)</label>
-    <input type="number" id="cvr" value="2" step="0.01" class="bx--text-input" />
-    <small>Conversion rate from lead to customer.</small>
-  </div>
-</fieldset>
-
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Subscription</legend>
-  <div class="bx--form-item">
-    <input type="checkbox" id="subscription" class="bx--checkbox" />
-    <label for="subscription" class="bx--checkbox-label">Enable subscription revenue</label>
-    <small>Include subscription revenue in lifetime value.</small>
-  </div>
-  <div id="subscription-fields" class="sub-fields" style="display:none">
-    <div class="bx--form-item">
-      <label for="sub-price" class="bx--label">Monthly Price</label>
-      <input type="number" id="sub-price" value="30" step="0.01" class="bx--text-input" />
-      <small>Recurring subscription fee per month.</small>
+        <div class="bx--row">
+          <div class="bx--col-lg-6">
+            <fieldset class="bx--fieldset bx--tile">
+              <legend class="bx--label">Costs</legend>
+              <div class="bx--form-item">
+                <label for="team" class="bx--label">Team Costs</label>
+                <input type="number" id="team" value="0" step="0.01" class="bx--text-input" />
+                <small>Fixed team costs included in profit calculations.</small>
+              </div>
+              <div class="bx--form-item">
+                <label for="tools" class="bx--label">Tools Cost</label>
+                <input type="number" id="tools" value="0" step="0.01" class="bx--text-input" />
+                <small>Ongoing tool expenses included in profit.</small>
+              </div>
+              <div class="bx--form-item">
+                <label for="fulfill" class="bx--label">Fulfillment Cost</label>
+                <input type="number" id="fulfill" value="0" step="0.01" class="bx--text-input" />
+                <small>Other fulfillment costs factored into profit.</small>
+              </div>
+            </fieldset>
+          </div>
+          <div class="bx--col-lg-6 bx--form-item">
+            <button type="submit" class="bx--btn bx--btn--primary">Calculate</button>
+            <button id="export" type="button" class="bx--btn">Download CSV</button>
+          </div>
+        </div>
+      </form>
+      <div id="roas-results"></div>
+      <svg id="roas-chart" width="600" height="300"></svg>
     </div>
-    <div class="bx--form-item">
-      <label for="sub-life" class="bx--label">Lifetime (mo)</label>
-      <input type="number" id="sub-life" value="6" step="1" class="bx--text-input" />
-      <small>Expected months a subscriber remains active.</small>
-    </div>
   </div>
-</fieldset>
-
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Services</legend>
-  <div class="bx--form-item">
-    <input type="checkbox" id="service" class="bx--checkbox" />
-    <label for="service" class="bx--checkbox-label">Enable services</label>
-    <small>Enable if you sell services that close after a lead.</small>
-  </div>
-  <div id="service-fields" class="svc-fields" style="display:none">
-    <div class="bx--form-item">
-      <label for="svc-price" class="bx--label">Booking Price</label>
-      <input type="number" id="svc-price" value="300" step="0.01" class="bx--text-input" />
-      <small>Revenue from an initial service booking.</small>
-    </div>
-    <div class="bx--form-item">
-      <label for="svc-len" class="bx--label">Contract Len (mo)</label>
-      <input type="number" id="svc-len" value="1" step="1" class="bx--text-input" />
-      <small>Contract length in months.</small>
-    </div>
-    <div class="bx--form-item">
-      <label for="l2c" class="bx--label">Lead→Close (%)</label>
-      <input type="number" id="l2c" value="30" step="0.1" class="bx--text-input" />
-      <small>Percent of leads that become clients.</small>
-    </div>
-  </div>
-</fieldset>
-
-<fieldset class="bx--fieldset">
-  <legend class="bx--label">Costs</legend>
-  <div class="bx--form-item">
-    <label for="team" class="bx--label">Team Costs</label>
-    <input type="number" id="team" value="0" step="0.01" class="bx--text-input" />
-    <small>Fixed team costs included in profit calculations.</small>
-  </div>
-  <div class="bx--form-item">
-    <label for="tools" class="bx--label">Tools Cost</label>
-    <input type="number" id="tools" value="0" step="0.01" class="bx--text-input" />
-    <small>Ongoing tool expenses included in profit.</small>
-  </div>
-  <div class="bx--form-item">
-    <label for="fulfill" class="bx--label">Fulfillment Cost</label>
-    <input type="number" id="fulfill" value="0" step="0.01" class="bx--text-input" />
-    <small>Other fulfillment costs factored into profit.</small>
-  </div>
-</fieldset>
-
-<button type="submit" class="bx--btn bx--btn--primary">Calculate</button>
-<button id="export" type="button" class="bx--btn">Download CSV</button>
-</form>
-<div id="roas-results"></div>
-<svg id="roas-chart" width="600" height="300"></svg>
 </div>
 
 


### PR DESCRIPTION
## Summary
- apply Carbon grid layout to ROAS calculator
- group input sections in tiles
- keep existing calculator logic

## Testing
- `npm run build`