### PR TITLE
feat: improve breadcrumb navigation

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,18 +15,30 @@ const title = propTitle ?? frontmatter.title ?? 'JWiedeman';
 const description =
   propDescription ?? frontmatter.description ?? 'Interstellar web projects by Joshua Wiedeman.';
 
-const pathSegments = Astro.url.pathname.split('/').filter(Boolean);
-const slugParts = pathSegments
-  .map((segment) =>
-    decodeURIComponent(segment)
-      .replace(/-/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .toLowerCase()
-  )
-  .filter(Boolean);
-const slugTrail = slugParts.join(' > ');
-const shouldShowSlug = showNav && slugTrail.length > 0;
+const rawSegments = Astro.url.pathname.split('/').filter(Boolean);
+
+const formatSegment = (segment: string) => {
+  const cleaned = decodeURIComponent(segment)
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!cleaned) return '';
+
+  return cleaned
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
+const breadcrumbs = rawSegments
+  .map((segment, index) => ({
+    label: formatSegment(segment),
+    href: `/${rawSegments.slice(0, index + 1).join('/')}`,
+  }))
+  .filter(({ label }) => label.length > 0);
+
+const shouldShowBreadcrumbs = showNav && breadcrumbs.length > 0;
 ---
 <!DOCTYPE html>
 <html lang="en" class="theme-light">
@@ -38,10 +50,20 @@ const shouldShowSlug = showNav && slugTrail.length > 0;
   </head>
   <body>
     {showNav && <Nav />}
-    {shouldShowSlug && (
-      <div class="slug-trail hairline-bottom">
-        <div class="container mono">{slugTrail}</div>
-      </div>
+    {shouldShowBreadcrumbs && (
+      <nav class="slug-trail hairline-bottom" aria-label="Breadcrumb">
+        <ol class="container mono breadcrumb-list">
+          {breadcrumbs.map((crumb, index) => (
+            <li class="breadcrumb-item" key={crumb.href}>
+              {index < breadcrumbs.length - 1 ? (
+                <a href={crumb.href}>{crumb.label}</a>
+              ) : (
+                <span aria-current="page">{crumb.label}</span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
     )}
     <main>
       <slot />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -221,6 +221,45 @@ nav .mode {
   text-transform: none;
 }
 
+.slug-trail .breadcrumb-list {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.slug-trail .breadcrumb-item {
+  display: flex;
+  align-items: center;
+}
+
+.slug-trail .breadcrumb-item::after {
+  content: '›';
+  margin: 0 var(--space-1);
+  color: var(--color-muted);
+}
+
+.slug-trail .breadcrumb-item:last-child::after {
+  content: none;
+}
+
+.slug-trail .breadcrumb-item a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.slug-trail .breadcrumb-item a:hover,
+.slug-trail .breadcrumb-item a:focus {
+  text-decoration: underline;
+}
+
+.slug-trail [aria-current='page'] {
+  color: var(--color-text);
+  font-weight: 700;
+}
+
 @media (max-width: 600px) {
   nav .container {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- format breadcrumb segments with proper capitalization
- render the slug trail as an accessible, navigable breadcrumb list
- style breadcrumb links and separators to match the existing theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e30027d86083239626f082f4616343