### PR TITLE
Fix GitHub Pages build by targeting Astro output

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+source: dist
+include:
+  - _astro


### PR DESCRIPTION
## Summary
- Configure Jekyll `_config.yml` to build from `dist` and include `_astro` assets

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5333765508323bbb5223f4531c8a5