### PR TITLE
feat: unify themes with tokens

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -18,7 +18,19 @@ const { title = 'Retro Site' } = Astro.props;
     </main>
     <Footer />
     <script>
-      const toggle = () => document.documentElement.classList.toggle('theme-dark');
+      const root = document.documentElement;
+      const apply = (mode) => {
+        root.classList.toggle('theme-dark', mode === 'dark');
+        root.classList.toggle('theme-light', mode === 'light');
+      };
+      const stored = localStorage.getItem('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      apply(stored || (prefersDark ? 'dark' : 'light'));
+      const toggle = () => {
+        const next = root.classList.contains('theme-dark') ? 'light' : 'dark';
+        apply(next);
+        localStorage.setItem('theme', next);
+      };
       document.querySelectorAll('[data-theme-toggle]').forEach(el => el.addEventListener('click', toggle));
     </script>
   </body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,6 +14,11 @@ const scheduleItems = [
 ---
 <Layout title="jwiedeman retro site">
   <Hero title="JWIEDEMAN" tagline="interstellar web projects" />
+  <ul class="credibility">
+    <li>Analytics implementation</li>
+    <li>Compliance scanning</li>
+    <li>Retro hardware R&D</li>
+  </ul>
   <Tabs items={tabItems} active={0} />
   <div class="grid">
     <div class="span-6">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,6 +22,13 @@
   --text-24: 24px;
   --text-32: 32px;
   --text-48: 48px;
+
+  /* radius */
+  --radius-0: 0;
+  --radius-1: 1px;
+  --radius-2: 2px;
+  --radius-3: 3px;
+  --radius-4: 4px;
 }
 
 /* light theme - NASA */
@@ -148,6 +155,21 @@ nav {
   padding-bottom: var(--space-2);
 }
 
+/* Credibility strip */
+.credibility {
+  display: flex;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-14);
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--space-3) 0;
+}
+
+.credibility li {
+  flex: 1;
+}
+
 nav ul {
   list-style: none;
   display: flex;
@@ -228,6 +250,7 @@ nav .mode {
   background-clip: padding-box;
   outline: 1px solid var(--color-rule);
   outline-offset: -1px;
+  border-radius: var(--radius-1);
 }
 
 .card .label {
@@ -246,6 +269,7 @@ nav .mode {
   padding: var(--space-3);
   outline: 1px solid var(--color-rule);
   outline-offset: -1px;
+  border-radius: var(--radius-1);
 }
 
 .panel::before {


### PR DESCRIPTION
## Summary
- expand design tokens with border radii
- persist light/dark theme preference and wire it to tokens
- add credibility strip copy on the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a53601c4688323af7d0334e24bbdc7