### PR TITLE
Improve docs navigation spacing

### DIFF
--- a/src/components/DocsLayout.astro
+++ b/src/components/DocsLayout.astro
@@ -36,6 +36,23 @@ function buildTree() {
 }
 const docTree = buildTree();
 
+// Determine breadcrumb based on current path
+const currentPath = Astro.url.pathname.replace(/\/$/, '').toLowerCase();
+function findPath(nodes, parents = []) {
+  for (const node of nodes) {
+    const nodePath = node.path?.replace(/\/$/, '').toLowerCase();
+    if (nodePath === currentPath) {
+      return [...parents, node];
+    }
+    if (node.children?.length) {
+      const result = findPath(node.children, [...parents, node]);
+      if (result) return result;
+    }
+  }
+  return null;
+}
+const breadcrumbNodes = findPath(docTree) || [];
+
 const searchIndex = [];
 for (const [file, mod] of Object.entries(modules)) {
   const rawKey = file.replace('../content/docs/', '').replace(/\.(md|mdx)$/, '');
@@ -112,6 +129,20 @@ for (const [file, mod] of Object.entries(blogInfo)) {
         </div>
       </aside>
       <main id="main-content" class="docs-main">
+        {breadcrumbNodes.length ? (
+          <nav aria-label="Breadcrumb" class="mb-3">
+            <ol class="breadcrumb">
+              <li class="breadcrumb-item"><a href="/">Home</a></li>
+              {breadcrumbNodes.map((node, idx) => (
+                idx < breadcrumbNodes.length - 1 ? (
+                  <li class="breadcrumb-item" key={idx}><a href={node.path}>{node.label}</a></li>
+                ) : (
+                  <li class="breadcrumb-item active" aria-current="page" key={idx}>{node.label}</li>
+                )
+              ))}
+            </ol>
+          </nav>
+        ) : null}
         <slot />
       </main>
       <aside class="sidebar-right">

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -50,7 +50,7 @@ h1, h2, h3, h4, h5, h6 {
   grid-template-columns: 16rem 1fr 16rem;
   gap: 2rem;
   max-width: var(--sl-content-width);
-  margin: 0 auto;
+  margin: 1rem auto 0;
   padding: 1rem 1rem 2rem;
 }
 
@@ -342,6 +342,8 @@ main#main-content > :not(.container-fluid) {
 .sidebar-left a.active {
   color: var(--sl-color-primary);
   text-decoration: underline;
+  background-color: #e9ecef;
+  font-weight: 600;
 }
 
 // Subtle animation for service cards


### PR DESCRIPTION
## Summary
- add breadcrumb trail for docs pages
- highlight active docs sidebar link
- space docs content below nav bar

## Testing
- `npm run build`