### PR TITLE
Fix mobile navbar alignment

### DIFF
--- a/src/components/CustomHeader.astro
+++ b/src/components/CustomHeader.astro
@@ -29,13 +29,13 @@ function isActive(item) {
 <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
 <nav class="navbar navbar-expand-lg navbar-light bg-white fixed-top navbar-charcoal" aria-label="Main navigation">
   <div class="container-fluid">
-    <button class="navbar-toggler me-2" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
     <a class="navbar-brand site-logo" href="/">
       <span class="site-logo-prefix">BlueFrog</span><span class="site-logo-analytics">Analytics</span>
     </a>
     <span class="nav-separator mx-2 d-none d-lg-inline">|</span>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
     <div class="collapse navbar-collapse" id="mainNav">
       <ul class="navbar-nav mb-2 mb-lg-0">
         {mainNav.map(item => (


### PR DESCRIPTION
## Summary
- keep site logo left-aligned on mobile/tablet navbars by moving it before the hamburger menu

## Testing
- `npm run build`
