### PR TITLE
fix: streamline blog card layout

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -289,6 +289,11 @@ nav .mode {
   color: var(--color-link);
 }
 
+/* Blog post cards use a single-column layout */
+.post-card {
+  grid-template-columns: 1fr;
+}
+
 /* Panel */
 .panel {
   position: relative;


### PR DESCRIPTION
## Summary
- simplify blog post card layout to avoid empty columns and keep text stacked

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad5b0d9b708323862f5d31c5e51cbb