### PR TITLE
Fix hero section width on services page

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -235,8 +235,8 @@ h1, h2, h3, h4, h5, h6 {
   color: #f5f5f5;
 }
 
-// Global content box: constrain width and center content for all pages
-main#main-content > * {
+// Constrain page sections while allowing full-width hero sections
+main#main-content > :not(.container-fluid) {
   max-width: var(--sl-content-width);
   margin: 0 auto;
   padding-bottom: 1.2rem;


### PR DESCRIPTION
## Summary
- allow `.container-fluid` sections to span full width

## Testing
- `npm run build`