### PR TITLE
Improve docs sidebar tree navigation

### DIFF
--- a/src/components/DocsLayout.astro
+++ b/src/components/DocsLayout.astro
@@ -162,6 +162,13 @@ for (const [file, mod] of Object.entries(blogInfo)) {
         }
       });
 
+      // Toggle folders in the sidebar
+      document.querySelectorAll('.doc-folder > .folder-label').forEach(label => {
+        label.addEventListener('click', () => {
+          label.parentElement.classList.toggle('open');
+        });
+      });
+
       // Keep current page link highlighted and its folder open
       const current = window.location.pathname.replace(/\/$/, '').toLowerCase();
       const link = Array.from(document.querySelectorAll('.sidebar-left a')).find(a => {
@@ -171,11 +178,22 @@ for (const [file, mod] of Object.entries(blogInfo)) {
       });
       if (link) {
         link.classList.add('active');
+
+        let folder = link.closest('.doc-folder');
+        while (folder) {
+          folder.classList.add('open');
+          folder = folder.parentElement.closest('.doc-folder');
+        }
+
         const item = link.closest('.accordion-item');
         if (item) {
-          item.classList.add('show');
+          const collapse = item.querySelector('.accordion-collapse');
+          if (collapse) collapse.classList.add('show');
           const heading = item.querySelector('.accordion-button');
-          if (heading) heading.setAttribute('aria-expanded', 'true');
+          if (heading) {
+            heading.classList.remove('collapsed');
+            heading.setAttribute('aria-expanded', 'true');
+          }
         }
       }
     </script>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -364,6 +364,30 @@ main#main-content > * {
   font-weight: 600;
 }
 
+.doc-folder > .folder-label {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
+.doc-folder > .folder-label::before {
+  content: '▸';
+  margin-right: 4px;
+  transition: transform 0.1s ease-in-out;
+}
+
+.doc-folder.open > .folder-label::before {
+  transform: rotate(90deg);
+}
+
+.doc-folder > ul {
+  display: none;
+}
+
+.doc-folder.open > ul {
+  display: block;
+}
+
 .doc-link-item a {
   display: block;
 }


### PR DESCRIPTION
## Summary
- add collapsible folder UI in sidebar
- highlight current article and keep its folders open automatically

## Testing
- `npm run build`