### PR TITLE
Add breadcrumb slug trail under navigation

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -14,6 +14,19 @@ const {
 const title = propTitle ?? frontmatter.title ?? 'JWiedeman';
 const description =
   propDescription ?? frontmatter.description ?? 'Interstellar web projects by Joshua Wiedeman.';
+
+const pathSegments = Astro.url.pathname.split('/').filter(Boolean);
+const slugParts = pathSegments
+  .map((segment) =>
+    decodeURIComponent(segment)
+      .replace(/-/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase()
+  )
+  .filter(Boolean);
+const slugTrail = slugParts.join(' > ');
+const shouldShowSlug = showNav && slugTrail.length > 0;
 ---
 <!DOCTYPE html>
 <html lang="en" class="theme-light">
@@ -25,6 +38,11 @@ const description =
   </head>
   <body>
     {showNav && <Nav />}
+    {shouldShowSlug && (
+      <div class="slug-trail hairline-bottom">
+        <div class="container mono">{slugTrail}</div>
+      </div>
+    )}
     <main>
       <slot />
     </main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -212,6 +212,15 @@ nav .mode {
   text-transform: uppercase;
 }
 
+.slug-trail .container {
+  padding-top: var(--space-1);
+  padding-bottom: var(--space-1);
+  font-size: var(--text-12);
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  text-transform: none;
+}
+
 @media (max-width: 600px) {
   nav .container {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- derive a slug trail from the current route and render it beneath the site navigation on non-home pages
- style the slug trail to match the existing NASA-inspired UI spacing and typography

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4321

------
https://chatgpt.com/codex/tasks/task_e_68e2fe8459ac8323a9cf38cb2654d785