### PR TITLE
Scaffold Astro project with retro styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.astro/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # jwiedeman.github.io
-Portfolio and fun
+
+Retro-themed portfolio powered by [Astro](https://astro.build).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'https://jwiedeman.github.io'
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "jwiedeman-github-io",
+  "type": "module",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "^4.10.0"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#000"/>
+  <text x="4" y="24" font-family="monospace" font-size="24" fill="#0f0">R</text>
+</svg>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,0 +1,15 @@
+---
+import '../styles/global.css';
+const { title = 'Retro Site' } = Astro.props;
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="jwiedeman retro site">
+  <h1>Welcome to the Retro Web</h1>
+  <p>This site is built with Astro for speed and a classic look.</p>
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,13 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Press Start 2P', monospace;
+  background: #000;
+  color: #0f0;
+}
+
+a {
+  color: #f0f;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
## Summary
- set up Astro configuration and tooling for jwiedeman.github.io
- add retro global styles, layout, and index page
- include simple R favicon

## Testing
- `npm run build` *(fails: sh: 1: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a52be1daec8323926afe5722479a8a