### PR TITLE
Implement boxed layout with fluid option

### DIFF
--- a/src/components/DocLayout.astro
+++ b/src/components/DocLayout.astro
@@ -3,6 +3,9 @@
 import BaseHead from './BaseHead.astro';
 import CustomHeader from './CustomHeader.astro';
 import CustomFooter from './CustomFooter.astro';
+
+const { fluid = false } = Astro.props;
+const mainClass = fluid ? 'container-fluid' : 'container';
 ---
 <html lang="en">
   <head>
@@ -10,7 +13,7 @@ import CustomFooter from './CustomFooter.astro';
   </head>
   <body>
     <CustomHeader />
-    <main id="main-content" class="bx--content">
+    <main id="main-content" class={`bx--content ${mainClass}`}>
       <slot />
     </main>
     <CustomFooter />

--- a/src/pages/tests/analytics-doctor.astro
+++ b/src/pages/tests/analytics-doctor.astro
@@ -2,7 +2,7 @@
 import DocLayout from '../../components/DocLayout.astro';
 import PageContent from '../../content/pages/Tests/analytics-doctor.mdx';
 ---
-<DocLayout>
+<DocLayout fluid={true}>
   <PageContent />
 </DocLayout>
 


### PR DESCRIPTION
## Summary
- support boxed and full-width layouts in `DocLayout`
- keep Analytics Doctor page full-width

## Testing
- `npm run build`