### PR TITLE
Disable Jekyll processing for Astro site

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll for GitHub Pages


### PR DESCRIPTION
## Summary
- disable GitHub Pages' Jekyll build to avoid parsing Astro files
- document purpose of the `.nojekyll` marker

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68ad37e565708323b833417a65923e30