### PR TITLE
Improve sidebar highlighting

### DIFF
--- a/src/components/DocsLayout.astro
+++ b/src/components/DocsLayout.astro
@@ -95,7 +95,7 @@ for (const [file, mod] of Object.entries(blogInfo)) {
                   return (
                     <li class="doc-folder list-group-item">
                       <span class="folder-label">{node.label}</span>
-                      <ul class="list-group list-group-flush ms-2">
+                      <ul class="list-group list-group-flush">
                         {renderNodes(node.children)}
                       </ul>
                     </li>
@@ -203,14 +203,15 @@ for (const [file, mod] of Object.entries(blogInfo)) {
         });
 
       // Keep current page link highlighted and its folder open
-        const current = window.location.pathname.replace(/\/$/, '').toLowerCase();
+        const normalizePath = (p) => p.toLowerCase().replace(/\/?(index\.html)?$/, '');
+        const current = normalizePath(window.location.pathname);
         const link = Array.from(document.querySelectorAll('.sidebar-left a')).find(a => {
           const href = a.getAttribute('href');
           if (!href) return false;
-          return href.replace(/\/$/, '').toLowerCase() === current;
+          return normalizePath(href) === current;
         });
         if (link) {
-          link.classList.add('active');
+          link.classList.add('doc-active');
 
           let folder = link.closest('.doc-folder');
           while (folder) {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -339,7 +339,7 @@ main#main-content > :not(.container-fluid) {
 }
 
 // Docs sidebar: highlight active article link
-.sidebar-left a.active {
+.sidebar-left a.doc-active {
   color: var(--sl-color-primary);
   text-decoration: underline;
   background-color: #e9ecef;
@@ -384,7 +384,7 @@ main#main-content > :not(.container-fluid) {
 
 .doc-folder > ul {
   display: none;
-  margin-left: 1rem;
+  margin-left: 1rem !important;
   padding-left: 0;
 }
 


### PR DESCRIPTION
## Summary
- fix sidebar highlight logic in DocsLayout to handle index.html paths
- use a distinct `doc-active` class and ensure nested docs are indented

## Testing
- `npm run build`
