### PR TITLE
fix: initialize blog filters reliably

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -49,10 +49,11 @@ const postsPerPage = 4;
   </div>
 
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    function init() {
       const postsContainer = document.getElementById('posts');
+      if (!postsContainer) return;
       const posts = Array.from(postsContainer.querySelectorAll('.post-card'));
-      const POSTS_PER_PAGE = parseInt(postsContainer?.dataset.postsPerPage || '1', 10);
+      const POSTS_PER_PAGE = parseInt(postsContainer.dataset.postsPerPage || '1', 10);
       let currentPage = 1;
       const selectedTags = new Set();
 
@@ -61,10 +62,10 @@ const postsPerPage = 4;
       const pagination = document.getElementById('pagination');
 
       function filterPosts() {
-        const q = searchInput.value.toLowerCase();
+        const q = searchInput?.value.toLowerCase() || '';
         posts.forEach(post => {
-          const matchesSearch = post.dataset.title.includes(q) || post.dataset.description.includes(q);
-          const tags = post.dataset.tags.split(',').map(t => t.trim());
+          const matchesSearch = post.dataset.title?.includes(q) || post.dataset.description?.includes(q);
+          const tags = (post.dataset.tags || '').split(',').map(t => t.trim()).filter(Boolean);
           const matchesTags = [...selectedTags].every(tag => tags.includes(tag));
           post.hidden = !(matchesSearch && matchesTags);
         });
@@ -93,7 +94,7 @@ const postsPerPage = 4;
         }
       }
 
-      searchInput.addEventListener('input', filterPosts);
+      searchInput?.addEventListener('input', filterPosts);
       tagButtons.forEach(btn => {
         btn.addEventListener('click', () => {
           const tag = btn.dataset.tag;
@@ -109,6 +110,12 @@ const postsPerPage = 4;
       });
 
       filterPosts();
-    });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
   </script>
 </Layout>


### PR DESCRIPTION
## Summary
- ensure blog search and tag filtering initialize even if DOMContentLoaded already fired
- guard against missing elements when filtering posts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_68adf6443ed48323bfccbae6c406b9df