### PR TITLE
Improve docs sidebar and HR styling

### DIFF
--- a/src/components/DocsLayout.astro
+++ b/src/components/DocsLayout.astro
@@ -75,9 +75,11 @@ const docTree = buildTree();
       </main>
       <aside class="sidebar-right">
         <nav>
-          <ul>
+          <ul class="bx--tree-view">
             {headings?.map(h => (
-              <li><a href={`#${h.slug}`}>{h.text}</a></li>
+              <li class="bx--tree-view__node" data-depth={h.depth}>
+                <a href={`#${h.slug}`}>{h.text}</a>
+              </li>
             ))}
           </ul>
         </nav>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -25,6 +25,13 @@ body {
   padding-right: 3rem;
 }
 
+/* Consistent horizontal rule styling */
+hr {
+  border: none;
+  border-top: 1px solid #e0e0e0;
+  margin: 2rem 0;
+}
+
 @media (max-width: 767px) {
   body {
     padding-left: 1rem;
@@ -72,6 +79,20 @@ body {
   border-left: 1px solid #e0e0e0;
   padding-left: 1rem;
 }
+// Right sidebar article headings
+.sidebar-right ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.sidebar-right li {
+  margin: 0.25rem 0;
+}
+.sidebar-right li[data-depth='3'] { margin-left: 1rem; }
+.sidebar-right li[data-depth='4'] { margin-left: 2rem; }
+.sidebar-right li[data-depth='5'] { margin-left: 3rem; }
+.sidebar-right li[data-depth='6'] { margin-left: 4rem; }
 // Search input in sidebars
 .sidebar-left input[type="search"] {
   width: 100%;


### PR DESCRIPTION
## Summary
- style `<hr>` to match Carbon
- add indentation and spacing for right sidebar headings
- use Carbon tree view classes in DocsLayout

## Testing
- `npm run build`
