### PR TITLE
Double topo hero animation speed

### DIFF
--- a/public/topo.js
+++ b/public/topo.js
@@ -4,7 +4,7 @@ let MAX_FPS = 30; // limit frames for smoother rendering
 let thresholdIncrement = 5;
 let thickLineThresholdMultiple = 3;
 let res = 8; // grid resolution
-let baseZOffset = 0.00015; // noise evolution speed
+let baseZOffset = 0.0003; // noise evolution speed
 
 const canvas = document.getElementById('topo-canvas');
 const ctx = canvas?.getContext('2d');

--- a/topo.js
+++ b/topo.js
@@ -5,7 +5,7 @@ const MAX_FPS = 30;                 // 0 = uncapped
 const thresholdIncrement = 5;       // contour step: 0..100 by 5
 const thickLineThresholdMultiple = 3; // every Nth line is thicker
 const res = 8;                      // grid cell size (smaller = more detail)
-const baseZOffset = 0.00018;        // field evolution speed
+const baseZOffset = 0.00036;        // field evolution speed
 const lineColor = "#d2d2d2";      // neutral contour color
 const hoverColor = "#FFFFFFCC";     // hover emphasis
 const targetFillRatio = 0.20;       // ~20% of visible slices get pages


### PR DESCRIPTION
## Summary
- accelerate topographic hero animation by increasing noise evolution rate

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`
- `npm run preview` *(no output after startup; terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a668885fd4832391cb43e39221eed0