### PR TITLE
Remove leftover Starlight mentions

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -1,4 +1,4 @@
-name: Deploy Starlight to GitHub Pages
+name: Deploy Documentation to GitHub Pages
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blue Frog Analytics Docs
 
-This repository hosts the documentation site for **Blue Frog Analytics**. It uses [Astro](https://astro.build) with Starlight for documentation features and is styled with IBM's [Carbon Design System](https://carbondesignsystem.com).
+This repository hosts the documentation site for **Blue Frog Analytics**. It is built with [Astro](https://astro.build) and styled using IBM's [Carbon Design System](https://carbondesignsystem.com).
 
 ## Getting Started
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ import rehypeKatex from 'rehype-katex';
 import remarkMermaid from 'remark-mermaidjs'
 import mdx from '@astrojs/mdx';
 import remarkGlossaryLinks from './src/plugins/remark-glossary-links.js';
-// Removed expressive-code integration to drop starlight deps
+// Removed expressive-code integration to simplify dependencies
 
 const DOCS_DIR = 'src/content/docs';
 const isDev = process.env.NODE_ENV === 'development';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "starlight",
+  "name": "bluefrog-docs",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "starlight",
+      "name": "bluefrog-docs",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/sitemap": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "starlight",
+  "name": "bluefrog-docs",
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Blue Frog Analytics Docs
 
-This repository hosts the documentation site for **Blue Frog Analytics**. It uses [Astro](https://astro.build) with Starlight for documentation features and is styled with IBM's [Carbon Design System](https://carbondesignsystem.com).
+This repository hosts the documentation site for **Blue Frog Analytics**. It is built with [Astro](https://astro.build) and styled using IBM's [Carbon Design System](https://carbondesignsystem.com).
 
 ## Getting Started
 

--- a/src/components/CustomFooter.astro
+++ b/src/components/CustomFooter.astro
@@ -1,5 +1,5 @@
 ---
-// Simplified footer without Starlight dependencies
+// Simplified footer using only Carbon styles
 const year = new Date().getFullYear();
 ---
 <footer class="bx--footer footer">

--- a/src/content/docs/guides/getting-started.md
+++ b/src/content/docs/guides/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Example Guide
-description: A guide in my new Starlight docs site.
+description: A guide in the Blue Frog Analytics documentation site.
 ---
 
 Guides lead a user through a specific task they want to accomplish, often with a sequence of steps.


### PR DESCRIPTION
## Summary
- update docs to drop Starlight references
- rename npm package to `bluefrog-docs`
- tweak CustomFooter and Astro config comments
- adjust GitHub workflow name

## Testing
- `npm run build`