### PR TITLE
style: align nav background with theme and refine links

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -105,7 +105,7 @@ const { title } = Astro.props;
       gap: var(--space-2);
       color: var(--frame-color);
 
-      background: #fff;
+      background: var(--color-bg);
       padding: var(--space-1) var(--space-2);
 
     }
@@ -122,7 +122,7 @@ const { title } = Astro.props;
       left: 0;
       right: 0;
 
-      background: #fff;
+      background: var(--color-bg);
 
       padding: var(--space-2);
       justify-content: space-between;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -186,7 +186,8 @@ nav ul {
 
 nav a {
   color: var(--color-text);
-  text-decoration: underline;
+  text-decoration: none;
+  font-weight: 700;
 }
 
 nav .brand {


### PR DESCRIPTION
## Summary
- match hero navigation background to site background color
- bold navigation links and remove underlines for clarity

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Missing script "lint" )*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68ad4f65b13883238974536067fb2227