### PR TITLE
Fix favicon link references

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -18,8 +18,8 @@ import favicon32 from '../assets/favicon-32x32.png';
 <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;600&display=swap" /></noscript>
 
 <!-- Favicon -->
-<link rel="icon" type="image/png" sizes="32x32" href={favicon32} />
-<link rel="icon" type="image/png" sizes="16x16" href={favicon16} />
+<link rel="icon" type="image/png" sizes="32x32" href={favicon32.src} />
+<link rel="icon" type="image/png" sizes="16x16" href={favicon16.src} />
 
 <!-- Bootstrap JS -->
 <script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- ensure imported favicon asset URLs point to their src values

## Testing
- `npm run build`