### PR TITLE
fix: configure GitHub Pages build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- configure Pages workflow to avoid Jekyll parsing of Astro files

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68ad35b1ccd88323b0dde25911fd7409