### PR TITLE
Prefix page titles with welcome tagline

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,7 +15,7 @@ const {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
-    <title>{title}</title>
+    <title>Welcome / {title}</title>
   </head>
   <body>
     {showNav && <Nav />}


### PR DESCRIPTION
## Summary
- Prefix page `<title>` tags with `Welcome /` for a consistent tab tagline

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68ad5a9dde008323afc136bffa9f9262