### PR TITLE
Expand AI lab portfolio entries

### DIFF
--- a/src/pages/lab/ai/index.md
+++ b/src/pages/lab/ai/index.md
@@ -4,6 +4,77 @@ title: "AI"
 ---
 <div class="container">
   <h1>AI</h1>
+  <p class="mono">Explorations in applied machine intelligence for real-world sensing, classification, and play.</p>
   <div class="grid">
+    <article class="card span-6">
+      <div class="label mono">AI-001</div>
+      <div>
+        <h2>Foot Traffic Intelligence</h2>
+        <p>
+          Multi-modal counting that fuses Wi-Fi probing, camera feeds, and door sensors to quantify movement across venues in near real time.
+        </p>
+        <ul>
+          <li>On-device processing keeps raw imagery private while streaming anonymized vectors to the edge.</li>
+          <li>Forecast module predicts surges so staff can stage resources before congestion starts.</li>
+          <li>Output dashboards plug into the analytics stack already deployed in the lab.</li>
+        </ul>
+      </div>
+    </article>
+    <article class="card span-6">
+      <div class="label mono">AI-002</div>
+      <div>
+        <h2>Mycology Classification</h2>
+        <p>
+          A fine-tuned vision transformer that learns from herbarium scans, macro photography, and spore print imagery to identify fungal species.
+        </p>
+        <ul>
+          <li>Active learning loop requests new labels for ambiguous samples gathered in the field.</li>
+          <li>Outputs include toxicity risk bands, look-alike warnings, and habitat metadata.</li>
+          <li>Packaging targets a lightweight mobile inference bundle for offline use in forests.</li>
+        </ul>
+      </div>
+    </article>
+    <article class="card span-6">
+      <div class="label mono">AI-003</div>
+      <div>
+        <h2>Phone Agent</h2>
+        <p>
+          Voice-first assistant that triages inbound calls, schedules follow-ups, and writes CRM notes using speech-to-text, LLM reasoning, and calendar sync.
+        </p>
+        <ul>
+          <li>Conversational state machine guards tone, compliance, and fallback routing to humans.</li>
+          <li>Integrates with Twilio SIP endpoints and the lab’s analytics warehouse.</li>
+          <li>Fine-tunes prompts from anonymized transcripts to raise resolution rates.</li>
+        </ul>
+      </div>
+    </article>
+    <article class="card span-6">
+      <div class="label mono">AI-004</div>
+      <div>
+        <h2>Demo Arcade Intelligence</h2>
+        <p>
+          Competitive arcade sandbox where reinforcement learners iterate strategies while a player can drop in at any time to challenge the live leaderboard.
+        </p>
+        <ul>
+          <li>Best-performing agent trains continuously, publishing policy notes after each improvement.</li>
+          <li>Human mode loads the canonical game without assists so guests can attempt to dethrone the agent.</li>
+          <li>Results feed a shared scoreboard with telemetry explaining how each run was achieved.</li>
+        </ul>
+      </div>
+    </article>
+    <article class="card span-6">
+      <div class="label mono">AI-005</div>
+      <div>
+        <h2>Mushroom Forecasting Alerts</h2>
+        <p>
+          Probabilistic growth model that ingests NOAA weather feeds, soil sensors, and phenology logs to forecast which species will fruit within a radius.
+        </p>
+        <ul>
+          <li>Users set distance thresholds and species lists; alerts trigger when humidity and heat align with a species’ fruiting profile.</li>
+          <li>Spatial tiles combine habitat suitability with recent mycology classification sightings.</li>
+          <li>Designed as a “weather-style” notification system that surfaces safe-foraging windows.</li>
+        </ul>
+      </div>
+    </article>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- flesh out the Lab → AI page with detailed project briefs for five applied intelligence initiatives
- highlight foot traffic analytics, mycology classification, phone agent operations, competitive arcade training, and mushroom growth forecasting concepts

## Testing
- npm test *(fails: Missing script: "test")*
- npm run lint *(fails: Missing script: "lint")*
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4321 *(manually terminated with Ctrl+C after verifying startup)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fcc1a69c83239f31e6f8bcd6cb58