### PR TITLE
Fix primary color to default Bootstrap blue

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,10 +1,11 @@
 :root {
   --sl-font-sans: "Helvetica Neue", Arial, sans-serif;
   /* Site palette */
-  --sl-color-primary: #305580; /* slate blue */
+  /* Use Bootstrap's default blue for primary theme colors */
+  --sl-color-primary: #0d6efd;
   --sl-color-accent: #88a5c9;
   --sl-border-radius: 0;
-  --bs-primary: #305580;
+  --bs-primary: #0d6efd;
   --bs-body-bg: #fcfdff;
   --bs-body-color: #161616;
   --header-height: 3.5rem;


### PR DESCRIPTION
## Summary
- switch primary color variables to Bootstrap's standard blue

## Testing
- `npm run build`