### PR TITLE
Fix blog navigation and card layout

### DIFF
--- a/src/components/BlogCarousel.astro
+++ b/src/components/BlogCarousel.astro
@@ -4,7 +4,7 @@ const { posts = [] } = Astro.props;
 <div class="blog-carousel" data-carousel>
   {posts.map((post, idx) => (
     <div class="carousel-slide" data-index={idx} hidden={idx !== 0}>
-      <h2 class="carousel-title"><a href={post.url}>{post.data.title}</a></h2>
+      <h2 class="carousel-title"><a href={`/blog/${post.slug}`}>{post.data.title}</a></h2>
       {post.data.description && <p class="carousel-desc">{post.data.description}</p>}
     </div>
   ))}

--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -1,20 +1,24 @@
 ---
 const { post } = Astro.props;
+const url = `/blog/${post.slug}`;
 ---
-<article class="blog-card" data-tags={(post.data.tags || []).join(' ')} onclick={`if(!event.target.closest('a')){window.location='${post.url}'}` }>
+<article class="bx--tile bx--tile--clickable blog-card" data-tags={(post.data.tags || []).join(' ')} onclick={`if(!event.target.closest('a')){window.location='${url}'}` }>
 
-  <h2 class="blog-card-title"><a href={post.url}>{post.data.title}</a></h2>
+  <h2 class="blog-card-title"><a href={url}>{post.data.title}</a></h2>
 
   {post.data.pubDate && <p class="blog-card-date">{post.data.pubDate.toLocaleDateString()}</p>}
   {post.data.description && <p class="blog-card-desc">{post.data.description}</p>}
   {post.data.tags?.length ? (
-    <p class="blog-card-tags">{post.data.tags.map(t => <a href={`/blog/tags/${t}/`}>{t}</a>).join(', ')}</p>
+    <p class="blog-card-tags">{post.data.tags.map(t => <a href={`/blog/tags/${t}`}>{t}</a>).join(', ')}</p>
   ) : null}
 </article>
 <style>
 .blog-card {
   margin-bottom: 2rem;
   cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 .blog-card-title { margin: 0 0 0.25rem; }
 .blog-card-date { margin: 0 0 0.5rem; color: #6f6f6f; }

--- a/src/components/CustomFooter.astro
+++ b/src/components/CustomFooter.astro
@@ -6,10 +6,10 @@ const year = new Date().getFullYear();
   <div class="bx--footer__row footer-content">
     <p class="copy">© {year} Blue Frog Analytics</p>
     <nav class="bx--footer-nav footer-nav">
-      <a href="/about/">About</a>
-      <a href="/privacy-policy/">Privacy Policy</a>
-      <a href="/terms-of-service/">Terms of Service</a>
-      <a href="/community/contact/">Contact</a>
+      <a href="/about">About</a>
+      <a href="/privacy-policy">Privacy Policy</a>
+      <a href="/terms-of-service">Terms of Service</a>
+      <a href="/community/contact">Contact</a>
     </nav>
     <!-- Social icons removed -->
   </div>

--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -2,10 +2,10 @@
 // Carbon global header with responsive side navigation
 const mainNav = [
   { label: 'Home', link: '/' },
-  { label: 'About', link: '/about/' },
-  { label: 'Services', link: '/services/' },
-  { label: 'Tests', link: '/testing/' },
-  { label: 'Blog', link: '/blog/' },
+  { label: 'About', link: '/about' },
+  { label: 'Services', link: '/services' },
+  { label: 'Tests', link: '/testing' },
+  { label: 'Blog', link: '/blog' },
   { label: 'Docs', link: '/introduction/how-blue-frog-analytics-works' },
 ];
 ---

--- a/src/components/FeaturedHero.astro
+++ b/src/components/FeaturedHero.astro
@@ -27,17 +27,20 @@ const [first, second, third] = posts;
 <style>
 .featured-main .blog-card {
   height: 100%;
-
   min-height: 12rem;
+  display: flex;
+  flex-direction: column;
 }
 .small-card .blog-card {
   margin-bottom: 1rem;
   min-height: 12rem;
+  display: flex;
+  flex-direction: column;
 }
 .featured-hero .blog-card {
   height: 100%;
   display: flex;
   flex-direction: column;
-
+  justify-content: space-between;
 }
 </style>

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -5,7 +5,7 @@ const { posts = [] } = Astro.props;
   <h3>Recent Posts</h3>
   <ul class="recent-posts-list">
     {posts.map(p => (
-      <li><a href={p.url}>{p.data.title}</a></li>
+      <li><a href={`/blog/${p.slug}`}>{p.data.title}</a></li>
     ))}
   </ul>
 </aside>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -20,7 +20,7 @@ const { Content } = await post.render();
     {post.data.pubDate && <p>{post.data.pubDate.toLocaleDateString()}</p>}
     <Content />
     {post.data.tags?.length ? (
-      <p>Tags: {post.data.tags.map(t => <a href={`/blog/tags/${t}/`}>{t}</a>).join(', ')}</p>
+      <p>Tags: {post.data.tags.map(t => <a href={`/blog/tags/${t}`}>{t}</a>).join(', ')}</p>
     ) : null}
   </article>
 </BlogLayout>

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -14,7 +14,7 @@ for (const post of posts) {
   <h1>Tags</h1>
   <ul>
     {Array.from(tagMap.entries()).map(([tag, count]) => (
-      <li key={tag}><a href={`/blog/tags/${tag}/`}>{tag} ({count})</a></li>
+      <li key={tag}><a href={`/blog/tags/${tag}`}>{tag} ({count})</a></li>
     ))}
   </ul>
 </BlogLayout>


### PR DESCRIPTION
## Summary
- fix navigation links to avoid trailing slashes
- fix blog article links and tags
- keep featured article cards aligned using Carbon tile classes

## Testing
- `npm run build`