### PR TITLE
feat: enrich about and work pages

### DIFF
--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -4,5 +4,17 @@ title: "About"
 ---
 <div class="container">
   <h1>About</h1>
-  <p>This site blends NASA manual discipline with CRT swagger.</p>
+  <p>Driven by curiosity and a knack for abstract problem solving, I specialize in digital analytics strategy, Adobe Analytics implementation, and Google Tag Manager (GTM) solutions that perform at scale. I design and deliver data layer architectures, SDK integrations, and cross-platform analytics implementations that meet GDPR, CCPA, HIPAA, and GxP compliance.</p>
+  <p>I’m never afraid to step out of my comfort zone if it means getting a project across the finish line faster and smarter. In one case, a slow BI processing heavy set of reports had myself and multiple engineers refining queries and architecture to optimize within our limits. I looked beyond my scope and found the real cause, the database was on the lowest billing tier. One setting change saved time, budget, and effort. That’s the abstract thinking and cross-team awareness I bring: questioning assumptions, finding root causes, and applying the fix with the highest impact.</p>
+  <p>I’ve led enterprise analytics deployments across web, mobile, OTT, and server-side environments, building event tracking frameworks, automation pipelines, and QA processes that make data accurate, actionable, and BI-ready. I bridge the gap between technical implementation and business outcomes, ensuring analytics, data engineering, BI, and compliance teams get exactly what they need.</p>
+  <p>Core strengths:</p>
+  <ul>
+    <li>Architecting &amp; deploying Adobe Analytics, GA4, and server-side GTM</li>
+    <li>Creating custom data layers, JavaScript tracking scripts, and API-based event ingestion</li>
+    <li>Automating tag audits and validation for scale and accuracy</li>
+    <li>Supporting BI &amp; Data Engineering with clean, governed data</li>
+    <li>Advising on analytics compliance in pharma, media, government, and enterprise</li>
+  </ul>
+  <p>Outside of work, you’ll find me kayaking, foraging for mushrooms, or studying cultures, subcultures, and belief systems, the same curiosity that drives my technical work.</p>
+  <p>Specialties: Adobe Analytics • GTM • Data Layer Architecture • Tag Management • Server-Side Tracking • SDK Integration • Analytics QA • GA4 • Event Tracking • Compliance (GDPR, CCPA, HIPAA, GxP) • Data Governance • API Integrations • OTT &amp; Mobile Analytics • BI Enablement • Billing Optimization • Defensive Design</p>
 </div>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -9,7 +9,17 @@ import Layout from '../layouts/Layout.astro';
         <div class="label">2022&ndash;Present</div>
         <div>
           <h2>Analytics Manager &middot; Fox Corporation</h2>
-          <p>Lead analytics strategy, implementation, and QA across web, mobile, OTT, and server-side platforms. Designed data layers, automated tag deployment, and ensured GDPR, CCPA, HIPAA, and GxP compliance.</p>
+          <p>Lead analytics strategy, implementation, and QA for FOX Digital Consumer Products Engineering across web, mobile, OTT, and server-side platforms. Own the full lifecycle from measurement design to deployment, ensuring Adobe Analytics and GTM implementations meet technical, compliance, and business needs in highly visible, regulated environments.</p>
+          <ul>
+            <li>Designed, documented, and delivered enterprise analytics solutions for digital properties, integrating with Adobe Analytics, Google Tag Manager, GA4, and custom SDKs.</li>
+            <li>Built and maintained data layer architectures, enabling accurate event tracking and scalable taxonomy across multiple platforms and brands.</li>
+            <li>Led cross-team troubleshooting to resolve systemic performance bottlenecks, including identifying a slow BI process root cause (low DB billing tier), resulting in immediate time and cost savings.</li>
+            <li>Automated tag deployment and validation processes, reducing manual QA time by 40%+ while improving data integrity.</li>
+            <li>Partnered with engineering, BI, product, and compliance teams to ensure data met GDPR, CCPA, HIPAA, and GxP standards.</li>
+            <li>Developed and executed analytics QA frameworks for OTT and mobile platforms, identifying and remediating SDK integration gaps.</li>
+            <li>Provided implementation guidance and best practices to analysts, engineers, and product owners to accelerate project delivery.</li>
+          </ul>
+          <p><strong>Key Skills:</strong> Adobe Analytics • Google Tag Manager • Data Layer Architecture • Server-Side GTM • SDK Integration • Analytics QA • GA4 • Event Tracking • Compliance (GDPR, CCPA, HIPAA, GxP) • API Integrations • BI Enablement • Cross-Team Problem Solving</p>
         </div>
       </article>
 
@@ -17,7 +27,17 @@ import Layout from '../layouts/Layout.astro';
         <div class="label">2018&ndash;2022</div>
         <div>
           <h2>Analytics Engineer &middot; Logical Position</h2>
-          <p>Served as the technical authority for analytics across 1,000+ clients. Built Adobe Analytics, Google Analytics, and GTM solutions, created custom tracking scripts, and established tagging taxonomies.</p>
+          <p>Served as the technical authority for digital analytics implementation across 1,000+ SMB and enterprise clients, leading the design, deployment, and QA of cross-platform measurement solutions that improved marketing attribution, campaign optimization, and BI reporting accuracy.</p>
+          <ul>
+            <li>Architected and deployed Adobe Analytics, Google Analytics, and GTM solutions, integrating with advertising platforms (Google Ads, Facebook Ads, Bing Ads).</li>
+            <li>Created custom JavaScript tracking scripts, data layers, and event-driven APIs to support advanced analytics and remarketing capabilities.</li>
+            <li>Established and enforced tagging taxonomies across hundreds of web properties, ensuring scalable, efficient, and accurate data capture.</li>
+            <li>Built automated tag audit and reporting processes, enabling faster detection and resolution of data discrepancies.</li>
+            <li>Partnered with BI teams to create data validation dashboards, ensuring parity across Amplitude, Adobe, and other analytics platforms.</li>
+            <li>Delivered training and documentation to marketing and engineering teams on analytics QA, debugging, and tag management.</li>
+            <li>Led troubleshooting for complex cross-domain tracking, SDK integrations, and server-side event routing.</li>
+          </ul>
+          <p><strong>Key Skills:</strong> Adobe Analytics • Google Analytics • GTM • Data Layer Design • Tag Management • JavaScript • API Integrations • BI Reporting • Cross-Domain Tracking • Analytics QA • Compliance Awareness • Performance Optimization</p>
         </div>
       </article>
 
@@ -25,7 +45,16 @@ import Layout from '../layouts/Layout.astro';
         <div class="label">2016&ndash;2018</div>
         <div>
           <h2>Technical Support &middot; MMC</h2>
-          <p>Managed distributed crypto mining infrastructure. Deployed SMB networks, monitored performance, and documented compliance and operations.</p>
+          <p>Provided technical operations, networking, and support for a distributed crypto mining infrastructure, ensuring uptime, performance, and compliance across multiple remote sites.</p>
+          <ul>
+            <li>Designed, deployed, and managed SMB networks and remote monitoring for 25+ mining systems.</li>
+            <li>Monitored performance and capacity to prevent overload and maintain optimal uptime.</li>
+            <li>Coordinated hardware planning, procurement, and replacement to maintain operational capacity.</li>
+            <li>Performed firmware updates, version locking, and preventive maintenance.</li>
+            <li>Created and maintained compliance and operational documentation for systems and processes.</li>
+            <li>Worked cross-functionally with operations, engineering, and vendors to align technical needs with business goals.</li>
+          </ul>
+          <p><strong>Key Skills:</strong> Networking • Remote Monitoring • Hardware Planning • Compliance Documentation • Performance Optimization</p>
         </div>
       </article>
 
@@ -33,15 +62,14 @@ import Layout from '../layouts/Layout.astro';
         <div class="label">2014&ndash;2016</div>
         <div>
           <h2>Support Specialist &middot; Maletis Beverage</h2>
-          <p>Provided Tier 1 &amp; 2 IT support for hardware, software, and network issues. Assisted with system upgrades and maintained business continuity.</p>
-        </div>
-      </article>
-
-      <article class="card span-12">
-        <div class="label">2013&ndash;2014</div>
-        <div>
-          <h2>Cyber System Operations &middot; United States Air Force</h2>
-          <p>Installed and managed server applications and storage solutions while maintaining operational security for USAF missions.</p>
+          <p>Delivered IT and operational support for a regional beverage distributor, ensuring continuity of business systems and technical workflows.</p>
+          <ul>
+            <li>Provided Tier 1 &amp; 2 technical support for hardware, software, and network issues.</li>
+            <li>Supported inventory, distribution, and sales systems to maintain operational flow.</li>
+            <li>Assisted with system upgrades and deployments, minimizing downtime.</li>
+            <li>Maintained clear communication with non-technical staff to quickly resolve issues.</li>
+          </ul>
+          <p><strong>Key Skills:</strong> Technical Support • System Deployment • Troubleshooting • Communication Skills</p>
         </div>
       </article>
     </div>


### PR DESCRIPTION
## Summary
- expand About page with detailed professional overview, core strengths, and specialties
- deepen Work page descriptions and remove Air Force entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68ad4e7e53788323bf9e3fa428177650