### PR TITLE
Prefix page titles with welcome tagline

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,12 +2,18 @@
 import '../styles/global.css';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+
 const {
-  title = 'Retro Site',
-  description = 'Interstellar web projects by Joshua Wiedeman.',
+  title: propTitle,
+  description: propDescription,
   showNav = true,
-  showFooter = true
+  showFooter = true,
+  frontmatter = {}
 } = Astro.props;
+
+const title = propTitle ?? frontmatter.title ?? 'JWiedeman';
+const description =
+  propDescription ?? frontmatter.description ?? 'Interstellar web projects by Joshua Wiedeman.';
 ---
 <!DOCTYPE html>
 <html lang="en" class="theme-light">
@@ -15,7 +21,7 @@ const {
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
-    <title>{title}</title>
+    <title>Welcome / {title}</title>
   </head>
   <body>
     {showNav && <Nav />}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,6 @@
 import Layout from '../layouts/Layout.astro';
 import Hero from '../components/Hero.astro';
 ---
-<Layout title="jwiedeman retro site" description="Interstellar web projects and experiments by Joshua Wiedeman." showNav={false} showFooter={false}>
+<Layout title="JWiedeman" description="Interstellar web projects and experiments by Joshua Wiedeman." showNav={false} showFooter={false}>
   <Hero title="JWIEDEMAN" />
 </Layout>


### PR DESCRIPTION
## Summary
- Prefix page `<title>` tags with `Welcome /` for a consistent tab tagline
- Set a site-wide default title of `JWiedeman` and update the homepage title to remove the old "retro site" text
- Read Markdown frontmatter in the layout so pages like About and Contact show their own titles instead of the fallback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_e_68ad5a9dde008323afc136bffa9f9262