### PR TITLE
Performance cleanup

### DIFF
--- a/public/js/ascii-loader.js
+++ b/public/js/ascii-loader.js
@@ -1,0 +1,6 @@
+window.addEventListener('load', () => {
+  const s = document.createElement('script');
+  s.type = 'module';
+  s.src = '/js/ascii-hero.js';
+  document.body.appendChild(s);
+});

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -14,13 +14,13 @@ import '../styles/global.scss';
 <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
 <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" /></noscript>
 
-<!-- Carbon JS (for interactive components) -->
-<script src="https://unpkg.com/carbon-components/scripts/carbon-components.min.js" defer></script>
+<!-- Carbon JS (load after page to avoid blocking) -->
 <script>
-  window.addEventListener("load", () => {
-    if (window.CarbonComponents) {
-      window.CarbonComponents.watch();
-    }
+  window.addEventListener('load', () => {
+    const s = document.createElement('script');
+    s.src = 'https://unpkg.com/carbon-components/scripts/carbon-components.min.js';
+    s.onload = () => { window.CarbonComponents?.watch(); };
+    document.body.appendChild(s);
   });
 </script>
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -143,4 +143,4 @@ template: splash
   </div>
 </section>
 
-<script type="module" src="/js/ascii-hero.js" defer></script>
+<script src="/js/ascii-loader.js" defer></script>

--- a/src/pages/carbon-components/index.astro
+++ b/src/pages/carbon-components/index.astro
@@ -13,14 +13,12 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" onload="this.onload=null;this.rel='stylesheet'" />
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" /></noscript>
-    <link rel="preload" as="style" href="/css/carbon.css" onload="this.onload=null;this.rel='stylesheet'" />
-    <noscript><link rel="stylesheet" href="/css/carbon.css" /></noscript>
-    <script src="https://unpkg.com/carbon-components/scripts/carbon-components.min.js" defer></script>
     <script>
       window.addEventListener('load', () => {
-        if (window.CarbonComponents) {
-          window.CarbonComponents.watch();
-        }
+        const s = document.createElement('script');
+        s.src = 'https://unpkg.com/carbon-components/scripts/carbon-components.min.js';
+        s.onload = () => { window.CarbonComponents?.watch(); };
+        document.body.appendChild(s);
       });
     </script>
   </head>


### PR DESCRIPTION
## Summary
- defer Carbon Components JS until after load
- load ASCII hero script via loader file
- remove unused Carbon CSS link from components sample page

## Testing
- `npm run build`