### PR TITLE
Fix recursive accordion in docs nav

### DIFF
--- a/src/components/DocsLayout.astro
+++ b/src/components/DocsLayout.astro
@@ -91,15 +91,15 @@ for (const [file, mod] of Object.entries(blogInfo)) {
             function renderNodes(nodes, activeNames) {
               return nodes.map(node => {
                 if (node.children?.length) {
-                  const open = activeNames.includes(node.name) ? ' open' : '';
+                  const isOpen = activeNames.includes(node.name);
                   return (
-                    <li class={`doc-folder list-group-item${open}`}>
-                      <span class="folder-label">{node.label}</span>
-
-                      <ul class="list-group list-group-flush ms-2">
-                        {renderNodes(node.children, activeNames)}
-
-                      </ul>
+                    <li class="list-group-item p-0">
+                      <details class="doc-folder" open={isOpen}>
+                        <summary class="folder-label">{node.label}</summary>
+                        <ul class="list-group list-group-flush ms-2">
+                          {renderNodes(node.children, activeNames)}
+                        </ul>
+                      </details>
                     </li>
                   );
                 }
@@ -107,7 +107,6 @@ for (const [file, mod] of Object.entries(blogInfo)) {
                 return (
                   <li class="doc-link-item list-group-item">
                     <a class={`text-decoration-none${isActive ? ' doc-active' : ''}`} href={node.path}>{node.label}</a>
-
                   </li>
                 );
               });
@@ -202,12 +201,7 @@ for (const [file, mod] of Object.entries(blogInfo)) {
         }
       });
 
-      // Toggle folders in the sidebar
-        document.querySelectorAll('.doc-folder > .folder-label').forEach(label => {
-          label.addEventListener('click', () => {
-            label.parentElement.classList.toggle('open');
-          });
-        });
+      // No manual toggle needed - <details> handles open state
 
 
       // Keep current page link highlighted and its folder open
@@ -221,10 +215,10 @@ for (const [file, mod] of Object.entries(blogInfo)) {
         if (link) {
           link.classList.add('doc-active');
 
-          let folder = link.closest('.doc-folder');
+          let folder = link.closest('details.doc-folder');
           while (folder) {
-            folder.classList.add('open');
-            folder = folder.parentElement.closest('.doc-folder');
+            folder.setAttribute('open', '');
+            folder = folder.parentElement.closest('details.doc-folder');
           }
 
           const item = link.closest('.accordion-item');

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -366,30 +366,30 @@ main#main-content > :not(.container-fluid) {
   font-weight: 600;
 }
 
-.doc-folder > .folder-label {
+.doc-folder > summary.folder-label {
   cursor: pointer;
   display: flex;
   align-items: center;
+  list-style: none;
 }
 
-.doc-folder > .folder-label::before {
+.doc-folder > summary.folder-label::-webkit-details-marker {
+  display: none;
+}
+
+.doc-folder > summary.folder-label::before {
   content: '▸';
   margin-right: 4px;
   transition: transform 0.1s ease-in-out;
 }
 
-.doc-folder.open > .folder-label::before {
+.doc-folder[open] > summary.folder-label::before {
   transform: rotate(90deg);
 }
 
 .doc-folder > ul {
-  display: none;
   margin-left: 1rem !important;
   padding-left: 0;
-}
-
-.doc-folder.open > ul {
-  display: block;
 }
 
 .doc-link-item a {


### PR DESCRIPTION
## Summary
- use `<details>` for nested doc folders
- simplify JS highlight logic and remove custom toggles
- adjust styling for `<details>` based tree view

## Testing
- `npm run build`