### PR TITLE
Improve Lighthouse scores and accessibility

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -4,8 +4,8 @@ const { label, title, blurb, href } = Astro.props;
 <article class="card">
   <div class="label mono">{label}</div>
   <div>
-    <h3>{title}</h3>
+    <h2>{title}</h2>
     <p>{blurb}</p>
-    <a href={href}>Read more</a>
+    <a href={href}>Read more about {title}</a>
   </div>
 </article>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,5 +1,5 @@
 ---
-import topoScript from '../scripts/topo.ts?url';
+import topoInit from '../scripts/topo-init.ts?url';
 const { title, tagline } = Astro.props;
 ---
 <section class="topo-hero">
@@ -105,6 +105,6 @@ const { title, tagline } = Astro.props;
       cursor: pointer;
     }
   </style>
-<script type="module" src={topoScript}></script>
+<script type="module" src={topoInit}></script>
 </section>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,25 +2,22 @@
 import '../styles/global.css';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
-const { title = 'Retro Site' } = Astro.props;
+import themeInit from '../scripts/theme-init.ts?url';
+import themeToggle from '../scripts/theme-toggle.ts?url';
+const { title = 'Retro Site', description = 'Interstellar web projects by Joshua Wiedeman.' } = Astro.props;
 ---
 <!DOCTYPE html>
 <html lang="en" class="theme-light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none'" />
+    <meta http-equiv="X-Frame-Options" content="DENY" />
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
+    <meta http-equiv="Strict-Transport-Security" content="max-age=31536000" />
     <title>{title}</title>
-    <script>
-      (function() {
-        const root = document.documentElement;
-        const stored = localStorage.getItem('theme');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const mode = stored || (prefersDark ? 'dark' : 'light');
-        root.classList.toggle('theme-dark', mode === 'dark');
-        root.classList.toggle('theme-light', mode === 'light');
-        if (!stored) localStorage.setItem('theme', mode);
-      })();
-    </script>
+    <script type="module" src={themeInit}></script>
   </head>
   <body>
     <Nav />
@@ -28,20 +25,6 @@ const { title = 'Retro Site' } = Astro.props;
       <slot />
     </main>
     <Footer />
-    <script>
-      const root = document.documentElement;
-      const update = () => {
-        const label = root.classList.contains('theme-dark') ? 'MODE: CRT' : 'MODE: NASA';
-        document.querySelectorAll('[data-theme-toggle]').forEach(btn => btn.textContent = label);
-      };
-      update();
-      document.querySelectorAll('[data-theme-toggle]').forEach(el => el.addEventListener('click', () => {
-        const next = root.classList.contains('theme-dark') ? 'light' : 'dark';
-        root.classList.toggle('theme-dark', next === 'dark');
-        root.classList.toggle('theme-light', next === 'light');
-        localStorage.setItem('theme', next);
-        update();
-      }));
-    </script>
+    <script type="module" src={themeToggle}></script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ const scheduleItems = [
   { day: 'THU 28/06', label: 'Review', href: '/blog' }
 ];
 ---
-<Layout title="jwiedeman retro site">
+<Layout title="jwiedeman retro site" description="Interstellar web projects and experiments by Joshua Wiedeman.">
   <Hero title="JWIEDEMAN" tagline="interstellar web projects" />
   <div class="container">
     <ul class="credibility">

--- a/src/scripts/theme-init.ts
+++ b/src/scripts/theme-init.ts
@@ -1,0 +1,8 @@
+const root = document.documentElement;
+const stored = localStorage.getItem('theme');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+const mode = stored || (prefersDark ? 'dark' : 'light');
+root.classList.toggle('theme-dark', mode === 'dark');
+root.classList.toggle('theme-light', mode === 'light');
+if (!stored) localStorage.setItem('theme', mode);
+

--- a/src/scripts/theme-toggle.ts
+++ b/src/scripts/theme-toggle.ts
@@ -1,0 +1,18 @@
+const root = document.documentElement;
+const update = () => {
+  const label = root.classList.contains('theme-dark') ? 'MODE: CRT' : 'MODE: NASA';
+  document.querySelectorAll('[data-theme-toggle]').forEach(btn => {
+    (btn as HTMLElement).textContent = label;
+  });
+};
+update();
+document.querySelectorAll('[data-theme-toggle]').forEach(el => {
+  el.addEventListener('click', () => {
+    const next = root.classList.contains('theme-dark') ? 'light' : 'dark';
+    root.classList.toggle('theme-dark', next === 'dark');
+    root.classList.toggle('theme-light', next === 'light');
+    localStorage.setItem('theme', next);
+    update();
+  });
+});
+

--- a/src/scripts/topo-init.ts
+++ b/src/scripts/topo-init.ts
@@ -1,0 +1,7 @@
+const load = () => import('./topo.ts');
+if ('requestIdleCallback' in window) {
+  (window as any).requestIdleCallback(load);
+} else {
+  setTimeout(load, 2000);
+}
+

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,7 +36,7 @@
   --color-bg: #f8f5f0;
   --color-text: #111111;
   --color-rule: #c0c5cc;
-  --color-accent: #fc3d21;
+  --color-accent: #b00000;
   --color-link: var(--color-accent);
   --color-muted: #666666;
 }


### PR DESCRIPTION
## Summary
- add meta description and security headers in layout
- darken accent color for better contrast
- replace generic card link and heading for clearer hierarchy
- lazy load topography script and externalize theme scripts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68a53ef182508323b83830463e2b3a01