### PR TITLE
Remove unnecessary coordinate flip animation

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -69,12 +69,6 @@ const { title, tagline } = Astro.props;
       left: 4px;
       font-size: var(--text-12);
       color: color-mix(in srgb, var(--frame-color) 60%, transparent);
-      animation: coord-spin 2s linear forwards;
-      transform-origin: center;
-    }
-    @keyframes coord-spin {
-      from { transform: rotateX(0deg); }
-      to { transform: rotateX(360deg); }
     }
     .topo-hero .hud .compass {
       position: absolute;


### PR DESCRIPTION
## Summary
- remove spinning animation from hero coordinate HUD

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a53db09cf48323872e9808bd512d4b