### PR TITLE
Fix CSP meta warnings and smooth topographic animation

### DIFF
--- a/public/topo.js
+++ b/public/topo.js
@@ -305,7 +305,7 @@
   function drawField(segsArray, alpha) {
     ctx.globalAlpha = alpha;
     segsArray.forEach((segs, idx) => {
-      ctx.lineWidth = idx % 3 === 0 ? 2 : 1;
+      ctx.lineWidth = idx % 3 === 0 ? 1.5 : 0.5;
       ctx.beginPath();
       drawSegments(segs);
       ctx.stroke();
@@ -323,9 +323,9 @@
   function loop() {
     if (!running) return;
     frame++;
-    if (frame % 3 === 0) recompute();
+    if (frame % 5 === 0) recompute();
     draw();
-    t += 25e-4;
+    t += 1e-3;
     requestAnimationFrame(loop);
   }
   var media = window.matchMedia("(prefers-reduced-motion: reduce)");

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,8 +12,7 @@ const { title = 'Retro Site', description = 'Interstellar web projects by Joshua
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-ancestors 'none'" />
-    <meta http-equiv="X-Frame-Options" content="DENY" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'data:'" />
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
     <meta http-equiv="Strict-Transport-Security" content="max-age=31536000" />
     <title>{title}</title>

--- a/src/scripts/topo.ts
+++ b/src/scripts/topo.ts
@@ -126,7 +126,7 @@ function drawSegments(segs: number[][]) {
 function drawField(segsArray: number[][][], alpha: number) {
   ctx!.globalAlpha = alpha;
   segsArray.forEach((segs, idx) => {
-    ctx!.lineWidth = idx % 3 === 0 ? 2 : 1;
+    ctx!.lineWidth = idx % 3 === 0 ? 1.5 : 0.5;
     ctx!.beginPath();
     drawSegments(segs);
     ctx!.stroke();
@@ -146,9 +146,9 @@ let running = true;
 function loop() {
   if (!running) return;
   frame++;
-  if (frame % 3 === 0) recompute();
+  if (frame % 5 === 0) recompute();
   draw();
-  t += 0.0025;
+  t += 0.001;
   requestAnimationFrame(loop);
 }
 


### PR DESCRIPTION
## Summary
- relax CSP to allow inline/data scripts and drop unsupported frame/X-Frame meta tags
- slow topographic canvas animation for smoother motion and thinner contour lines

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a547744ca483239604ecd1465ce370