### PR TITLE
chore: exclude source files from jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,8 @@
-source: dist
-include:
-  - _astro
+exclude:
+  - src
+  - node_modules
+  - public
+  - package.json
+  - package-lock.json
+  - astro.config.mjs
+  - tsconfig.json


### PR DESCRIPTION
## Summary
- prevent GitHub Pages Jekyll from processing Astro source files

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68a54d06e1bc8323b44ae499041af511