### PR TITLE
fix: add missing front matter to Hero component

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,4 +1,4 @@
-
+---
 const { title, tagline } = Astro.props;
 ---
 <section class="topo-hero">


### PR DESCRIPTION
## Summary
- ensure Hero component begins with proper front matter to allow Astro build

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68a5437cfa988323bea72151170d244d