### PR TITLE
fix blog pagination initialization and align article spacing

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -32,7 +32,7 @@ const postsPerPage = 2;
       </section>
     )}
 
-    <div id="posts" class="grid">
+    <div id="posts" class="grid" data-posts-per-page={postsPerPage}>
       {posts.map(post => (
         <article class="card post-card span-6" data-tags={post.data.tags.join(',')} data-title={post.data.title.toLowerCase()} data-description={post.data.description.toLowerCase()}>
           <div class="label mono">{post.data.pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</div>
@@ -51,7 +51,8 @@ const postsPerPage = 2;
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const posts = Array.from(document.querySelectorAll('.post-card'));
-      const postsPerPage = {postsPerPage};
+      const postsContainer = document.getElementById('posts');
+      const POSTS_PER_PAGE = parseInt(postsContainer?.dataset.postsPerPage || '1', 10);
       let currentPage = 1;
       const selectedTags = new Set();
 
@@ -73,10 +74,10 @@ const postsPerPage = 2;
 
       function paginate() {
         const visiblePosts = posts.filter(p => !p.hidden);
-        const totalPages = Math.ceil(visiblePosts.length / postsPerPage) || 1;
+        const totalPages = Math.ceil(visiblePosts.length / POSTS_PER_PAGE) || 1;
         visiblePosts.forEach((post, index) => {
-          const start = (currentPage - 1) * postsPerPage;
-          const end = start + postsPerPage;
+          const start = (currentPage - 1) * POSTS_PER_PAGE;
+          const end = start + POSTS_PER_PAGE;
           post.style.display = index >= start && index < end ? '' : 'none';
         });
         pagination.innerHTML = '';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -83,6 +83,10 @@ hr {
   margin: 0;
 }
 
+article {
+  padding: var(--space-2);
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-sans);
   margin-top: 0;


### PR DESCRIPTION
## Summary
- fix ReferenceError in blog pagination script by reading posts-per-page from the DOM
- give all `<article>` elements consistent padding for uniform layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68ad52179a64832392b08a5899dd701e