### PR TITLE
Restore topo morphing and ensure compass visibility

### DIFF
--- a/public/topo.js
+++ b/public/topo.js
@@ -4,7 +4,8 @@ let MAX_FPS = 30; // limit frames for smoother rendering
 let thresholdIncrement = 5;
 let thickLineThresholdMultiple = 3;
 let res = 8; // grid resolution
-let baseZOffset = 0.00005; // slower noise evolution
+let baseZOffset = 0.0001; // noise evolution speed
+let zDirection = 1; // oscillates noise for looping morph
 
 const canvas = document.getElementById('topo-canvas');
 const ctx = canvas?.getContext('2d');
@@ -46,7 +47,8 @@ function animate() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   const lineColor = getComputedStyle(canvas).getPropertyValue('--contour-color').trim() || '#EDEDED';
 
-  zOffset += baseZOffset;
+  zOffset += baseZOffset * zDirection;
+  if (zOffset > 1 || zOffset < 0) zDirection *= -1;
   generateNoise();
 
   const roundedNoiseMin = Math.floor(noiseMin / thresholdIncrement) * thresholdIncrement;

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -24,7 +24,7 @@ const { title, tagline } = Astro.props;
       width: 100%;
       aspect-ratio: 4/3;
       max-height: 72vh;
-      margin-bottom: var(--space-3);
+      margin: 0 var(--space-2) var(--space-3);
       --frame-color: var(--color-text);
       --grid-major: color-mix(in srgb, var(--color-accent) 30%, transparent);
       --grid-minor: color-mix(in srgb, var(--color-accent) 15%, transparent);


### PR DESCRIPTION
## Summary
- Reintroduce looping morph animation to topo map by oscillating noise offset
- Add horizontal margins so E/W compass labels stay in view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68a54b3b33f483238d9cd8b6274a9c90