### PR TITLE
Link sections and switch to system fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,14 @@
 html,body{height:100%}
 body{
   margin:0; background:var(--bg); color:var(--fg);
-  font-family: Inter, Helvetica, Arial, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans", "Liberation Sans", sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans", "Liberation Sans", sans-serif;
   line-height:var(--lh); font-size:var(--fs-16);
   letter-spacing:0.01em;
 }
 
 /* Swap to mono if CRT theme for the 90s look */
 .theme-crt body, .mono{
-  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-family: "Courier New", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
 /* =============== 2) LAYOUT GRID =============== */
@@ -152,7 +152,7 @@ nav{ border-bottom:1px solid var(--rule); margin-bottom:16px; }
 nav .container{ display:flex; gap:16px; align-items:baseline }
 nav a{ text-decoration:none; padding:8px 4px; border-bottom:2px solid transparent }
 nav a:hover{ background:none; color:var(--accent); border-bottom-color:var(--accent) }
-.brand{ font-weight:700; font-size:var(--fs-16); letter-spacing:.06em }
+.brand{ font-weight:700; font-size:var(--fs-32); letter-spacing:.06em }
 
 footer{ margin-top:48px; border-top:1px solid var(--rule); padding:16px 0; color:var(--muted) }
 </style>
@@ -160,8 +160,8 @@ footer{ margin-top:48px; border-top:1px solid var(--rule); padding:16px 0; color
 <body>
 <nav>
   <div class="container">
-    <div class="brand upper">BLUE FROG // JOSHUA</div>
-    <a href="#">Work</a><a href="#">Blog</a><a href="#">Experiments</a><a href="#">About</a>
+    <a href="/" class="brand upper">BLUE FROG // JOSHUA</a>
+    <a href="#work">Work</a><a href="#blog">Blog</a><a href="#experiments">Experiments</a><a href="#about">About</a>
     <span class="right badge mono">MODE: <span id="mode">NASA</span></span>
   </div>
 </nav>
@@ -176,8 +176,9 @@ footer{ margin-top:48px; border-top:1px solid var(--rule); padding:16px 0; color
   </div>
 </header>
 
-<main class="container grid grid-paper">
-  <section class="span-8">
+<main>
+  <section id="work" class="container grid grid-paper">
+    <div class="span-8">
     <div class="tabs">
       <div class="tab is-active">Case Studies</div>
       <div class="tab">Experiments</div>
@@ -191,7 +192,7 @@ footer{ margin-top:48px; border-top:1px solid var(--rule); padding:16px 0; color
       <div>
         <h2>DSAS vs custom metrics — enterprise AA rollout</h2>
         <p>Implementation patterns, data contracts, and <span class="code">spec-to-QA</span> automation.</p>
-        <a href="#">Read the brief →</a>
+        <a href="/work">Read the brief →</a>
       </div>
     </article>
 
@@ -211,23 +212,39 @@ footer{ margin-top:48px; border-top:1px solid var(--rule); padding:16px 0; color
         </g>
       </svg>
     </div>
-  </section>
+    </div>
 
-  <aside class="span-4">
+    <aside class="span-4">
     <h3 class="upper">This week</h3>
     <div class="rule"></div>
     <div class="mono">
-      <div>WED 27/06  <a href="#">New Makers — G. Kerbosch</a></div>
+      <div>WED 27/06  <a href="/blog">New Makers — G. Kerbosch</a></div>
       <div>FRI 29/06  Workshop / <span class="badge">Tickets</span></div>
       <div>SAT 30/06  Session II / Room A</div>
-      <div>MON 01/07  <a href="#">Full program →</a></div>
+      <div>MON 01/07  <a href="/experiments">Full program →</a></div>
     </div>
-  </aside>
+    </aside>
+  </section>
+
+  <section id="blog" class="container">
+    <h2>Blog</h2>
+    <p class="mono">Articles coming soon.</p>
+  </section>
+
+  <section id="experiments" class="container">
+    <h2>Experiments</h2>
+    <p class="mono">Projects under development.</p>
+  </section>
+
+  <section id="about" class="container">
+    <h2>About</h2>
+    <p>Blue Frog Analytics explores rare-tech and simulation.</p>
+  </section>
 </main>
 
 <footer class="container flex">
   <div>© 2025 Blue Frog Analytics</div>
-  <div class="right"><a href="#" onclick="toggleTheme(event)">toggle theme</a></div>
+  <div class="right"><a href="#mode" onclick="toggleTheme(event)">toggle theme</a></div>
 </footer>
 
 <script>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,6 @@
 <nav class="hairline-bottom">
   <div class="container">
-    <div class="brand">JWIEDEMAN</div>
+    <a href="/" class="brand">JWIEDEMAN</a>
     <ul>
       <li><a href="/work">Work</a></li>
       <li><a href="/blog">Blog</a></li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,8 +8,8 @@ import Schedule from '../components/Schedule.astro';
 
 const tabItems = ['Work','Blog','Experiments','About'];
 const scheduleItems = [
-  { day: 'WED 27/06', label: 'Launch', href: '#' },
-  { day: 'THU 28/06', label: 'Review', href: '#' }
+  { day: 'WED 27/06', label: 'Launch', href: '/work' },
+  { day: 'THU 28/06', label: 'Review', href: '/blog' }
 ];
 ---
 <Layout title="jwiedeman retro site">
@@ -23,7 +23,7 @@ const scheduleItems = [
     <Tabs items={tabItems} active={0} />
     <div class="grid">
       <div class="span-6">
-        <Card label="2024" title="Mission Control" blurb="New design system." href="#" />
+        <Card label="2024" title="Mission Control" blurb="New design system." href="/work" />
       </div>
       <div class="span-6">
         <Panel />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,5 @@
 /* Global styles and design system */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=IBM+Plex+Mono:wght@400;600&display=swap');
+/* Using system fonts for performance */
 
 /* Design tokens */
 :root {
@@ -12,8 +12,8 @@
   --space-6: 48px;
 
   /* typography */
-  --font-sans: 'Inter', 'Helvetica Neue', Arial, sans-serif;
-  --font-mono: 'IBM Plex Mono', monospace;
+  --font-sans: 'Helvetica Neue', Helvetica, Arial, system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans', 'Liberation Sans', sans-serif;
+  --font-mono: 'Courier New', Courier, monospace;
 
   --text-12: 12px;
   --text-14: 14px;
@@ -195,8 +195,10 @@ nav a {
 }
 
 nav .brand {
-  font-weight: 600;
+  font-weight: 700;
+  font-size: var(--text-32);
   text-transform: uppercase;
+  text-decoration: none;
 }
 
 nav .mode {


### PR DESCRIPTION
## Summary
- Link brand to home and wire navigation to on-page sections
- Replace Google font imports with system fonts and enlarge brand styling
- Point card and schedule entries to real pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a53a63dd7c8323acfa833be1138230