### PR TITLE
Set navbar background to white

### DIFF
--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -11,7 +11,7 @@ const mainNav = [
 ---
 <!-- Skip link for accessibility -->
 <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
-<nav class="navbar navbar-expand-lg navbar-light bg-transparent fixed-top navbar-charcoal" aria-label="Main navigation">
+<nav class="navbar navbar-expand-lg navbar-light bg-white fixed-top navbar-charcoal" aria-label="Main navigation">
   <div class="container-fluid">
     <button class="navbar-toggler me-2" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
## Summary
- adjust nav to use Bootstrap's `bg-white` class instead of transparent

## Testing
- `npm run build`