### PR TITLE
Fix breadcrumb alignment by scoping nav styles

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,4 +1,4 @@
-<nav class="hairline-bottom">
+<nav class="primary-nav hairline-bottom">
   <div class="container">
     <a href="/" class="brand" data-astro-prefetch>JWIEDEMAN</a>
     <ul>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -52,17 +52,19 @@ const shouldShowBreadcrumbs = showNav && breadcrumbs.length > 0;
     {showNav && <Nav />}
     {shouldShowBreadcrumbs && (
       <nav class="slug-trail hairline-bottom" aria-label="Breadcrumb">
-        <ol class="container mono breadcrumb-list">
-          {breadcrumbs.map((crumb, index) => (
-            <li class="breadcrumb-item" key={crumb.href}>
-              {index < breadcrumbs.length - 1 ? (
-                <a href={crumb.href}>{crumb.label}</a>
-              ) : (
-                <span aria-current="page">{crumb.label}</span>
-              )}
-            </li>
-          ))}
-        </ol>
+        <div class="container mono">
+          <ol class="breadcrumb-list">
+            {breadcrumbs.map((crumb, index) => (
+              <li class="breadcrumb-item" key={crumb.href}>
+                {index < breadcrumbs.length - 1 ? (
+                  <a href={crumb.href}>{crumb.label}</a>
+                ) : (
+                  <span aria-current="page">{crumb.label}</span>
+                )}
+              </li>
+            ))}
+          </ol>
+        </div>
       </nav>
     )}
     <main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -156,7 +156,7 @@ main {
 }
 
 /* Navigation */
-nav .container {
+.primary-nav .container {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -180,7 +180,7 @@ nav .container {
   flex: 1;
 }
 
-nav ul {
+.primary-nav ul {
   list-style: none;
   display: flex;
   gap: var(--space-2);
@@ -188,20 +188,20 @@ nav ul {
   padding: 0;
 }
 
-nav a {
+.primary-nav a {
   color: var(--color-text);
   text-decoration: none;
   font-weight: 700;
 }
 
-nav .brand {
+.primary-nav .brand {
   font-weight: 700;
   font-size: var(--text-32);
   text-transform: uppercase;
   text-decoration: none;
 }
 
-nav .mode {
+.primary-nav .mode {
   font-size: var(--text-12);
   padding: var(--space-1) var(--space-2);
   border: none;
@@ -224,6 +224,8 @@ nav .mode {
 .slug-trail .breadcrumb-list {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
   gap: var(--space-1);
   list-style: none;
   padding: 0;
@@ -261,12 +263,12 @@ nav .mode {
 }
 
 @media (max-width: 600px) {
-  nav .container {
+  .primary-nav .container {
     flex-direction: column;
     align-items: flex-start;
     gap: var(--space-1);
   }
-  nav ul {
+  .primary-nav ul {
     flex-direction: column;
     width: 100%;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -229,7 +229,7 @@ main {
   gap: var(--space-1);
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 0 auto;
 }
 
 .slug-trail .breadcrumb-item {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -229,7 +229,7 @@ main {
   gap: var(--space-1);
   list-style: none;
   padding: 0;
-  margin: 0 auto;
+  margin: 0;
 }
 
 .slug-trail .breadcrumb-item {


### PR DESCRIPTION
## Summary
- scope the primary navigation markup with a `.primary-nav` class so its layout rules no longer bleed into breadcrumbs
- update the navigation CSS to target `.primary-nav` specifically and allow breadcrumb lists to wrap while staying left-aligned

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build
- npm run dev -- --host 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68e3013c9a008323ac3ac9fd4cb3478b