### PR TITLE
Expand layout for full-width header, footer, and hero

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,8 @@
 ---
 const year = new Date().getFullYear();
 ---
-<footer class="container hairline-top">
-  <span>&copy; {year} jwiedeman</span>
+<footer class="hairline-top">
+  <div class="container">
+    <span>&copy; {year} jwiedeman</span>
+  </div>
 </footer>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,10 +1,12 @@
-<nav class="container hairline-bottom">
-  <div class="brand">JWIEDEMAN</div>
-  <ul>
-    <li><a href="/work">Work</a></li>
-    <li><a href="/blog">Blog</a></li>
-    <li><a href="/experiments">Experiments</a></li>
-    <li><a href="/about">About</a></li>
-  </ul>
-  <button class="mode mono" data-theme-toggle>MODE: NASA</button>
+<nav class="hairline-bottom">
+  <div class="container">
+    <div class="brand">JWIEDEMAN</div>
+    <ul>
+      <li><a href="/work">Work</a></li>
+      <li><a href="/blog">Blog</a></li>
+      <li><a href="/experiments">Experiments</a></li>
+      <li><a href="/about">About</a></li>
+    </ul>
+    <button class="mode mono" data-theme-toggle>MODE: NASA</button>
+  </div>
 </nav>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,7 +24,7 @@ const { title = 'Retro Site' } = Astro.props;
   </head>
   <body>
     <Nav />
-    <main class="container">
+    <main>
       <slot />
     </main>
     <Footer />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,6 +2,8 @@
 import Layout from '../layouts/Layout.astro';
 ---
 <Layout title="About">
-  <h1>About</h1>
-  <p>This site blends NASA manual discipline with CRT swagger.</p>
+  <div class="container">
+    <h1>About</h1>
+    <p>This site blends NASA manual discipline with CRT swagger.</p>
+  </div>
 </Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,6 +2,8 @@
 import Layout from '../../layouts/Layout.astro';
 ---
 <Layout title="Blog">
-  <h1>Blog</h1>
-  <p>Posts coming soon.</p>
+  <div class="container">
+    <h1>Blog</h1>
+    <p>Posts coming soon.</p>
+  </div>
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -2,6 +2,8 @@
 import Layout from '../layouts/Layout.astro';
 ---
 <Layout title="Contact">
-  <h1>Contact</h1>
-  <p>Reach me at <a href="mailto:me@example.com">me@example.com</a>.</p>
+  <div class="container">
+    <h1>Contact</h1>
+    <p>Reach me at <a href="mailto:me@example.com">me@example.com</a>.</p>
+  </div>
 </Layout>

--- a/src/pages/experiments.astro
+++ b/src/pages/experiments.astro
@@ -2,6 +2,8 @@
 import Layout from '../layouts/Layout.astro';
 ---
 <Layout title="Experiments">
-  <h1>Experiments</h1>
-  <p>Playground and prototypes.</p>
+  <div class="container">
+    <h1>Experiments</h1>
+    <p>Playground and prototypes.</p>
+  </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,19 +14,21 @@ const scheduleItems = [
 ---
 <Layout title="jwiedeman retro site">
   <Hero title="JWIEDEMAN" tagline="interstellar web projects" />
-  <ul class="credibility">
-    <li>Analytics implementation</li>
-    <li>Compliance scanning</li>
-    <li>Retro hardware R&D</li>
-  </ul>
-  <Tabs items={tabItems} active={0} />
-  <div class="grid">
-    <div class="span-6">
-      <Card label="2024" title="Mission Control" blurb="New design system." href="#" />
+  <div class="container">
+    <ul class="credibility">
+      <li>Analytics implementation</li>
+      <li>Compliance scanning</li>
+      <li>Retro hardware R&D</li>
+    </ul>
+    <Tabs items={tabItems} active={0} />
+    <div class="grid">
+      <div class="span-6">
+        <Card label="2024" title="Mission Control" blurb="New design system." href="#" />
+      </div>
+      <div class="span-6">
+        <Panel />
+      </div>
     </div>
-    <div class="span-6">
-      <Panel />
-    </div>
+    <Schedule items={scheduleItems} />
   </div>
-  <Schedule items={scheduleItems} />
 </Layout>

--- a/src/pages/lab/index.astro
+++ b/src/pages/lab/index.astro
@@ -2,6 +2,8 @@
 import Layout from '../../layouts/Layout.astro';
 ---
 <Layout title="Lab">
-  <h1>Lab</h1>
-  <p>Experimental projects will appear here.</p>
+  <div class="container">
+    <h1>Lab</h1>
+    <p>Experimental projects will appear here.</p>
+  </div>
 </Layout>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -2,6 +2,8 @@
 import Layout from '../layouts/Layout.astro';
 ---
 <Layout title="Work">
-  <h1>Work</h1>
-  <p>Project archive coming soon.</p>
+  <div class="container">
+    <h1>Work</h1>
+    <p>Project archive coming soon.</p>
+  </div>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -95,6 +95,9 @@ h1, h2, h3, h4, h5, h6 {
 
 main {
   flex: 1;
+}
+
+main > .container {
   margin-top: var(--space-4);
 }
 
@@ -154,7 +157,7 @@ main {
 }
 
 /* Navigation */
-nav {
+nav .container {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -314,7 +317,7 @@ nav .mode {
 }
 
 /* Footer */
-footer {
+footer .container {
   font-size: var(--text-12);
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);


### PR DESCRIPTION
## Summary
- Allow header and footer to span full width while keeping inner content centered
- Let pages control their own container so hero and other full-width sections aren't constrained
- Adjust global styles to support new structure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a538b87ee48323b8d55a87fa54427e