### PR TITLE
Add dual-theme starter page with NASA and CRT styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en" class="theme-nasa"> <!-- swap to theme-crt -->
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Blue Frog / Joshua — Portfolio</title>
+<style>
+/* =============== 1) TOKENS =============== */
+:root{
+  --max:1200px; --col:12; --gutter:16px; --baseline:8px;
+
+  /* NASA light */
+  --bg:#f7f7f5; --fg:#0b0b0b; --muted:#5a5a5a; --rule:#d9d9d4; --accent:#ff3b30; --accent-2:#0066ff;
+
+  /* typography scale (8px base) */
+  --fs-12:12px; --fs-14:14px; --fs-16:16px; --fs-18:18px; --fs-20:20px; --fs-24:24px; --fs-32:32px; --fs-48:48px; --lh:1.333; /* ~4/3 */
+  --radius:4px;
+}
+
+.theme-crt{
+  --bg:#0a0c0f; --fg:#e6f1ff; --muted:#9fb3c8; --rule:#1e232b; --accent:#7cffb2; --accent-2:#70a0ff;
+}
+
+*{box-sizing:border-box}
+html,body{height:100%}
+body{
+  margin:0; background:var(--bg); color:var(--fg);
+  font-family: Inter, Helvetica, Arial, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans", "Liberation Sans", sans-serif;
+  line-height:var(--lh); font-size:var(--fs-16);
+  letter-spacing:0.01em;
+}
+
+/* Swap to mono if CRT theme for the 90s look */
+.theme-crt body, .mono{
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+/* =============== 2) LAYOUT GRID =============== */
+.container{
+  max-width:var(--max); margin:auto; padding:24px clamp(12px,3vw,24px);
+}
+
+.grid{ display:grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap:var(--gutter); }
+.span-12{ grid-column: span 12; } .span-8{grid-column: span 8;} .span-6{grid-column: span 6;} .span-4{grid-column: span 4;}
+@media (max-width:900px){ .span-8,.span-6{grid-column: span 12;} }
+@media (max-width:600px){ .span-4{grid-column: span 12;} }
+
+/* Optional visible baseline/grid for the “De School” vibe */
+.grid-paper{
+  background:
+    linear-gradient(to right, var(--rule) 1px, transparent 1px) 0 0/ calc((var(--max)/var(--col))) 100%,
+    linear-gradient(to bottom, var(--rule) 1px, transparent 1px) 0 0/ 100% var(--baseline);
+}
+.grid-paper .card{ background:rgba(255,255,255,0.6); }
+.theme-crt .grid-paper{ background:
+    linear-gradient(to right, var(--rule) 1px, transparent 1px) 0 0/ calc((var(--max)/var(--col))) 100%,
+    linear-gradient(to bottom, var(--rule) 1px, transparent 1px) 0 0/ 100% var(--baseline); }
+
+/* =============== 3) TYPE SYSTEM =============== */
+h1,h2,h3{ margin:0 0 8px 0; font-weight:700; letter-spacing:0.01em }
+h1{ font-size: clamp(var(--fs-24), 3.2vw, var(--fs-48)); line-height:1.1 }
+h2{ font-size: clamp(var(--fs-20), 2vw, var(--fs-32)); line-height:1.15 }
+h3{ font-size: var(--fs-20); }
+p{ margin:0 0 calc(var(--baseline)*2) 0 }
+
+small, .caption{ font-size:var(--fs-12); color:var(--muted) }
+
+/* =============== 4) HAIRLINES & RULES =============== */
+/* Retina-safe 1px lines using gradients (don’t rely on borders) */
+.rule{ background:
+  linear-gradient(var(--rule), var(--rule)) center/100% 1px no-repeat; height:1px; margin: calc(var(--baseline)*2) 0; }
+
+/* =============== 5) LINKS (90s defaults) =============== */
+a{ color:var(--fg); text-decoration: underline; text-decoration-thickness:1px; text-underline-offset:2px }
+a:hover{ background:var(--fg); color:var(--bg); text-decoration:none; }
+
+/* =============== 6) CARDS / PANELS =============== */
+.card{
+  padding:16px; border-radius:var(--radius);
+  background:transparent;
+  /* outline box using layered gradients for crisp corners */
+  background-image:
+    linear-gradient(var(--bg),var(--bg)), /* inner */
+    linear-gradient(var(--fg),var(--fg)); /* outline via background-clip trick */
+  background-origin: padding-box, border-box;
+  background-clip: padding-box, border-box;
+  border:1px solid transparent; /* enables the clip trick */
+}
+
+/* File card meta block (Baths cover / Swiss grid influence) */
+.meta{
+  display:flex; gap:16px; align-items:flex-start;
+}
+.meta .label{ font-size:var(--fs-12); text-transform:uppercase; letter-spacing:.08em; color:var(--muted) }
+
+/* =============== 7) TABS (S4AD / secret files vibe) =============== */
+.tabs{ display:flex; flex-wrap:wrap; gap:4px; margin-bottom:8px; }
+.tab{
+  padding:6px 10px; border-radius:4px 4px 0 0;
+  background:
+    linear-gradient(var(--rule),var(--rule)) bottom/100% 1px no-repeat,
+    linear-gradient(var(--bg),var(--bg));
+  cursor:pointer; user-select:none;
+  font-size:var(--fs-14);
+}
+.tab.is-active{
+  background:
+    linear-gradient(var(--fg),var(--fg)) bottom/100% 2px no-repeat,
+    linear-gradient(var(--bg),var(--bg));
+}
+
+/* =============== 8) VECTOR PANEL (CAD/oscilloscope) =============== */
+.panel{
+  position:relative; background: radial-gradient(ellipse at center, rgba(127,255,178,.05), transparent 60%) , var(--bg);
+  border:1px solid var(--rule); padding:12px; overflow:hidden; min-height:220px;
+}
+.theme-crt .panel{ background: radial-gradient(ellipse at center, rgba(124,255,178,.09), transparent 60%), #06080b; }
+.panel::before{
+  content:""; position:absolute; inset:0;
+  background:
+    linear-gradient(to right, rgba(124,255,178,.22) 1px, transparent 1px) 0 0/ 24px 100%,
+    linear-gradient(to bottom, rgba(124,255,178,.22) 1px, transparent 1px) 0 0/ 100% 16px;
+  mix-blend-mode:screen; pointer-events:none;
+  opacity:.35; /* grid lines like your CAD shots */
+}
+.theme-nasa .panel::before{ opacity:.15; background:
+    linear-gradient(to right, var(--rule) 1px, transparent 1px) 0 0/ 24px 100%,
+    linear-gradient(to bottom, var(--rule) 1px, transparent 1px) 0 0/ 100% 16px; }
+
+/* =============== 9) SCANLINES (toggleable) =============== */
+.scanlines{ position:relative; }
+.scanlines::after{
+  content:""; position:absolute; inset:0; pointer-events:none; opacity:.25;
+  background:linear-gradient(rgba(0,0,0,.35) 1px, transparent 1px) 0 0/100% 2px;
+  mix-blend-mode:multiply;
+}
+.theme-nasa .scanlines::after{ display:none } /* only for CRT theme unless you force it */
+
+/* =============== 10) UTILITIES =============== */
+.badge{ padding:2px 6px; border:1px solid var(--fg); border-radius:2px; font-size:var(--fs-12)}
+.flex{ display:flex; gap:12px; align-items:center }
+.right{ margin-left:auto }
+.mono{ letter-spacing:0 }
+.kern-tight{ letter-spacing:-0.01em }
+.upper{ text-transform:uppercase; letter-spacing:.08em }
+.figure{ border:1px solid var(--rule); padding:6px }
+img{ max-width:100%; display:block; image-rendering:auto } /* use pixelated only for icons */
+.code{ font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background:rgba(127,127,127,.1); padding:2px 4px; border-radius:2px }
+
+/* =============== 11) RESPONSIVE MENU (minimal 90s) =============== */
+nav{ border-bottom:1px solid var(--rule); margin-bottom:16px; }
+nav .container{ display:flex; gap:16px; align-items:baseline }
+nav a{ text-decoration:none; padding:8px 4px; border-bottom:2px solid transparent }
+nav a:hover{ background:none; color:var(--accent); border-bottom-color:var(--accent) }
+.brand{ font-weight:700; font-size:var(--fs-16); letter-spacing:.06em }
+
+footer{ margin-top:48px; border-top:1px solid var(--rule); padding:16px 0; color:var(--muted) }
+</style>
+</head>
+<body>
+<nav>
+  <div class="container">
+    <div class="brand upper">BLUE FROG // JOSHUA</div>
+    <a href="#">Work</a><a href="#">Blog</a><a href="#">Experiments</a><a href="#">About</a>
+    <span class="right badge mono">MODE: <span id="mode">NASA</span></span>
+  </div>
+</nav>
+
+<header class="container">
+  <div class="grid">
+    <div class="span-12">
+      <h1 class="kern-tight">Rare-tech operator. Domain-shifter. <span class="upper" style="color:var(--accent)">SCP-hireable</span>.</h1>
+      <p class="mono">Analytics • Compliance • Retro hardware • Simulation</p>
+      <div class="rule"></div>
+    </div>
+  </div>
+</header>
+
+<main class="container grid grid-paper">
+  <section class="span-8">
+    <div class="tabs">
+      <div class="tab is-active">Case Studies</div>
+      <div class="tab">Experiments</div>
+      <div class="tab">Specs</div>
+    </div>
+    <article class="card meta">
+      <div style="min-width:96px" class="figure">
+        <div class="badge mono">A-34</div>
+        <div class="caption">threat ★★★</div>
+      </div>
+      <div>
+        <h2>DSAS vs custom metrics — enterprise AA rollout</h2>
+        <p>Implementation patterns, data contracts, and <span class="code">spec-to-QA</span> automation.</p>
+        <a href="#">Read the brief →</a>
+      </div>
+    </article>
+
+    <div class="rule"></div>
+
+    <div class="panel scanlines">
+      <!-- draw some vector-ish UI -->
+      <svg width="100%" height="220" viewBox="0 0 600 220" fill="none">
+        <g stroke="var(--accent)" stroke-width="1">
+          <polyline points="0,160 80,120 160,160 240,100 320,140 400,90 480,130 600,80"/>
+          <circle cx="80" cy="120" r="3"/><circle cx="240" cy="100" r="3"/><circle cx="400" cy="90" r="3"/>
+        </g>
+        <g stroke="var(--accent-2)" stroke-width=".8">
+          <rect x="12" y="12" width="120" height="60"/>
+          <line x1="12" y1="42" x2="132" y2="42"/>
+          <polyline points="160,20 220,20 220,60 160,60 160,20"/>
+        </g>
+      </svg>
+    </div>
+  </section>
+
+  <aside class="span-4">
+    <h3 class="upper">This week</h3>
+    <div class="rule"></div>
+    <div class="mono">
+      <div>WED 27/06  <a href="#">New Makers — G. Kerbosch</a></div>
+      <div>FRI 29/06  Workshop / <span class="badge">Tickets</span></div>
+      <div>SAT 30/06  Session II / Room A</div>
+      <div>MON 01/07  <a href="#">Full program →</a></div>
+    </div>
+  </aside>
+</main>
+
+<footer class="container flex">
+  <div>© 2025 Blue Frog Analytics</div>
+  <div class="right"><a href="#" onclick="toggleTheme(event)">toggle theme</a></div>
+</footer>
+
+<script>
+function toggleTheme(e){
+  e && e.preventDefault();
+  const c = document.documentElement;
+  const nasa = c.classList.contains('theme-nasa');
+  c.classList.toggle('theme-nasa', !nasa);
+  c.classList.toggle('theme-crt', nasa);
+  document.getElementById('mode').textContent = nasa ? 'CRT' : 'NASA';
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone `index.html` demo with NASA-inspired light theme and CRT-style dark theme
- include grid layout, tabs, vector panel, and theme toggle script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52ec10df483239380867bccfa2319