### PR TITLE
Restore ASCII frog hero on landing page

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -7,20 +7,23 @@ template: splash
 
 
 {/* Hero Section */}
-<section className="container py-5 bg-white text-center">
-  <div className="row justify-content-center">
-    <div className="col-lg-8">
+<section className="container-fluid hero-section landing-hero bg-white">
+  <div className="row">
+    <div className="col-lg-8 offset-lg-2 hero-content">
       <h1 className="display-4">Precision analytics for the modern web.</h1>
       <p className="lead">
         Inspired by NASA's clean aesthetic, Blue Frog Analytics audits and optimizes every metric. Launch with confidence—and keep your site performing at its peak.
       </p>
-      <div className="d-flex gap-3 justify-content-center">
+      <div className="d-flex gap-3">
         <a href="/introduction/how-blue-frog-analytics-works" className="btn btn-primary">Get Started</a>
         <a href="/introduction/use-cases" className="btn btn-outline-primary">Learn More</a>
       </div>
     </div>
   </div>
+  <div id="ascii-art" aria-hidden="true"></div>
 </section>
+
+<script type="module" src="/js/ascii-hero.js" defer></script>
 
 {/* Mission Overview */}
 <section className="container py-5 bg-light">

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -123,6 +123,11 @@ h1, h2, h3, h4, h5, h6 {
   background: #ffffff;
 }
 
+// Landing page hero gets extra height
+.landing-hero {
+  min-height: 50vh;
+}
+
 @media (max-width: 767px) {
   .hero-section {
     width: 100%;


### PR DESCRIPTION
## Summary
- reintroduce animated ASCII frog hero on landing
- load ASCII script only on home page
- add `landing-hero` CSS class for expanded hero height

## Testing
- `npm run build`