### PR TITLE
Refine Carbon page layout

### DIFF
--- a/src/components/BlogLayout.astro
+++ b/src/components/BlogLayout.astro
@@ -9,7 +9,7 @@ import CustomFooter from './CustomFooter.astro';
   </head>
   <body>
     <CustomHeader />
-    <main id="main-content">
+    <main id="main-content" class="bx--content">
       <slot />
     </main>
     <CustomFooter />

--- a/src/components/DocLayout.astro
+++ b/src/components/DocLayout.astro
@@ -10,7 +10,7 @@ import CustomFooter from './CustomFooter.astro';
   </head>
   <body>
     <CustomHeader />
-    <main id="main-content">
+    <main id="main-content" class="bx--content">
       <slot />
     </main>
     <CustomFooter />

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -7,7 +7,7 @@ template: splash
 
 
 {/* Hero Section */}
-<div className="bx--grid bx--theme--white">
+<section className="carbon-container bx--grid bx--theme--white">
   <div className="bx--row">
     <div className="bx--col-lg-8 bx--offset-lg-2 bx--text-center">
       <h1 className="bx--type-expressive-heading-05">Precision analytics for the modern web.</h1>
@@ -20,10 +20,10 @@ template: splash
       </div>
     </div>
   </div>
-</div>
+</section>
 
 {/* Mission Overview */}
-<section className="bx--grid bx--theme--g10">
+<section className="carbon-container bx--grid bx--theme--g10">
   <div className="bx--row">
     <div className="bx--col-lg-12 bx--text-center">
       <h2 className="bx--type-expressive-heading-04">Mission Overview</h2>
@@ -53,7 +53,7 @@ template: splash
 </section>
 
 {/* Launch Sequence */}
-<section className="bx--grid bx--theme--g10">
+<section className="carbon-container bx--grid bx--theme--g10">
   <div className="bx--row">
     <div className="bx--col-lg-12 bx--text-center">
       <h2 className="bx--type-expressive-heading-04">Launch Sequence</h2>
@@ -83,7 +83,7 @@ template: splash
 </section>
 
 {/* Why Choose Blue Frog */}
-<section className="bx--grid bx--theme--white">
+<section className="carbon-container bx--grid bx--theme--white">
   <div className="bx--row">
     <div className="bx--col-lg-12 bx--text-center">
       <h2 className="bx--type-expressive-heading-04">Why Choose Blue Frog Analytics?</h2>
@@ -109,7 +109,7 @@ template: splash
 </section>
 
 {/* Use Cases */}
-<section className="bx--grid bx--theme--g10">
+<section className="carbon-container bx--grid bx--theme--g10">
   <div className="bx--row">
     <div className="bx--col-lg-12 bx--text-center">
       <h2 className="bx--type-expressive-heading-04">Use Cases & Workflows</h2>
@@ -132,7 +132,7 @@ template: splash
 </section>
 
 {/* Call to Action */}
-<section className="bx--grid bx--theme--white">
+<section className="carbon-container bx--grid bx--theme--white">
   <div className="bx--row">
     <div className="bx--col-lg-8 bx--offset-lg-2 bx--text-center">
         <h2 className="bx--type-expressive-heading-04">Ready to launch your mission?</h2>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -14,11 +14,11 @@ const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
 ---
 <BlogLayout>
   <div class="blog-page">
-    <section class="blog-hero bx--grid">
+    <section class="blog-hero carbon-container bx--grid">
       <FeaturedHero posts={featured} />
     </section>
 
-    <section class="blog-search bx--grid">
+    <section class="blog-search carbon-container bx--grid">
 
       <div class="search-row bx--row">
 
@@ -36,7 +36,7 @@ const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
       </div>
     </section>
 
-    <section class="blog-posts bx--grid">
+    <section class="blog-posts carbon-container bx--grid">
       <div class="bx--row">
         <div class="bx--col-sm-8 bx--col-md-8 bx--col-lg-12">
           <div class="bx--row" id="posts-list">
@@ -54,7 +54,6 @@ const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
     </section>
     <script src="/js/blog-search.js" defer></script>
     <style>
-      #main-content > .blog-page { max-width: none; padding: 0; }
       .blog-hero { margin-bottom: 1rem; }
       .blog-search { margin-bottom: 2rem; }
       .search-row { display: flex; flex-wrap: wrap; align-items: center; }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -7,7 +7,8 @@
   --sl-color-accent: #{colors.$blue-60};
   --sl-border-radius: 0;
   --cds-text: #161616;
-  --cds--ui-shell--header-height: 100px;
+  /* Use Carbon default header height */
+  --cds--ui-shell--header-height: 3rem;
   --cds-background: #f0f0f0;
 }
 
@@ -18,11 +19,9 @@ body {
   color: var(--cds-text);
   /* Prevent horizontal scrollbars from full-width sections */
   overflow-x: hidden;
-  /* Offset all pages below the fixed header */
-  padding-top: 7rem;
+  /* Offset pages below the fixed header */
+  padding-top: var(--cds--ui-shell--header-height);
   padding-bottom: 1rem;
-  padding-left: 3rem;
-  padding-right: 3rem;
 }
 
 /* Consistent horizontal rule styling */
@@ -32,12 +31,7 @@ hr {
   margin: 2rem 0;
 }
 
-@media (max-width: 767px) {
-  body {
-    padding-left: 1rem;
-    padding-right: 1rem;
-  }
-}
+
 
 
 
@@ -250,6 +244,12 @@ main#main-content > * {
 .carbon-container:last-child,
 .section:last-child {
   margin-bottom: 0;
+}
+
+/* Space out tiles within standardized sections */
+.carbon-container .bx--tile,
+.section .bx--tile {
+  margin-bottom: 1rem;
 }
 
 .carbon-hero {


### PR DESCRIPTION
## Summary
- add `bx--content` wrapper in Doc and Blog layouts
- use Carbon `carbon-container` sections on home and blog pages
- apply consistent tile spacing in global styles

## Testing
- `npm run build`
