### PR TITLE
Fix sidebar highlight logic

### DIFF
--- a/src/components/DocsLayout.astro
+++ b/src/components/DocsLayout.astro
@@ -95,7 +95,7 @@ for (const [file, mod] of Object.entries(blogInfo)) {
                   return (
                     <li class="doc-folder list-group-item">
                       <span class="folder-label">{node.label}</span>
-                      <ul class="list-group list-group-flush ms-2">
+                      <ul class="list-group list-group-flush">
                         {renderNodes(node.children)}
                       </ul>
                     </li>
@@ -203,11 +203,15 @@ for (const [file, mod] of Object.entries(blogInfo)) {
         });
 
       // Keep current page link highlighted and its folder open
-        const current = window.location.pathname.replace(/\/$/, '').toLowerCase();
+        const normalizePath = (p) => {
+          const url = new URL(p, window.location.origin);
+          return url.pathname.toLowerCase().replace(/\/?(index\.html)?$/, '');
+        };
+        const current = normalizePath(window.location.pathname);
         const link = Array.from(document.querySelectorAll('.sidebar-left a')).find(a => {
           const href = a.getAttribute('href');
           if (!href) return false;
-          return href.replace(/\/$/, '').toLowerCase() === current;
+          return normalizePath(href) === current;
         });
         if (link) {
           link.classList.add('active');

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -384,7 +384,7 @@ main#main-content > :not(.container-fluid) {
 
 .doc-folder > ul {
   display: none;
-  margin-left: 1rem;
+  margin-left: 1rem !important;
   padding-left: 0;
 }
 
@@ -397,6 +397,6 @@ main#main-content > :not(.container-fluid) {
 }
 
 .doc-link-item {
-  margin-left: 0.5rem;
+  margin-left: 0.5rem !important;
 }
 


### PR DESCRIPTION
## Summary
- remove extra left margin class from docs sidebar
- ensure docs sidebar indentation overrides Bootstrap
- highlight current docs article reliably using URL normalization

## Testing
- `npm run build`
