### PR TITLE
Refactor services page for clarity

### DIFF
--- a/src/content/pages/services.mdx
+++ b/src/content/pages/services.mdx
@@ -25,6 +25,15 @@ template: splash
   </div>
 </section>
 
+<section className="container py-4 bg-white">
+  <div className="row">
+    <div className="col-lg-8 offset-lg-2">
+      <h2 className="h2">What We Offer</h2>
+      <p>From one-off audits to ongoing advisory and DIY courses, our services cover every step of digital growth. Mix and match packages or build a custom plan that fits your goals.</p>
+    </div>
+  </div>
+</section>
+
 <section className="container bg-white py-5">
   <div className="row">
     <div className="col-12">
@@ -44,8 +53,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Micro Audit</h3>
-                  <p className="mb-0">2-hour rapid assessment with concise action items and a 30-minute follow-up.<br />
-                  <strong>$300/month</strong> – Team size: 1 advisor – Premium support: 2 weeks – Free updates: One-time.</p>
+                  <p>2-hour rapid assessment with concise action items and a 30-minute follow-up.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$300/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: 2 weeks</li>
+                    <li>Free updates: One-time</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -53,8 +67,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Analytics Health Check</h3>
-                  <p className="mb-0">Quick review of your analytics setup with actionable recommendations and a 1-hour call.<br />
-                  <strong>$500/month</strong> – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.</p>
+                  <p>Quick review of your analytics setup with actionable recommendations and a 1-hour call.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$500/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: 1 month</li>
+                    <li>Free updates: One-time</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -62,8 +81,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Quick Tech &amp; Growth Audit</h3>
-                  <p className="mb-0">8-hour in-depth audit, evaluation report, and a 1-hour follow-up session.<br />
-                  <strong>$1000/month</strong> – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.</p>
+                  <p>8-hour in-depth audit, evaluation report, and a 1-hour follow-up session.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$1000/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: 1 month</li>
+                    <li>Free updates: One-time</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -71,8 +95,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Growth Accelerator Workshop</h3>
-                  <p className="mb-0">Full-day intensive workshop with a custom strategic roadmap and 60-minute follow-up.<br />
-                  <strong>$5000/month</strong> – Team size: 1 advisor – Premium support: 1 month – Free updates: One-time.</p>
+                  <p>Full-day intensive workshop with a custom strategic roadmap and 60-minute follow-up.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$5000/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: 1 month</li>
+                    <li>Free updates: One-time</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -80,8 +109,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Starter Advisory</h3>
-                  <p className="mb-0">4 hours/month with a monthly strategy call and limited email support.<br />
-                  <strong>$1500/month</strong> – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.</p>
+                  <p>4 hours/month with a monthly strategy call and limited email support.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$1500/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: Monthly</li>
+                    <li>Free updates: Monthly</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -89,8 +123,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">SMB Advisory</h3>
-                  <p className="mb-0">8 hours/month, monthly strategy call, priority email &amp; Slack support.<br />
-                  <strong>$3000/month</strong> – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.</p>
+                  <p>8 hours/month with a monthly strategy call plus priority email and Slack support.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$3000/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: Monthly</li>
+                    <li>Free updates: Monthly</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -98,8 +137,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Professional Advisory <span className="badge bg-success">Best Value</span></h3>
-                  <p className="mb-0">20 hours/month with bi-weekly strategy meetings and dedicated Slack/email support plus KPI analysis.<br />
-                  <strong>$7500/month</strong> – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.</p>
+                  <p>20 hours/month with bi-weekly strategy meetings and dedicated Slack/email support plus KPI analysis.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$7500/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: Monthly</li>
+                    <li>Free updates: Monthly</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -107,8 +151,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Premium Advisory</h3>
-                  <p className="mb-0">40 hours/month, weekly sessions, comprehensive dashboards, and on-call support.<br />
-                  <strong>$12000/month</strong> – Team size: 1 advisor – Premium support: Monthly – Free updates: Monthly.</p>
+                  <p>40 hours/month, weekly sessions, comprehensive dashboards, and on-call support.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$12000/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: Monthly</li>
+                    <li>Free updates: Monthly</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -116,8 +165,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Embedded Growth Officer</h3>
-                  <p className="mb-0">2–3 days/week fractional executive presence with tech strategy oversight.<br />
-                  <strong>$20000/month</strong> – Team size: 1 fractional executive – Premium support: Monthly – Free updates: Monthly.</p>
+                  <p>2–3 days/week fractional executive presence with tech strategy oversight.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$20000/month</strong></li>
+                    <li>Team size: 1 fractional executive</li>
+                    <li>Premium support: Monthly</li>
+                    <li>Free updates: Monthly</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -125,8 +179,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Flexible Hours Block</h3>
-                  <p className="mb-0">Prepaid block of 10 hours for strategic support or troubleshooting (valid 3 months).<br />
-                  <strong>$2500/month</strong> – Team size: 1 advisor – Premium support: 3 months – Free updates: One-time.</p>
+                  <p>Prepaid block of 10 hours for strategic support or troubleshooting (valid 3 months).</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$2500/month</strong></li>
+                    <li>Team size: 1 advisor</li>
+                    <li>Premium support: 3 months</li>
+                    <li>Free updates: One-time</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -138,8 +197,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">DIY Growth Toolkit</h3>
-                  <p className="mb-0">Templates, guides, and quarterly educational webinars with lifetime access.<br />
-                  <strong>$500/month</strong> – Team size: Unlimited access – Premium support: Lifetime – Free updates: Quarterly.</p>
+                  <p>Templates, guides, and quarterly educational webinars with lifetime access.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$500/month</strong></li>
+                    <li>Team size: Unlimited access</li>
+                    <li>Premium support: Lifetime</li>
+                    <li>Free updates: Quarterly</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -147,8 +211,13 @@ template: splash
               <div className="card h-100">
                 <div className="card-body">
                   <h3 className="h5">Analytics Mastery Course</h3>
-                  <p className="mb-0">Complete self-paced analytics training with lifetime updates and monthly live Q&amp;A sessions.<br />
-                  <strong>$1000/month</strong> – Team size: Unlimited access – Premium support: Lifetime – Free updates: Monthly.</p>
+                  <p>Complete self-paced analytics training with lifetime updates and monthly live Q&amp;A sessions.</p>
+                  <ul className="list-unstyled small mb-0">
+                    <li><strong>$1000/month</strong></li>
+                    <li>Team size: Unlimited access</li>
+                    <li>Premium support: Lifetime</li>
+                    <li>Free updates: Monthly</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -281,10 +350,17 @@ template: splash
           </div>
         </div>
       </div>
+      <h2 className="h2 mt-4">Our Approach</h2>
       <ol className="list-group list-group-numbered my-4">
-        <li className="list-group-item">Discovery</li>
-        <li className="list-group-item">Implementation</li>
-        <li className="list-group-item">Growth</li>
+        <li className="list-group-item">
+          <strong>Discovery:</strong> We evaluate your current setup and goals.
+        </li>
+        <li className="list-group-item">
+          <strong>Implementation:</strong> Integrate the right tools and build out the solution.
+        </li>
+        <li className="list-group-item">
+          <strong>Growth:</strong> Continuous optimization and insight-driven experiments.
+        </li>
       </ol>
       <div className="text-center">
         <button className="btn btn-primary" data-bs-toggle="modal" data-bs-target="#blueprintModal">Claim Your Complimentary Growth Blueprint</button>


### PR DESCRIPTION
## Summary
- add "What We Offer" intro section
- reformat service package cards with bullet list details
- clarify engagement steps with new "Our Approach" section

## Testing
- `npm run build`