### PR TITLE
Fix active navbar highlighting

### DIFF
--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -14,7 +14,7 @@ const currentPath =
     ? '/'
     : Astro.url.pathname.replace(/\/$/, '').toLowerCase();
 function isActive(item) {
-  const link = item.link.replace(/\/$/, '').toLowerCase();
+  const link = item.link === '/' ? '/' : item.link.replace(/\/$/, '').toLowerCase();
 
   if (item.label === 'Docs') return isDocs;
   if (item.label === 'Tests') {


### PR DESCRIPTION
## Summary
- avoid removing trailing slash from root URL in `isActive`

## Testing
- `npm run build`
