### PR TITLE
Add analytics sandbox examples

### DIFF
--- a/src/pages/lab/analytics/adobe-analytics.astro
+++ b/src/pages/lab/analytics/adobe-analytics.astro
@@ -1,0 +1,36 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+<Layout title="Adobe Analytics">
+  <div class="container">
+    <h1>Adobe Analytics Sandbox</h1>
+    <p>Example AppMeasurement setup and link tracking.</p>
+    <button id="adobe-button">Track Button</button>
+    <a href="#" id="adobe-link">Track Link</a>
+    <form id="adobe-form">
+      <input type="text" name="example" />
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+  <script src="https://example.com/AppMeasurement.js"></script>
+  <script>
+    var s = {
+      tl: function(el, type, name){},
+      t: function(){},
+    };
+    s.t();
+    const button = document.getElementById('adobe-button');
+    const link = document.getElementById('adobe-link');
+    const form = document.getElementById('adobe-form');
+    button.addEventListener('click', () => {
+      s.tl(true, 'o', 'Adobe Button');
+    });
+    link.addEventListener('click', () => {
+      s.tl(true, 'o', 'Adobe Link');
+    });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      s.tl(true, 'o', 'Adobe Form');
+    });
+  </script>
+</Layout>

--- a/src/pages/lab/analytics/ga4-sandbox.astro
+++ b/src/pages/lab/analytics/ga4-sandbox.astro
@@ -1,0 +1,35 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+<Layout title="GA4 Sandbox">
+  <div class="container">
+    <h1>GA4 Sandbox</h1>
+    <p>Example base snippet and event tracking for Google Analytics 4.</p>
+    <button id="ga4-button">Track Button</button>
+    <a href="#" id="ga4-link">Track Link</a>
+    <form id="ga4-form">
+      <input type="text" name="example" />
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-XXXXXXXXXX');
+    const button = document.getElementById('ga4-button');
+    const link = document.getElementById('ga4-link');
+    const form = document.getElementById('ga4-form');
+    button.addEventListener('click', () => {
+      gtag('event', 'button_click', { 'event_label': 'GA4 Button' });
+    });
+    link.addEventListener('click', () => {
+      gtag('event', 'link_click', { 'event_label': 'GA4 Link' });
+    });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      gtag('event', 'form_submit', { 'event_label': 'GA4 Form' });
+    });
+  </script>
+</Layout>

--- a/src/pages/lab/analytics/gtm-sandbox.astro
+++ b/src/pages/lab/analytics/gtm-sandbox.astro
@@ -1,0 +1,39 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+<Layout title="GTM Sandbox">
+  <div class="container">
+    <h1>GTM Sandbox</h1>
+    <p>Google Tag Manager base code with event tracking.</p>
+    <button id="gtm-button">Track Button</button>
+    <a href="#" id="gtm-link">Track Link</a>
+    <form id="gtm-form">
+      <input type="text" name="example" />
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-XXXXXXX');
+  </script>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <script>
+    const button = document.getElementById('gtm-button');
+    const link = document.getElementById('gtm-link');
+    const form = document.getElementById('gtm-form');
+    button.addEventListener('click', () => {
+      dataLayer.push({event: 'button_click', label: 'GTM Button'});
+    });
+    link.addEventListener('click', () => {
+      dataLayer.push({event: 'link_click', label: 'GTM Link'});
+    });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      dataLayer.push({event: 'form_submit', label: 'GTM Form'});
+    });
+  </script>
+</Layout>

--- a/src/pages/lab/analytics/index.md
+++ b/src/pages/lab/analytics/index.md
@@ -4,4 +4,13 @@ title: "Analytics"
 ---
 <div class="container">
   <h1>Analytics</h1>
+  <ul>
+    <li><a href="/lab/analytics/ga4-sandbox/">GA4 Sandbox</a></li>
+    <li><a href="/lab/analytics/gtm-sandbox/">GTM Sandbox</a></li>
+    <li><a href="/lab/analytics/adobe-analytics/">Adobe Analytics</a></li>
+    <li><a href="/lab/analytics/x-pixel/">X Pixel</a></li>
+    <li><a href="/lab/analytics/meta-pixel/">Meta Pixel</a></li>
+    <li><a href="/lab/analytics/linkedin-pixel/">LinkedIn Pixel</a></li>
+    <li><a href="/lab/analytics/unified-data-layer/">Unified Data Layer</a></li>
+  </ul>
 </div>

--- a/src/pages/lab/analytics/linkedin-pixel.astro
+++ b/src/pages/lab/analytics/linkedin-pixel.astro
@@ -1,0 +1,47 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+<Layout title="LinkedIn Pixel">
+  <div class="container">
+    <h1>LinkedIn Pixel Sandbox</h1>
+    <p>LinkedIn Insight Tag base snippet with event tracking.</p>
+    <button id="linkedin-button">Track Button</button>
+    <a href="#" id="linkedin-link">Track Link</a>
+    <form id="linkedin-form">
+      <input type="text" name="example" />
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+  <script type="text/javascript">
+    _linkedin_partner_id = "LINKEDIN-ID";
+    window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+    window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+  </script>
+  <script type="text/javascript">
+    (function(l) {
+      if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+      window.lintrk.q=[]}
+      var s = document.getElementsByTagName("script")[0];
+      var b = document.createElement("script");
+      b.type = "text/javascript";b.async = true;
+      b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+      s.parentNode.insertBefore(b, s);
+    })(window.lintrk);
+    const button = document.getElementById('linkedin-button');
+    const link = document.getElementById('linkedin-link');
+    const form = document.getElementById('linkedin-form');
+    button.addEventListener('click', () => {
+      lintrk('track', { conversion_id: 1 });
+    });
+    link.addEventListener('click', () => {
+      lintrk('track', { conversion_id: 2 });
+    });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      lintrk('track', { conversion_id: 3 });
+    });
+  </script>
+  <noscript>
+    <img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=LINKEDIN-ID&fmt=gif" />
+  </noscript>
+</Layout>

--- a/src/pages/lab/analytics/meta-pixel.astro
+++ b/src/pages/lab/analytics/meta-pixel.astro
@@ -1,0 +1,38 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+<Layout title="Meta Pixel">
+  <div class="container">
+    <h1>Meta Pixel Sandbox</h1>
+    <p>Meta Pixel base snippet with event tracking.</p>
+    <button id="meta-button">Track Button</button>
+    <a href="#" id="meta-link">Track Link</a>
+    <form id="meta-form">
+      <input type="text" name="example" />
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+  <script>
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', 'META-PIXEL-ID');
+    fbq('track', 'PageView');
+    const button = document.getElementById('meta-button');
+    const link = document.getElementById('meta-link');
+    const form = document.getElementById('meta-form');
+    button.addEventListener('click', () => {
+      fbq('track','ButtonClick');
+    });
+    link.addEventListener('click', () => {
+      fbq('track','LinkClick');
+    });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      fbq('track','FormSubmit');
+    });
+  </script>
+  <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=META-PIXEL-ID&ev=PageView&noscript=1"/></noscript>
+</Layout>

--- a/src/pages/lab/analytics/unified-data-layer.astro
+++ b/src/pages/lab/analytics/unified-data-layer.astro
@@ -1,0 +1,34 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+<Layout title="Unified Data Layer">
+  <div class="container">
+    <h1>Unified Data Layer</h1>
+    <p>Example data layer pattern with custom events.</p>
+    <button id="udl-button">Track Button</button>
+    <a href="#" id="udl-link">Track Link</a>
+    <form id="udl-form">
+      <input type="text" name="example" />
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function track(eventName, detail) {
+      window.dataLayer.push({ event: eventName, ...detail });
+    }
+    const button = document.getElementById('udl-button');
+    const link = document.getElementById('udl-link');
+    const form = document.getElementById('udl-form');
+    button.addEventListener('click', () => {
+      track('button_click', { label: 'UDL Button' });
+    });
+    link.addEventListener('click', () => {
+      track('link_click', { label: 'UDL Link' });
+    });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      track('form_submit', { label: 'UDL Form' });
+    });
+  </script>
+</Layout>

--- a/src/pages/lab/analytics/x-pixel.astro
+++ b/src/pages/lab/analytics/x-pixel.astro
@@ -1,0 +1,32 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+---
+<Layout title="X Pixel">
+  <div class="container">
+    <h1>X Pixel Sandbox</h1>
+    <p>Twitter Pixel base snippet with event tracking.</p>
+    <button id="x-button">Track Button</button>
+    <a href="#" id="x-link">Track Link</a>
+    <form id="x-form">
+      <input type="text" name="example" />
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+  <script>
+    !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);},s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
+    twq('config','TW-XXXXXXXXXX');
+    const button = document.getElementById('x-button');
+    const link = document.getElementById('x-link');
+    const form = document.getElementById('x-form');
+    button.addEventListener('click', () => {
+      twq('event','button_click');
+    });
+    link.addEventListener('click', () => {
+      twq('event','link_click');
+    });
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      twq('event','form_submit');
+    });
+  </script>
+</Layout>


### PR DESCRIPTION
## Summary
- add GA4 and GTM sandbox pages with sample event tracking
- include Adobe, X, Meta, and LinkedIn pixel examples
- provide unified data layer demo and update analytics index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68ad4e453304832390b3cb3760e1b500