### PR TITLE
Anchor footer to bottom and space content below header

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -66,6 +66,9 @@ html {
 
 body {
   margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 a {
@@ -88,6 +91,11 @@ h1, h2, h3, h4, h5, h6 {
 
 .mono {
   font-family: var(--font-mono);
+}
+
+main {
+  flex: 1;
+  margin-top: var(--space-4);
 }
 
 /* Container and grid system */


### PR DESCRIPTION
## Summary
- Use flex column layout to stretch pages so the footer sticks to the bottom even when content is short
- Offset main content from the header to prevent hero overlay with navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a537aabaac8323b15d18d3e4c6e914