### PR TITLE
Enable Astro link prefetching

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  site: 'https://jwiedeman.github.io'
+  site: 'https://jwiedeman.github.io',
+  prefetch: true
 });

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -15,12 +15,12 @@ const { title } = Astro.props;
     </div>
   </div>
   <nav class="hero-nav">
-    <a href="/" class="brand">{title}</a>
+    <a href="/" class="brand" data-astro-prefetch>{title}</a>
     <ul>
-      <li><a href="/work">Work</a></li>
-      <li><a href="/blog">Blog</a></li>
-      <li><a href="/lab">Lab</a></li>
-      <li><a href="/about">About</a></li>
+      <li><a href="/work" data-astro-prefetch>Work</a></li>
+      <li><a href="/blog" data-astro-prefetch>Blog</a></li>
+      <li><a href="/lab" data-astro-prefetch>Lab</a></li>
+      <li><a href="/about" data-astro-prefetch>About</a></li>
     </ul>
   </nav>
   <script type="module" src="/topo.js"></script>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,11 +1,11 @@
 <nav class="hairline-bottom">
   <div class="container">
-    <a href="/" class="brand">JWIEDEMAN</a>
+    <a href="/" class="brand" data-astro-prefetch>JWIEDEMAN</a>
     <ul>
-      <li><a href="/work">Work</a></li>
-      <li><a href="/blog">Blog</a></li>
-      <li><a href="/lab">Lab</a></li>
-      <li><a href="/about">About</a></li>
+      <li><a href="/work" data-astro-prefetch>Work</a></li>
+      <li><a href="/blog" data-astro-prefetch>Blog</a></li>
+      <li><a href="/lab" data-astro-prefetch>Lab</a></li>
+      <li><a href="/about" data-astro-prefetch>About</a></li>
     </ul>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- add built-in prefetch support to Astro config
- prefetch navigation links for faster page transitions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68ad24d7f0f48323a0c7d8c61281b4e9