### PR TITLE
Add .nojekyll to serve Astro assets on GitHub Pages

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Prevent GitHub Pages from ignoring the _astro directory


### PR DESCRIPTION
## Summary
- add `.nojekyll` so GitHub Pages serves the `_astro` CSS bundle

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68a5529920348323a12afb70667fd090