### PR TITLE
Implement glossary autolink plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import remarkMermaid from 'remark-mermaidjs'
 import mdx from '@astrojs/mdx';
+import remarkGlossaryLinks from './src/plugins/remark-glossary-links.js';
 // Removed expressive-code integration to drop starlight deps
 
 const DOCS_DIR = 'src/content/docs';
@@ -98,7 +99,7 @@ export default defineConfig({
     // MDX for .md/.mdx with math
     mdx({
       extension: ['.md', '.mdx'],
-      remarkPlugins: [remarkMath, remarkMermaid],
+      remarkPlugins: [remarkMath, remarkMermaid, remarkGlossaryLinks],
       rehypePlugins: [rehypeKatex],
     }),
     // Sitemap generation

--- a/src/plugins/remark-glossary-links.js
+++ b/src/plugins/remark-glossary-links.js
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+import {unified} from 'unified';
+import remarkParse from 'remark-parse';
+import {visit} from 'unist-util-visit';
+import GithubSlugger from 'github-slugger';
+import {findAndReplace} from 'mdast-util-find-and-replace';
+
+const glossaryPath = path.resolve('src/content/docs/Introduction/Terminology-Glossary.md');
+let termMap = {};
+
+function loadGlossary() {
+  if (termMap.__loaded) return termMap;
+  const content = fs.readFileSync(glossaryPath, 'utf8');
+  const tree = unified().use(remarkParse).parse(content);
+  const slugger = new GithubSlugger();
+  termMap = {};
+  visit(tree, 'heading', (node) => {
+    if (node.depth === 3) {
+      const text = node.children.map((c) => c.value || '').join('').trim();
+      if (text) {
+        const slug = slugger.slug(text);
+        termMap[text] = slug;
+      }
+    }
+  });
+  termMap.__loaded = true;
+  return termMap;
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export default function remarkGlossaryLinks() {
+  const terms = loadGlossary();
+  const replacements = Object.entries(terms).map(([term, slug]) => [
+    new RegExp(`\\b${escapeRegExp(term)}\\b`, 'gi'),
+    (match) => ({
+      type: 'link',
+      url: `/introduction/terminology-glossary#${slug}`,
+      children: [{type: 'text', value: match}],
+    }),
+  ]);
+  return (tree) => {
+    findAndReplace(tree, replacements, {ignore: ['link', 'heading', 'code', 'inlineCode']});
+  };
+}


### PR DESCRIPTION
## Summary
- auto-detect glossary headings and convert matching terms to links
- wire the plugin into Astro's MDX config

## Testing
- `npm run build`