### PR TITLE
Move homepage toward Bootstrap NASA style

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -7,45 +7,47 @@ template: splash
 
 
 {/* Hero Section */}
-<section className="carbon-container bx--grid bx--theme--white">
-  <div className="bx--row">
-    <div className="bx--col-lg-8 bx--offset-lg-2 bx--text-center">
-      <h1 className="bx--type-expressive-heading-05">Precision analytics for the modern web.</h1>
-      <p className="bx--type-body-long-02">
-        Inspired by Carbon’s design principles, Blue Frog Analytics audits and optimizes every metric. Launch with confidence—and keep your site performing at its peak.
+<section className="container py-5 bg-white text-center">
+  <div className="row justify-content-center">
+    <div className="col-lg-8">
+      <h1 className="display-4">Precision analytics for the modern web.</h1>
+      <p className="lead">
+        Inspired by NASA's clean aesthetic, Blue Frog Analytics audits and optimizes every metric. Launch with confidence—and keep your site performing at its peak.
       </p>
-      <div className="bx--btn-set">
-        <a href="/introduction/how-blue-frog-analytics-works" className="bx--btn bx--btn--primary">Get Started</a>
-        <a href="/introduction/use-cases" className="bx--btn bx--btn--secondary">Learn More</a>
+      <div className="d-flex gap-3 justify-content-center">
+        <a href="/introduction/how-blue-frog-analytics-works" className="btn btn-primary">Get Started</a>
+        <a href="/introduction/use-cases" className="btn btn-outline-primary">Learn More</a>
       </div>
     </div>
   </div>
 </section>
 
 {/* Mission Overview */}
-<section className="carbon-container bx--grid bx--theme--g10">
-  <div className="bx--row">
-    <div className="bx--col-lg-12 bx--text-center">
-      <h2 className="bx--type-expressive-heading-04">Mission Overview</h2>
+<section className="container py-5 bg-light">
+  <div className="row text-center mb-4">
+    <div className="col-lg-12">
+      <h2 className="h2">Mission Overview</h2>
     </div>
-    <div className="bx--col-lg-8 bx--offset-lg-2 bx--text-center">
-      <p className="bx--type-body-long-02">
+    <div className="col-lg-8 offset-lg-2">
+      <p>
         Blue Frog Analytics is an <strong>intelligent web auditing platform</strong> designed for teams demanding accuracy. Delivering <strong>precise insights</strong> into tracking, SEO and performance issues before they become critical.
       </p>
     </div>
   </div>
 
-  <div className="bx--row bx--row--condensed">
+  <div className="row text-center gy-4">
     {[
       ['Tracking Validation', 'Ensure accurate GA, Meta and Bing integrations.'],
       ['SEO Enhancements', 'Optimize Core Web Vitals, metadata and structured data.'],
       ['Performance Insights', 'Identify bottlenecks & improve page speeds.'],
       ['Compliance Checks', 'Stay compliant with GDPR, CPRA and WCAG.']
     ].map(([title, desc]) => (
-      <div key={title} className="bx--col-lg-3 bx--col-md-4 bx--col-sm-4">
-        <div className="bx--tile bx--tile--light bx--tile--clickable">
-          <h4 className="bx--type-heading-compact-01">{title}</h4>
-          <p className="bx--type-body-short-01">{desc}</p>
+      <div key={title} className="col-lg-3 col-md-4 col-sm-6">
+        <div className="card h-100 border-0 shadow-sm">
+          <div className="card-body">
+            <h4 className="h5">{title}</h4>
+            <p className="mb-0">{desc}</p>
+          </div>
         </div>
       </div>
     ))}
@@ -53,54 +55,56 @@ template: splash
 </section>
 
 {/* Launch Sequence */}
-<section className="carbon-container bx--grid bx--theme--g10">
-  <div className="bx--row">
-    <div className="bx--col-lg-12 bx--text-center">
-      <h2 className="bx--type-expressive-heading-04">Launch Sequence</h2>
+<section className="container py-5 bg-light">
+  <div className="row text-center mb-4">
+    <div className="col-12">
+      <h2 className="h2">Launch Sequence</h2>
     </div>
   </div>
 
-  <div className="bx--row bx--col-lg-8 bx--offset-lg-2">
-    <ol className="bx--list--ordered bx--list--expressive">
-      <li>
-        <p className="bx--type-heading-compact-01">Scan Your Website</p>
-        <p className="bx--type-body-short-01">Audit your tracking, SEO and performance issues thoroughly.</p>
-      </li>
-      <li>
-        <p className="bx--type-heading-compact-01">Actionable Reports</p>
-        <p className="bx--type-body-short-01">Gain detailed, clear insights to drive decisions.</p>
-      </li>
-      <li>
-        <p className="bx--type-heading-compact-01">Implement Fixes</p>
-        <p className="bx--type-body-short-01">Easy-to-follow, step-by-step optimization guides.</p>
-      </li>
-      <li>
-        <p className="bx--type-heading-compact-01">Monitor & Improve</p>
-        <p className="bx--type-body-short-01">Run scheduled scans ensuring ongoing site health.</p>
-      </li>
-    </ol>
+  <div className="row justify-content-center">
+    <div className="col-lg-8">
+      <ol className="list-group list-group-numbered">
+        <li className="list-group-item">
+          <strong>Scan Your Website</strong>
+          <p className="mb-0">Audit your tracking, SEO and performance issues thoroughly.</p>
+        </li>
+        <li className="list-group-item">
+          <strong>Actionable Reports</strong>
+          <p className="mb-0">Gain detailed, clear insights to drive decisions.</p>
+        </li>
+        <li className="list-group-item">
+          <strong>Implement Fixes</strong>
+          <p className="mb-0">Easy-to-follow, step-by-step optimization guides.</p>
+        </li>
+        <li className="list-group-item">
+          <strong>Monitor &amp; Improve</strong>
+          <p className="mb-0">Run scheduled scans ensuring ongoing site health.</p>
+        </li>
+      </ol>
+    </div>
   </div>
 </section>
 
 {/* Why Choose Blue Frog */}
-<section className="carbon-container bx--grid bx--theme--white">
-  <div className="bx--row">
-    <div className="bx--col-lg-12 bx--text-center">
-      <h2 className="bx--type-expressive-heading-04">Why Choose Blue Frog Analytics?</h2>
+<section className="container py-5 bg-white">
+  <div className="row text-center mb-4">
+    <div className="col-12">
+      <h2 className="h2">Why Choose Blue Frog Analytics?</h2>
     </div>
   </div>
-  <div className="bx--row bx--row--condensed">
+  <div className="row text-center gy-4">
     {[
       ['Data Accuracy', 'No lost pixels or tags.'],
       ['Performance Optimization', 'AI suggestions for speed.'],
       ['SEO & Compliance', 'Reveal compliance gaps.'],
       ['Custom Reporting', 'Seamless integrations.']
     ].map(([title, desc]) => (
-      <div key={title} className="bx--col-lg-3 bx--col-md-4 bx--col-sm-4">
-        <div className="bx--card">
-          <div className="bx--card__content">
-            <h4 className="bx--type-heading-compact-01">{title}</h4>
-            <p className="bx--type-body-short-01">{desc}</p>
+      <div key={title} className="col-lg-3 col-md-4 col-sm-6">
+        <div className="card h-100 border-0">
+          <div className="card-body">
+            <h4 className="h5">{title}</h4>
+            <p className="mb-0">{desc}</p>
           </div>
         </div>
       </div>
@@ -109,22 +113,24 @@ template: splash
 </section>
 
 {/* Use Cases */}
-<section className="carbon-container bx--grid bx--theme--g10">
-  <div className="bx--row">
-    <div className="bx--col-lg-12 bx--text-center">
-      <h2 className="bx--type-expressive-heading-04">Use Cases & Workflows</h2>
+<section className="container py-5 bg-light">
+  <div className="row text-center mb-4">
+    <div className="col-12">
+      <h2 className="h2">Use Cases &amp; Workflows</h2>
     </div>
   </div>
-  <div className="bx--row bx--row--condensed">
+  <div className="row text-center gy-4">
     {[
       ['Developers', 'Debugging & optimization.'],
       ['Marketers', 'Conversions & SEO.'],
       ['Compliance', 'GDPR, CPRA, WCAG audits.']
     ].map(([title, desc]) => (
-      <div key={title} className="bx--col-lg-4 bx--col-md-4 bx--col-sm-4">
-        <div className="bx--tile bx--tile--clickable">
-          <h4 className="bx--type-heading-compact-01">{title}</h4>
-          <p className="bx--type-body-short-01">{desc}</p>
+      <div key={title} className="col-lg-4 col-md-4 col-sm-6">
+        <div className="card h-100 border-0 shadow-sm">
+          <div className="card-body">
+            <h4 className="h5">{title}</h4>
+            <p className="mb-0">{desc}</p>
+          </div>
         </div>
       </div>
     ))}
@@ -132,12 +138,12 @@ template: splash
 </section>
 
 {/* Call to Action */}
-<section className="carbon-container bx--grid bx--theme--white">
-  <div className="bx--row">
-    <div className="bx--col-lg-8 bx--offset-lg-2 bx--text-center">
-        <h2 className="bx--type-expressive-heading-04">Ready to launch your mission?</h2>
-      <p className="bx--type-body-long-02">Start your free audit now and experience Blue Frog Analytics.</p>
-      <a href="/introduction/how-blue-frog-analytics-works" className="bx--btn bx--btn--primary">Launch Audit</a>
+<section className="container py-5 bg-white text-center">
+  <div className="row justify-content-center">
+    <div className="col-lg-8">
+      <h2 className="h2">Ready to launch your mission?</h2>
+      <p>Start your free audit now and experience Blue Frog Analytics.</p>
+      <a href="/introduction/how-blue-frog-analytics-works" className="btn btn-primary">Launch Audit</a>
     </div>
   </div>
 </section>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,11 +1,11 @@
 :root {
-  --sl-font-sans: "IBM Plex Sans", "Helvetica Neue", Arial, sans-serif;
+  --sl-font-sans: "Helvetica Neue", Arial, sans-serif;
   /* Site palette */
-  --sl-color-primary: #0b3d91; /* NASA blue */
-  --sl-color-accent: #4682b4;
+  --sl-color-primary: #305580; /* slate blue */
+  --sl-color-accent: #88a5c9;
   --sl-border-radius: 0;
-  --bs-primary: #0b3d91;
-  --bs-body-bg: #f8f9fa;
+  --bs-primary: #305580;
+  --bs-body-bg: #fcfdff;
   --bs-body-color: #161616;
   --header-height: 3.5rem;
 }
@@ -27,6 +27,12 @@ hr {
   border: none;
   border-top: 1px solid #e0e0e0;
   margin: 2rem 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-weight: 400;
 }
 
 
@@ -332,18 +338,3 @@ main#main-content > * {
   text-decoration: underline;
 }
 
-// Desktop header: add separator between logo and nav
-/* Increase site logo text size globally */
-
-.bx--header__name.site-logo {
-
-  font-size: 130%;
-}
-
-@media (min-width: 768px) {
-  .bx--header__name.site-logo {
-    padding-right: 1rem;
-    margin-right: 1rem;
-    border-right: 1px solid rgba(40, 40, 40, 0.2);
-  }
-}


### PR DESCRIPTION
## Summary
- drop Carbon markup from the docs homepage
- rebuild sections using Bootstrap 5 components
- switch global palette to a blue slate NASA-inspired scheme
- apply uppercase heading styling

## Testing
- `npm run build`