### PR TITLE
feat: expand meta pixel sandbox instrumentation

### DIFF
--- a/src/pages/lab/analytics/meta-pixel.astro
+++ b/src/pages/lab/analytics/meta-pixel.astro
@@ -1,38 +1,519 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
 ---
-<Layout title="Meta Pixel">
-  <div class="container">
-    <h1>Meta Pixel Sandbox</h1>
-    <p>Meta Pixel base snippet with event tracking.</p>
-    <button id="meta-button">Track Button</button>
-    <a href="#" id="meta-link">Track Link</a>
-    <form id="meta-form">
-      <input type="text" name="example" />
-      <button type="submit">Submit</button>
-    </form>
+<Layout title="Meta Pixel Sandbox">
+  <div class="container meta-sandbox">
+    <header class="meta-header">
+      <h1>Meta Pixel Instrumentation Sandbox</h1>
+      <p>
+        A hands-on view of how Meta Pixel events are applied to individual interface elements. Trigger any
+        interaction to inspect the exact payload that would be transmitted to the Meta Events Manager.
+      </p>
+      <div class="meta-header__details">
+        <span class="mono">Pixel ID: META-PIXEL-ID</span>
+        <span class="mono">Test Event Code: META-SANDBOX</span>
+      </div>
+    </header>
+
+    <div class="meta-grid">
+      <section class="meta-panel">
+        <h2>Tracked interface elements</h2>
+        <p>
+          Each element below has data attributes that declare the Meta event name, interaction type, and
+          structured payload. These attributes are wired to <code>fbq('track')</code> calls inside the
+          sandbox script.
+        </p>
+
+        <article class="meta-card" data-meta-card>
+          <header>
+            <h3>Primary Call-to-Action</h3>
+            <p class="mono" data-meta-call>fbq('track', 'LaunchCTA')</p>
+          </header>
+          <p>
+            Simulates the main conversion action on a mission landing page. Useful for validating revenue
+            and priority metadata before launching a campaign.
+          </p>
+          <dl class="meta-card__meta">
+            <div>
+              <dt>Event</dt>
+              <dd class="mono">LaunchCTA</dd>
+            </div>
+            <div>
+              <dt>Interaction</dt>
+              <dd class="mono">click</dd>
+            </div>
+            <div>
+              <dt>Action Source</dt>
+              <dd class="mono">website</dd>
+            </div>
+          </dl>
+          <button
+            class="meta-action"
+            data-meta-event="LaunchCTA"
+            data-meta-interaction="click"
+            data-meta-payload='{"component":"cta","cta_label":"Initiate Launch Sequence","priority":"primary","value":1250,"currency":"USD"}'
+            data-meta-feedback="cta-status"
+          >
+            Initiate Launch Sequence
+          </button>
+          <p id="cta-status" class="meta-status">Idle — waiting for interaction.</p>
+          <details>
+            <summary class="mono">Payload blueprint</summary>
+            <pre class="meta-pre" data-meta-payload-preview></pre>
+          </details>
+        </article>
+
+        <article class="meta-card" data-meta-card>
+          <header>
+            <h3>Specification Link</h3>
+            <p class="mono" data-meta-call>fbq('track', 'ViewSpecifications')</p>
+          </header>
+          <p>
+            Represents a mid-funnel click to read a technical PDF. The payload records link context and
+            document classification for downstream attribution.
+          </p>
+          <dl class="meta-card__meta">
+            <div>
+              <dt>Event</dt>
+              <dd class="mono">ViewSpecifications</dd>
+            </div>
+            <div>
+              <dt>Interaction</dt>
+              <dd class="mono">click</dd>
+            </div>
+            <div>
+              <dt>Prevent default</dt>
+              <dd class="mono">true (demo only)</dd>
+            </div>
+          </dl>
+          <a
+            href="#"
+            class="meta-action meta-action--link"
+            data-meta-event="ViewSpecifications"
+            data-meta-interaction="click"
+            data-meta-prevent-default="true"
+            data-meta-payload='{"component":"document_link","destination":"mission-brief.pdf","content_category":"mission-overview","position":2}'
+            data-meta-feedback="link-status"
+          >
+            Download Mission Brief (PDF)
+          </a>
+          <p id="link-status" class="meta-status">Idle — waiting for interaction.</p>
+          <details>
+            <summary class="mono">Payload blueprint</summary>
+            <pre class="meta-pre" data-meta-payload-preview></pre>
+          </details>
+        </article>
+
+        <article class="meta-card" data-meta-card>
+          <header>
+            <h3>Qualified Lead Form</h3>
+            <p class="mono" data-meta-call>fbq('track', 'LeadSubmission')</p>
+          </header>
+          <p>
+            Mimics a short lead capture form with hashed identifiers. Submission is intercepted so you can
+            review the outgoing payload without leaving the page.
+          </p>
+          <dl class="meta-card__meta">
+            <div>
+              <dt>Event</dt>
+              <dd class="mono">LeadSubmission</dd>
+            </div>
+            <div>
+              <dt>Interaction</dt>
+              <dd class="mono">submit</dd>
+            </div>
+            <div>
+              <dt>Identifiers</dt>
+              <dd class="mono">SHA-256 placeholders</dd>
+            </div>
+          </dl>
+          <form
+            class="meta-form"
+            data-meta-event="LeadSubmission"
+            data-meta-interaction="submit"
+            data-meta-prevent-default="true"
+            data-meta-payload='{"form_id":"lead-capture-sandbox","lead_type":"enterprise","advanced_matching":{"email":"4b825dc642cb6eb9a060e54bf8d69288","external_id":"9f5738f9c2d64f7fa2cb"}}'
+            data-meta-feedback="form-status"
+          >
+            <label>
+              Mission Focus
+              <select name="mission_focus">
+                <option value="orbital">Orbital Research</option>
+                <option value="deep-space">Deep Space Comms</option>
+                <option value="earth-observation">Earth Observation</option>
+              </select>
+            </label>
+            <label>
+              Mission Email (hashed)
+              <input type="text" name="hashed_email" value="4b825dc642cb6eb9a060e54bf8d69288" readonly />
+            </label>
+            <button type="submit" class="meta-action">Transmit Lead</button>
+          </form>
+          <p id="form-status" class="meta-status">Idle — waiting for interaction.</p>
+          <details>
+            <summary class="mono">Payload blueprint</summary>
+            <pre class="meta-pre" data-meta-payload-preview></pre>
+          </details>
+        </article>
+      </section>
+
+      <aside class="meta-console">
+        <h2>Mock transmission console</h2>
+        <p>
+          Shows the raw request body that would be delivered to the Meta Events API. Messages are generated
+          locally so no network traffic leaves this sandbox.
+        </p>
+        <div class="meta-console__log" data-meta-console aria-live="polite">
+          <div class="meta-console__empty" data-meta-empty>
+            Awaiting transmissions. Trigger any element to populate this feed.
+          </div>
+        </div>
+      </aside>
+    </div>
   </div>
+
+  <style>
+    .meta-sandbox {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+      padding-top: var(--space-4);
+      padding-bottom: var(--space-5);
+    }
+
+    .meta-header {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      background: rgba(17, 17, 17, 0.04);
+      border: 1px solid var(--color-rule);
+      padding: var(--space-3);
+    }
+
+    .meta-header__details {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-2);
+    }
+
+    .meta-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+      gap: var(--space-4);
+    }
+
+    .meta-panel {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-3);
+    }
+
+    .meta-panel > p {
+      margin: 0;
+    }
+
+    .meta-card {
+      border: 1px solid var(--color-rule);
+      background: var(--color-bg);
+      padding: var(--space-3);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .meta-card header h3 {
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: var(--space-1);
+    }
+
+    .meta-card__meta {
+      display: grid;
+      gap: var(--space-1);
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      margin: 0;
+    }
+
+    .meta-card__meta dt {
+      font-size: var(--text-12);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-muted);
+    }
+
+    .meta-card__meta dd {
+      margin: 0;
+    }
+
+    .meta-action {
+      font-family: var(--font-sans);
+      font-size: var(--text-16);
+      background: var(--color-text);
+      color: var(--color-bg);
+      border: none;
+      padding: var(--space-2);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      cursor: pointer;
+      transition: background 0.2s ease, transform 0.2s ease;
+    }
+
+    .meta-action:hover,
+    .meta-action:focus {
+      background: var(--color-accent);
+      outline: none;
+    }
+
+    .meta-action:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 2px;
+    }
+
+    .meta-action--link {
+      display: inline-block;
+      text-decoration: none;
+      text-align: center;
+    }
+
+    .meta-action--fired {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+    }
+
+    .meta-status {
+      font-size: var(--text-14);
+      color: var(--color-muted);
+      margin: 0;
+    }
+
+    .meta-pre {
+      background: rgba(17, 17, 17, 0.06);
+      border: 1px solid var(--color-rule);
+      padding: var(--space-2);
+      overflow-x: auto;
+      font-size: var(--text-14);
+    }
+
+    .meta-form {
+      display: grid;
+      gap: var(--space-2);
+      margin-top: var(--space-1);
+    }
+
+    .meta-form label {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-1);
+      font-size: var(--text-14);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .meta-form select,
+    .meta-form input {
+      padding: var(--space-1);
+      border: 1px solid var(--color-rule);
+      background: #fff;
+      font-size: var(--text-16);
+      font-family: var(--font-sans);
+    }
+
+    .meta-console {
+      border: 1px solid var(--color-rule);
+      background: rgba(17, 17, 17, 0.02);
+      padding: var(--space-3);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      max-height: 100%;
+      position: sticky;
+      top: var(--space-4);
+      align-self: flex-start;
+    }
+
+    .meta-console__log {
+      display: grid;
+      gap: var(--space-2);
+      max-height: 520px;
+      overflow: auto;
+      padding-right: var(--space-1);
+      border-top: 1px solid var(--color-rule);
+      padding-top: var(--space-2);
+    }
+
+    .meta-console__empty {
+      color: var(--color-muted);
+      font-size: var(--text-14);
+    }
+
+    .console-entry {
+      border: 1px solid var(--color-rule);
+      background: var(--color-bg);
+      padding: var(--space-2);
+      display: grid;
+      gap: var(--space-1);
+    }
+
+    .console-entry__header {
+      font-size: var(--text-14);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .console-entry pre {
+      margin: 0;
+      font-size: var(--text-14);
+      background: rgba(17, 17, 17, 0.04);
+      border: 1px solid var(--color-rule);
+      padding: var(--space-1);
+      overflow-x: auto;
+    }
+
+    @media (max-width: 1024px) {
+      .meta-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .meta-console {
+        position: static;
+      }
+    }
+  </style>
+
   <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-    n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
-    n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
-    t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script',
-    'https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', 'META-PIXEL-ID');
-    fbq('track', 'PageView');
-    const button = document.getElementById('meta-button');
-    const link = document.getElementById('meta-link');
-    const form = document.getElementById('meta-form');
-    button.addEventListener('click', () => {
-      fbq('track','ButtonClick');
+    const metaPixelId = 'META-PIXEL-ID';
+    const metaEndpoint = `https://graph.facebook.com/v18.0/${metaPixelId}/events`;
+    const testEventCode = 'META-SANDBOX';
+
+    const consoleLog = document.querySelector('[data-meta-console]');
+    const emptyState = document.querySelector('[data-meta-empty]');
+
+    const prettyJson = (value) => JSON.stringify(value, null, 2);
+
+    const pushConsoleEntry = (summary, body) => {
+      if (emptyState) {
+        emptyState.remove();
+      }
+
+      const entry = document.createElement('article');
+      entry.className = 'console-entry';
+
+      const header = document.createElement('div');
+      header.className = 'console-entry__header mono';
+      const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
+      header.textContent = `${timestamp} · ${summary}`;
+
+      const payloadBlock = document.createElement('pre');
+      payloadBlock.textContent = body;
+
+      entry.append(header, payloadBlock);
+      consoleLog.prepend(entry);
+
+      const entries = consoleLog.querySelectorAll('.console-entry');
+      if (entries.length > 8) {
+        entries[entries.length - 1].remove();
+      }
+    };
+
+    const fbq = (command, ...args) => {
+      if (command === 'track') {
+        const [eventName, parameters = {}] = args;
+        const payload = {
+          data: [
+            {
+              event_name: eventName,
+              event_time: Math.floor(Date.now() / 1000),
+              event_source_url: window.location.href,
+              action_source: 'website',
+              custom_data: parameters,
+            },
+          ],
+          test_event_code: testEventCode,
+        };
+
+        pushConsoleEntry(
+          `POST ${eventName}`,
+          prettyJson({ method: 'POST', url: metaEndpoint, body: payload })
+        );
+      } else if (command === 'init') {
+        const [pixelId, advancedMatching = {}] = args;
+        pushConsoleEntry(
+          "fbq('init')",
+          prettyJson({ pixelId, advancedMatching })
+        );
+      } else {
+        pushConsoleEntry(
+          `fbq('${command}')`,
+          prettyJson({ command, args })
+        );
+      }
+    };
+
+    fbq.loaded = true;
+    fbq.version = '2.0';
+    fbq.queue = [];
+    window.fbq = fbq;
+    window._fbq = fbq;
+
+    const interactiveElements = document.querySelectorAll('[data-meta-event]');
+
+    const applyPayloadPreview = (element, payload) => {
+      const card = element.closest('[data-meta-card]');
+      if (!card) return;
+      const callLabel = card.querySelector('[data-meta-call]');
+      if (callLabel) {
+        callLabel.textContent = `fbq('track', '${element.dataset.metaEvent}', ${prettyJson(payload)})`;
+      }
+      const previewBlock = card.querySelector('[data-meta-payload-preview]');
+      if (previewBlock) {
+        previewBlock.textContent = prettyJson(payload);
+      }
+    };
+
+    const registerInteraction = (element) => {
+      const { metaEvent, metaInteraction, metaPreventDefault, metaFeedback } = element.dataset;
+      let payload = {};
+      try {
+        payload = element.dataset.metaPayload ? JSON.parse(element.dataset.metaPayload) : {};
+      } catch (error) {
+        payload = { error: 'Failed to parse payload', raw: element.dataset.metaPayload };
+      }
+
+      applyPayloadPreview(element, payload);
+
+      const interaction = metaInteraction || 'click';
+      element.addEventListener(interaction, (event) => {
+        if (metaPreventDefault === 'true') {
+          event.preventDefault();
+        }
+
+        fbq('track', metaEvent, payload);
+
+        element.classList.add('meta-action--fired');
+        window.setTimeout(() => {
+          element.classList.remove('meta-action--fired');
+        }, 320);
+
+        if (metaFeedback) {
+          const feedbackNode = document.getElementById(metaFeedback);
+          if (feedbackNode) {
+            const firedAt = new Date().toLocaleTimeString('en-US', { hour12: false });
+            feedbackNode.textContent = `Last fired at ${firedAt}`;
+          }
+        }
+      });
+    };
+
+    interactiveElements.forEach(registerInteraction);
+
+    fbq('init', metaPixelId, {
+      external_id: 'sandbox-visitor-0021',
+      email: 'a6f5c2f14bd54d90abca1b1c8b4123ff',
     });
-    link.addEventListener('click', () => {
-      fbq('track','LinkClick');
-    });
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      fbq('track','FormSubmit');
+
+    fbq('track', 'PageView', {
+      page_section: 'meta_pixel_sandbox',
+      environment: 'lab',
     });
   </script>
-  <noscript><img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=META-PIXEL-ID&ev=PageView&noscript=1"/></noscript>
 </Layout>


### PR DESCRIPTION
## Summary
- rebuild the Meta Pixel sandbox with a retro-themed two-column layout and instrumentation callouts
- annotate each interactive element with data attributes and payload previews that stay in sync with the demo
- add a mock transmission console that captures fbq commands and renders the outgoing Meta Events API payloads

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4321

------
https://chatgpt.com/codex/tasks/task_e_68e2ff31c6808323839e11ee0bb1b840