### PR TITLE
Redesign Lab index with theme-aligned cards

### DIFF
--- a/src/pages/lab/index.md
+++ b/src/pages/lab/index.md
@@ -4,11 +4,41 @@ title: "Lab"
 ---
 <div class="container">
   <h1>Lab</h1>
-  <ul>
-    <li><a href="/lab/ai/">AI</a></li>
-    <li><a href="/lab/analytics/">Analytics</a></li>
-    <li><a href="/lab/ads/">Ads</a></li>
-    <li><a href="/lab/marketing/">Marketing</a></li>
-    <li><a href="/lab/art/">Art</a></li>
-  </ul>
+  <div class="grid">
+    <article class="card span-4">
+      <div class="label mono">001</div>
+      <div>
+        <h2><a href="/lab/ai/">AI</a></h2>
+        <p>Machine learning and generative models.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">002</div>
+      <div>
+        <h2><a href="/lab/analytics/">Analytics</a></h2>
+        <p>Measurement, instrumentation, and data design.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">003</div>
+      <div>
+        <h2><a href="/lab/ads/">Ads</a></h2>
+        <p>Ad tech experiments and campaign tooling.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">004</div>
+      <div>
+        <h2><a href="/lab/marketing/">Marketing</a></h2>
+        <p>Growth, messaging, and audience strategy.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">005</div>
+      <div>
+        <h2><a href="/lab/art/">Art</a></h2>
+        <p>Generative art, design, and visual studies.</p>
+      </div>
+    </article>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- replace bullet list on Lab index with a grid of numbered cards that match site style

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad5984cc1883238594c631f678e11a