### PR TITLE
feat: unify analytics sandboxes

### DIFF
--- a/src/pages/lab/analytics/adobe-analytics.astro
+++ b/src/pages/lab/analytics/adobe-analytics.astro
@@ -1,40 +1,40 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
+import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="Adobe Analytics Sandbox">
-  <section class="container sandbox">
-    <header class="sandbox__header">
-      <p class="sandbox__eyebrow mono">LAB / ANALYTICS</p>
-      <h1>Adobe Analytics Instrumentation Sandbox</h1>
-      <p>
-        Explore how AppMeasurement calls fire across a miniature mission control interface. Trigger the
-        interactions on the left and watch the mock beacon payloads stream into the console on the right.
+  <div class="container analytics-sandbox adobe-sandbox">
+    <header class="sandbox-header hairline-bottom">
+      <p class="supertitle mono">Analytics Lab / Instrumentation</p>
+      <h1>Adobe Analytics Sandbox</h1>
+      <p class="intro">
+        Explore how AppMeasurement tracking fires across a miniature mission control interface. Engage the
+        components on the left and observe the simulated beacon payloads rendered in the console.
       </p>
+      <dl class="sandbox-meta">
+        <div>
+          <dt>Report suite</dt>
+          <dd class="mono">jwiedeman.sandbox</dd>
+        </div>
+        <div>
+          <dt>Endpoint</dt>
+          <dd class="mono">https://metrics-demo.sc.omtrdc.net/b/ss/.../s</dd>
+        </div>
+      </dl>
     </header>
 
-    <div class="grid sandbox__grid">
-      <section class="span-7 sandbox__panel">
-        <h2>Tracked elements</h2>
-        <p class="sandbox__intro">
-          Each component below mirrors a real implementation pattern. Inline notes surface the link names, link
-          types, and key variables bound to the interaction.
-        </p>
-
-        <article class="tracking-card" aria-labelledby="launch-cta-title">
-          <div class="tracking-card__meta">
-            <p id="launch-cta-title" class="tracking-card__title">Primary CTA &mdash; Launch Sequence</p>
-            <p class="tracking-card__summary mono">linkName: cta:launch-sequence &middot; linkType: o</p>
-          </div>
-          <button
-            id="aa-primary-cta"
-            class="tracking-card__action"
-            data-aa-component="mission-controls"
-            data-aa-role="primary-cta"
-            type="button"
-          >
-            Initiate Launch
-          </button>
-          <dl class="tracking-card__details">
+    <div class="sandbox-grid">
+      <section class="sandbox-panel">
+        <article class="sandbox-card adobe-card" aria-labelledby="adobe-cta-title">
+          <header>
+            <p id="adobe-cta-title" class="sandbox-card__tag mono">linkName: cta:launch-sequence · linkType: o</p>
+            <h3>Primary CTA — Launch sequence</h3>
+          </header>
+          <p>
+            Demonstrates a high-priority interaction within mission controls. The payload forwards event,
+            prop, eVar, and contextData bindings typical of conversion CTAs.
+          </p>
+          <dl class="sandbox-card__meta">
             <div>
               <dt>events</dt>
               <dd class="mono">event5</dd>
@@ -45,33 +45,35 @@ import Layout from '../../../layouts/Layout.astro';
             </div>
             <div>
               <dt>eVar4</dt>
-              <dd class="mono">Launch &mdash; Primary</dd>
+              <dd class="mono">Launch — Primary</dd>
             </div>
             <div>
               <dt>contextData</dt>
-              <dd class="mono">component=mission-controls, priority=primary</dd>
+              <dd class="mono">component=mission-controls · priority=primary</dd>
             </div>
           </dl>
-          <pre class="tracking-card__code mono">
-<span>s.tl(this, 'o', 'cta:launch-sequence', &#123; events: 'event5', prop4: 'launch:cta', eVar4: 'Launch — Primary', contextData: &#123; component: 'mission-controls', priority: 'primary' &#125; &#125;);</span>
-          </pre>
+          <button
+            id="aa-primary-cta"
+            class="sandbox-action"
+            data-aa-component="mission-controls"
+            data-aa-role="primary-cta"
+            type="button"
+          >
+            Initiate launch
+          </button>
+          <pre class="adobe-code mono">{`s.tl(this, 'o', 'cta:launch-sequence', { events: 'event5', prop4: 'launch:cta', eVar4: 'Launch — Primary', contextData: { component: 'mission-controls', priority: 'primary' } });`}</pre>
         </article>
 
-        <article class="tracking-card" aria-labelledby="nav-link-title">
-          <div class="tracking-card__meta">
-            <p id="nav-link-title" class="tracking-card__title">Secondary Link &mdash; Telemetry Logs</p>
-            <p class="tracking-card__summary mono">linkName: nav:telemetry-logs &middot; linkType: o</p>
-          </div>
-          <a
-            id="aa-secondary-link"
-            class="tracking-card__action tracking-card__action--link"
-            href="#"
-            data-aa-component="global-nav"
-            data-aa-role="secondary-link"
-          >
-            View Telemetry Logs
-          </a>
-          <dl class="tracking-card__details">
+        <article class="sandbox-card adobe-card" aria-labelledby="adobe-link-title">
+          <header>
+            <p id="adobe-link-title" class="sandbox-card__tag mono">linkName: nav:telemetry-logs · linkType: o</p>
+            <h3>Secondary link — Telemetry logs</h3>
+          </header>
+          <p>
+            Mirrors navigation link tracking with module metadata and contextData to label destination
+            hierarchies.
+          </p>
+          <dl class="sandbox-card__meta">
             <div>
               <dt>events</dt>
               <dd class="mono">event8</dd>
@@ -86,36 +88,31 @@ import Layout from '../../../layouts/Layout.astro';
             </div>
             <div>
               <dt>contextData</dt>
-              <dd class="mono">component=global-nav, destination=telemetry</dd>
+              <dd class="mono">component=global-nav · destination=telemetry</dd>
             </div>
           </dl>
-          <pre class="tracking-card__code mono">
-<span>s.tl(this, 'o', 'nav:telemetry-logs', &#123; events: 'event8', prop6: 'nav:telemetry', eVar6: 'Navigation Link', contextData: &#123; component: 'global-nav', destination: 'telemetry' &#125; &#125;);</span>
-          </pre>
+          <a
+            id="aa-secondary-link"
+            class="sandbox-link"
+            href="#"
+            data-aa-component="global-nav"
+            data-aa-role="secondary-link"
+          >
+            View telemetry logs
+          </a>
+          <pre class="adobe-code mono">{`s.tl(this, 'o', 'nav:telemetry-logs', { events: 'event8', prop6: 'nav:telemetry', eVar6: 'Navigation Link', contextData: { component: 'global-nav', destination: 'telemetry' } });`}</pre>
         </article>
 
-        <article class="tracking-card" aria-labelledby="form-title">
-          <div class="tracking-card__meta">
-            <p id="form-title" class="tracking-card__title">Form Submit &mdash; Telemetry Upload</p>
-            <p class="tracking-card__summary mono">linkName: form:telemetry-upload &middot; linkType: o</p>
-          </div>
-          <form
-            id="aa-telemetry-form"
-            class="tracking-card__form"
-            data-aa-component="telemetry"
-            data-aa-role="form"
-          >
-            <label class="mono" for="aa-telemetry-id">Mission ID</label>
-            <input id="aa-telemetry-id" name="missionId" type="text" placeholder="e.g. apollo-204" required />
-            <label class="mono" for="aa-telemetry-channel">Channel</label>
-            <select id="aa-telemetry-channel" name="channel">
-              <option value="orbital">Orbital</option>
-              <option value="lunar">Lunar</option>
-              <option value="deep-space">Deep Space</option>
-            </select>
-            <button class="tracking-card__action" type="submit">Upload Telemetry Packet</button>
-          </form>
-          <dl class="tracking-card__details">
+        <article class="sandbox-card adobe-card" aria-labelledby="adobe-form-title">
+          <header>
+            <p id="adobe-form-title" class="sandbox-card__tag mono">linkName: form:telemetry-upload · linkType: o</p>
+            <h3>Telemetry upload form</h3>
+          </header>
+          <p>
+            Captures a structured form submission including mission ID and channel selections. Prevents
+            default submission so you can inspect the payload inline.
+          </p>
+          <dl class="sandbox-card__meta">
             <div>
               <dt>events</dt>
               <dd class="mono">event12</dd>
@@ -130,21 +127,35 @@ import Layout from '../../../layouts/Layout.astro';
             </div>
             <div>
               <dt>contextData</dt>
-              <dd class="mono">component=telemetry, submission=form</dd>
+              <dd class="mono">component=telemetry · submission=form</dd>
             </div>
           </dl>
-          <pre class="tracking-card__code mono">
-<span>s.tl(this, 'o', 'form:telemetry-upload', &#123; events: 'event12', prop9: 'form:telemetry', eVar9: 'Telemetry Upload', contextData: &#123; component: 'telemetry', submission: 'form' &#125; &#125;);</span>
-          </pre>
+          <form
+            id="aa-telemetry-form"
+            class="sandbox-form"
+            data-aa-component="telemetry"
+            data-aa-role="form"
+          >
+            <label for="aa-telemetry-id">Mission ID</label>
+            <input id="aa-telemetry-id" name="missionId" type="text" placeholder="e.g. apollo-204" required />
+            <label for="aa-telemetry-channel">Channel</label>
+            <select id="aa-telemetry-channel" name="channel">
+              <option value="orbital">Orbital</option>
+              <option value="lunar">Lunar</option>
+              <option value="deep-space">Deep space</option>
+            </select>
+            <button class="sandbox-action" type="submit">Upload telemetry packet</button>
+          </form>
+          <pre class="adobe-code mono">{`s.tl(this, 'o', 'form:telemetry-upload', { events: 'event12', prop9: 'form:telemetry', eVar9: 'Telemetry Upload', contextData: { component: 'telemetry', submission: 'form' } });`}</pre>
         </article>
 
-        <section class="pageview-card" aria-labelledby="pageview-title">
-          <h2 id="pageview-title">Page load variables</h2>
+        <section class="sandbox-card adobe-card adobe-pageview" aria-labelledby="adobe-pageview-title">
+          <h2 id="adobe-pageview-title">Page load variables</h2>
           <p>
-            On load, <code class="mono">s.t()</code> seeds core classification variables for this sandbox view.
-            These frame the report suite, channel, and template metadata.
+            Initial <code>s.t()</code> call seeds persistent classification variables for this sandbox view.
+            These values frame the report suite, channel, and template metadata.
           </p>
-          <ul class="pageview-card__list mono">
+          <ul class="sandbox-list mono">
             <li>pageName = lab:analytics:adobe-analytics</li>
             <li>channel = lab</li>
             <li>eVar1 = Adobe Analytics Sandbox</li>
@@ -153,36 +164,28 @@ import Layout from '../../../layouts/Layout.astro';
             <li>contextData.page.missionPhase = demo</li>
             <li>contextData.page.template = sandbox</li>
           </ul>
-          <pre class="tracking-card__code mono">
-<span>s.t(&#123; pageName: 'lab:analytics:adobe-analytics', channel: 'lab', events: 'event1', prop1: 'lab:analytics', eVar1: 'Adobe Analytics Sandbox', contextData: &#123; 'page.missionPhase': 'demo', 'page.template': 'sandbox' &#125; &#125;);</span>
-          </pre>
+          <pre class="adobe-code mono">{`s.t({ pageName: 'lab:analytics:adobe-analytics', channel: 'lab', events: 'event1', prop1: 'lab:analytics', eVar1: 'Adobe Analytics Sandbox', contextData: { 'page.missionPhase': 'demo', 'page.template': 'sandbox' } });`}</pre>
         </section>
       </section>
 
-      <aside class="span-5 sandbox__panel sandbox__panel--console" aria-label="Adobe Analytics request console">
-        <div class="console__header">
-          <h2>Beacon payloads</h2>
-          <button type="button" class="console__reset" data-aa-reset>Clear log</button>
+      <aside class="sandbox-console adobe-console" aria-labelledby="adobe-console-heading">
+        <div class="adobe-console__header">
+          <h2 id="adobe-console-heading">Beacon payloads</h2>
+          <button type="button" class="sandbox-action adobe-reset" data-aa-reset>Clear log</button>
         </div>
-        <p class="console__description">
-          Mock requests to <code class="mono">https://metrics-demo.sc.omtrdc.net/b/ss/jwiedeman.sandbox/1/JS-2.23.0/s</code>.
-          Entries render as the raw query string plus the structured JSON payload for inspection.
+        <p>
+          Simulated requests to <code class="mono">https://metrics-demo.sc.omtrdc.net/b/ss/jwiedeman.sandbox/1/JS-2.23.0/s</code>.
+          Entries render the raw query string along with the structured JSON payload.
         </p>
-        <div
-          class="console__window mono"
-          data-aa-console
-          role="log"
-          aria-live="polite"
-          aria-relevant="additions"
-        >
-          <p class="console__empty">Awaiting Adobe Analytics activity&hellip;</p>
+        <div class="console-stream" data-aa-console role="log" aria-live="polite" aria-relevant="additions">
+          <p class="console-empty">Awaiting Adobe Analytics activity…</p>
         </div>
         <noscript>
-          <p class="console__noscript">Enable JavaScript to observe the simulated beacon output.</p>
+          <p class="console-empty">Enable JavaScript to observe the simulated beacon output.</p>
         </noscript>
       </aside>
     </div>
-  </section>
+  </div>
 
   <script type="module">
     const consoleWindow = document.querySelector('[data-aa-console]');
@@ -190,7 +193,7 @@ import Layout from '../../../layouts/Layout.astro';
     const endpoint = 'https://metrics-demo.sc.omtrdc.net/b/ss/jwiedeman.sandbox/1/JS-2.23.0/s';
 
     const removeEmptyState = () => {
-      const empty = consoleWindow?.querySelector('.console__empty');
+      const empty = consoleWindow?.querySelector('.console-empty');
       if (empty) {
         empty.remove();
       }
@@ -198,472 +201,165 @@ import Layout from '../../../layouts/Layout.astro';
 
     const addEmptyState = () => {
       if (!consoleWindow) return;
-      if (consoleWindow.children.length === 0) {
-        const empty = document.createElement('p');
-        empty.className = 'console__empty';
-        empty.innerHTML = 'Awaiting Adobe Analytics activity&hellip;';
-        consoleWindow.append(empty);
+      if (consoleWindow.querySelector('.console-empty')) {
+        return;
       }
+      const paragraph = document.createElement('p');
+      paragraph.className = 'console-empty';
+      paragraph.textContent = 'Awaiting Adobe Analytics activity…';
+      consoleWindow.append(paragraph);
     };
 
-    const renderPayload = (method, label, payload) => {
+    const appendConsoleEntry = (payload) => {
       if (!consoleWindow) return;
       removeEmptyState();
 
-      const params = new URLSearchParams();
-      const appendParam = (key, value) => {
-        if (value === undefined || value === null || value === '') return;
-        if (Array.isArray(value)) {
-          if (value.length > 0) {
-            params.append(key, value.join(','));
-          }
-          return;
-        }
-        if (typeof value === 'object') {
-          if (key === 'contextData') {
-            Object.entries(value).forEach(([contextKey, contextValue]) => {
-              appendParam(`c.${contextKey}`, contextValue);
-            });
-            params.append('c.', 'true');
-            params.append('.c', 'true');
-            return;
-          }
-          Object.entries(value).forEach(([childKey, childValue]) => {
-            appendParam(`${key}.${childKey}`, childValue);
-          });
-          return;
-        }
-        params.append(key, value);
-      };
-
-      Object.entries(payload).forEach(([key, value]) => appendParam(key, value));
-
       const entry = document.createElement('article');
-      entry.className = 'console__entry';
-      const timestamp = new Date().toISOString();
-      const queryString = params.toString();
-      entry.innerHTML = `
-        <header class="console__entry-header">
-          <span class="console__entry-method">${method}</span>
-          <span class="console__entry-label">${label}</span>
-          <span class="console__entry-timestamp">${timestamp}</span>
-        </header>
-        <div class="console__entry-url">GET ${endpoint}?${queryString}</div>
-        <details class="console__entry-details">
-          <summary>Structured payload</summary>
-          <pre>${JSON.stringify(payload, null, 2)}</pre>
-        </details>
-      `;
+      entry.className = 'console-entry';
+
+      const header = document.createElement('div');
+      header.className = 'console-entry__meta mono';
+      const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
+      header.textContent = `${timestamp} · ${payload.summary}`;
+
+      const requestBlock = document.createElement('pre');
+      requestBlock.className = 'console-entry__body';
+      requestBlock.textContent = payload.request;
+
+      const dataBlock = document.createElement('pre');
+      dataBlock.className = 'console-entry__body';
+      dataBlock.textContent = JSON.stringify(payload.data, null, 2);
+
+      entry.append(header, requestBlock, dataBlock);
       consoleWindow.prepend(entry);
+
+      const maxEntries = 8;
+      const entries = consoleWindow.querySelectorAll('.console-entry');
+      if (entries.length > maxEntries) {
+        entries[entries.length - 1].remove();
+      }
     };
 
-    const s = {
-      account: 'jwiedeman.sandbox',
-      linkTrackVars: '',
-      linkTrackEvents: '',
-      events: '',
-      contextData: {},
-      t(overrides = {}) {
-        const { contextData: overrideContext = {}, ...rest } = overrides;
-        const payload = {
-          pageName: 'lab:analytics:adobe-analytics',
-          channel: 'lab',
-          events: 'event1',
-          prop1: 'lab:analytics',
-          eVar1: 'Adobe Analytics Sandbox',
-          contextData: {
-            'page.missionPhase': 'demo',
-            'page.template': 'sandbox',
-            ...overrideContext,
-          },
-          ...rest,
-        };
-        renderPayload('s.t()', 'Page View', payload);
-        return payload;
-      },
-      tl(element, linkType, linkName, overrides = {}) {
-        const payload = {
-          linkType,
+    const buildPayload = (linkName, linkType, attributes) => {
+      const query = new URLSearchParams({
+        AQB: '1',
+        AQE: '1',
+        pe: linkType,
+        pev2: linkName,
+        ...attributes,
+      });
+
+      return {
+        summary: `${linkType.toUpperCase()} · ${linkName}`,
+        request: `${endpoint}?${query.toString()}`,
+        data: {
           linkName,
-          events: overrides.events ?? '',
-          prop4: overrides.prop4,
-          prop6: overrides.prop6,
-          prop9: overrides.prop9,
-          eVar4: overrides.eVar4,
-          eVar6: overrides.eVar6,
-          eVar9: overrides.eVar9,
-          contextData: overrides.contextData ?? {},
-          ctaLabel: element?.textContent?.trim(),
-        };
-        renderPayload('s.tl()', linkName, payload);
-        return payload;
-      },
+          linkType,
+          ...attributes,
+        },
+      };
     };
 
-    window.s = s;
-    window.AASandbox = { renderPayload };
+    const fireLinkTracking = (linkName, linkType, attributes) => {
+      const payload = buildPayload(linkName, linkType, attributes);
+      appendConsoleEntry(payload);
+    };
 
-    const instrumentation = [
-      {
-        selector: '#aa-primary-cta',
-        eventType: 'click',
-        linkType: 'o',
+    const bindingMap = {
+      cta: {
         linkName: 'cta:launch-sequence',
-        overrides: {
+        linkType: 'o',
+        attributes: {
           events: 'event5',
           prop4: 'launch:cta',
           eVar4: 'Launch — Primary',
-          contextData: {
-            component: 'mission-controls',
-            priority: 'primary',
-          },
+          'contextData.component': 'mission-controls',
+          'contextData.priority': 'primary',
         },
-        preventDefault: true,
       },
-      {
-        selector: '#aa-secondary-link',
-        eventType: 'click',
-        linkType: 'o',
+      nav: {
         linkName: 'nav:telemetry-logs',
-        overrides: {
+        linkType: 'o',
+        attributes: {
           events: 'event8',
           prop6: 'nav:telemetry',
           eVar6: 'Navigation Link',
-          contextData: {
-            component: 'global-nav',
-            destination: 'telemetry',
-          },
+          'contextData.component': 'global-nav',
+          'contextData.destination': 'telemetry',
         },
-        preventDefault: true,
       },
-      {
-        selector: '#aa-telemetry-form',
-        eventType: 'submit',
-        linkType: 'o',
+      form: {
         linkName: 'form:telemetry-upload',
-        overrides: {
+        linkType: 'o',
+        attributes: {
           events: 'event12',
           prop9: 'form:telemetry',
           eVar9: 'Telemetry Upload',
-          contextData: {
-            component: 'telemetry',
-            submission: 'form',
-          },
+          'contextData.component': 'telemetry',
+          'contextData.submission': 'form',
         },
-        preventDefault: true,
       },
-    ];
+    };
 
-    instrumentation.forEach((item) => {
-      const element = document.querySelector(item.selector);
-      if (!element) return;
-
-      const handler = (event) => {
-        if (item.preventDefault) {
-          event.preventDefault();
-        }
-        s.tl(element, item.linkType, item.linkName, item.overrides);
-      };
-
-      element.addEventListener(item.eventType, handler);
+    document.getElementById('aa-primary-cta')?.addEventListener('click', () => {
+      fireLinkTracking(bindingMap.cta.linkName, bindingMap.cta.linkType, bindingMap.cta.attributes);
     });
 
-    if (resetButton && consoleWindow) {
-      resetButton.addEventListener('click', () => {
-        consoleWindow.replaceChildren();
-        addEmptyState();
-      });
-    }
+    document.getElementById('aa-secondary-link')?.addEventListener('click', (event) => {
+      event.preventDefault();
+      fireLinkTracking(bindingMap.nav.linkName, bindingMap.nav.linkType, bindingMap.nav.attributes);
+    });
 
-    s.t();
+    document.getElementById('aa-telemetry-form')?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      fireLinkTracking(bindingMap.form.linkName, bindingMap.form.linkType, bindingMap.form.attributes);
+      event.currentTarget.reset();
+    });
+
+    resetButton?.addEventListener('click', () => {
+      if (!consoleWindow) return;
+      consoleWindow.innerHTML = '';
+      addEmptyState();
+    });
+
+    const pageViewPayload = buildPayload('page:view', 't', {
+      events: 'event1',
+      pageName: 'lab:analytics:adobe-analytics',
+      channel: 'lab',
+      prop1: 'lab:analytics',
+      eVar1: 'Adobe Analytics Sandbox',
+      'contextData.page.missionPhase': 'demo',
+      'contextData.page.template': 'sandbox',
+    });
+    appendConsoleEntry(pageViewPayload);
   </script>
 
   <style>
-    .sandbox {
-      padding-top: var(--space-4);
-      padding-bottom: var(--space-5);
-    }
-
-    .sandbox__header {
-      max-width: 720px;
-      margin-bottom: var(--space-4);
-    }
-
-    .sandbox__eyebrow {
-      letter-spacing: 0.2em;
-      text-transform: uppercase;
-      font-size: var(--text-12);
-      color: var(--color-muted);
-      margin-bottom: var(--space-1);
-    }
-
-    .sandbox__grid {
-      align-items: flex-start;
-    }
-
-    .sandbox__panel {
-      background: rgba(255, 255, 255, 0.6);
-      border: 1px solid var(--color-rule);
-      padding: var(--space-3);
-      border-radius: var(--radius-2);
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.06);
-      backdrop-filter: blur(3px);
-    }
-
-    .sandbox__panel h2 {
-      font-size: var(--text-24);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      margin-bottom: var(--space-2);
-    }
-
-    .sandbox__intro {
-      margin-bottom: var(--space-3);
-      color: var(--color-muted);
-    }
-
-    .tracking-card,
-    .pageview-card {
-      border-top: 1px solid var(--color-rule);
-      padding-top: var(--space-3);
-      margin-top: var(--space-3);
-    }
-
-    .tracking-card:first-of-type {
-      border-top: none;
-      padding-top: 0;
-      margin-top: 0;
-    }
-
-    .tracking-card__meta {
-      margin-bottom: var(--space-2);
-    }
-
-    .tracking-card__title {
-      font-size: var(--text-20);
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      margin-bottom: var(--space-1);
-    }
-
-    .tracking-card__summary {
-      color: var(--color-muted);
-      font-size: var(--text-14);
-    }
-
-    .tracking-card__action {
-      appearance: none;
-      background: var(--color-text);
-      color: var(--color-bg);
-      border: none;
-      border-radius: var(--radius-2);
-      padding: var(--space-2) var(--space-3);
-      font-weight: 700;
-      cursor: pointer;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-    }
-
-    .tracking-card__action:hover,
-    .tracking-card__action:focus {
-      background: var(--color-accent);
-      color: var(--color-bg);
-      outline: none;
-    }
-
-    .tracking-card__action--link {
-      display: inline-block;
-      text-decoration: none;
-      border: 1px solid var(--color-text);
-    }
-
-    .tracking-card__form {
-      display: grid;
-      gap: var(--space-1);
-      margin-bottom: var(--space-2);
-    }
-
-    .tracking-card__form input,
-    .tracking-card__form select {
-      padding: var(--space-1);
-      border: 1px solid var(--color-rule);
-      border-radius: var(--radius-2);
-      font-size: var(--text-16);
-    }
-
-    .tracking-card__details {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: var(--space-2);
-      margin: var(--space-2) 0;
-    }
-
-    .tracking-card__details dt {
-      font-size: var(--text-12);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--color-muted);
-      margin-bottom: 4px;
-    }
-
-    .tracking-card__details dd {
+    .adobe-sandbox .adobe-card pre.adobe-code {
       margin: 0;
-      font-size: var(--text-14);
-    }
-
-    .tracking-card__code {
-      background: rgba(17, 17, 17, 0.06);
       padding: var(--space-2);
+      border: 1px solid var(--color-rule);
       border-radius: var(--radius-2);
-      font-size: var(--text-12);
+      background: rgba(0, 0, 0, 0.04);
       overflow-x: auto;
+      font-size: var(--text-12);
+      line-height: 1.4;
     }
 
-    .pageview-card h2 {
-      font-size: var(--text-20);
-      margin-bottom: var(--space-1);
+    .adobe-sandbox .adobe-console {
+      gap: var(--space-2);
     }
 
-    .pageview-card__list {
-      list-style: none;
-      padding: 0;
-      margin: 0 0 var(--space-2) 0;
-      display: grid;
-      gap: 4px;
-    }
-
-    .sandbox__panel--console {
-      background: #111111;
-      color: #f0f0f0;
-      border-color: #2f2f2f;
-    }
-
-    .sandbox__panel--console code,
-    .sandbox__panel--console pre {
-      color: inherit;
-    }
-
-    .console__header {
+    .adobe-sandbox .adobe-console__header {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      margin-bottom: var(--space-2);
-    }
-
-    .console__header h2 {
-      font-size: var(--text-20);
-      margin: 0;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .console__reset {
-      background: transparent;
-      border: 1px solid #f0f0f0;
-      color: #f0f0f0;
-      padding: 4px 12px;
-      border-radius: var(--radius-2);
-      cursor: pointer;
-      font-size: var(--text-12);
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .console__reset:hover,
-    .console__reset:focus {
-      background: #f0f0f0;
-      color: #111111;
-      outline: none;
-    }
-
-    .console__description {
-      font-size: var(--text-14);
-      color: #c7c7c7;
-      margin-bottom: var(--space-2);
-    }
-
-    .console__window {
-      background: rgba(0, 0, 0, 0.6);
-      border: 1px solid #2f2f2f;
-      border-radius: var(--radius-2);
-      min-height: 260px;
-      padding: var(--space-2);
-      display: grid;
       gap: var(--space-2);
     }
 
-    .console__empty {
-      color: #8c8c8c;
-    }
-
-    .console__entry {
-      border: 1px solid #2f2f2f;
-      border-radius: var(--radius-2);
-      padding: var(--space-2);
-      background: rgba(10, 10, 10, 0.85);
-      display: grid;
-      gap: var(--space-1);
-    }
-
-    .console__entry-header {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--space-1);
+    .adobe-sandbox .adobe-reset {
       font-size: var(--text-12);
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: #8bd3dd;
-    }
-
-    .console__entry-method {
-      font-weight: 700;
-    }
-
-    .console__entry-label {
-      color: #f6c177;
-    }
-
-    .console__entry-timestamp {
-      margin-left: auto;
-      color: #6a8e9b;
-    }
-
-    .console__entry-url {
-      font-size: var(--text-12);
-      line-height: 1.4;
-      word-break: break-all;
-      color: #f0f0f0;
-    }
-
-    .console__entry-details summary {
-      cursor: pointer;
-      font-size: var(--text-12);
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: #8bd3dd;
-    }
-
-    .console__entry-details pre {
-      margin-top: var(--space-1);
-      font-size: var(--text-12);
-      line-height: 1.4;
-      white-space: pre-wrap;
-    }
-
-    .console__noscript {
-      margin-top: var(--space-2);
-      font-size: var(--text-14);
-      color: #f6c177;
-    }
-
-    @media (max-width: 900px) {
-      .sandbox__panel {
-        margin-bottom: var(--space-3);
-      }
-
-      .sandbox__panel--console {
-        order: -1;
-      }
+      letter-spacing: 0.12em;
     }
   </style>
 </Layout>

--- a/src/pages/lab/analytics/ga4-sandbox.astro
+++ b/src/pages/lab/analytics/ga4-sandbox.astro
@@ -1,8 +1,8 @@
----
 import Layout from '../../../layouts/Layout.astro';
+import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="GA4 Sandbox">
-  <div class="container ga4-sandbox">
+  <div class="container analytics-sandbox ga4-sandbox">
     <header class="sandbox-header hairline-bottom">
       <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>GA4 Sandbox</h1>
@@ -24,23 +24,23 @@ import Layout from '../../../layouts/Layout.astro';
     </header>
 
     <div class="sandbox-grid">
-      <section class="sandbox-playground" aria-labelledby="ga4-playground-heading">
+      <section class="sandbox-panel" aria-labelledby="ga4-playground-heading">
         <h2 id="ga4-playground-heading">Tracked interface elements</h2>
         <p class="playground-copy">
           Each card documents the GA4 event name, trigger, and parameters attached to the component. These
           map directly to the <code>gtag('event')</code> calls fired when you engage with the UI.
         </p>
 
-        <article class="tracked-card" data-event="select_content">
+        <article class="sandbox-card tracked-card" data-event="select_content">
           <header>
-            <p class="tracked-tag mono">Event: select_content</p>
+            <p class="sandbox-card__tag mono">Event: select_content</p>
             <h3>Primary mission CTA</h3>
           </header>
           <p>
             Demonstrates a hero-level call to action capturing content selection. This is a high-intent
             click, so the payload includes metadata describing the hero placement and label text.
           </p>
-          <dl class="tracked-definition">
+          <dl class="tracked-definition sandbox-card__meta">
             <div>
               <dt>Trigger</dt>
               <dd>Button click</dd>
@@ -52,19 +52,19 @@ import Layout from '../../../layouts/Layout.astro';
               </dd>
             </div>
           </dl>
-          <button id="ga4-cta" class="tracked-action">Request mission brief</button>
+          <button id="ga4-cta" class="sandbox-action">Request mission brief</button>
         </article>
 
-        <article class="tracked-card" data-event="view_promotion">
+        <article class="sandbox-card tracked-card" data-event="view_promotion">
           <header>
-            <p class="tracked-tag mono">Event: view_promotion</p>
+            <p class="sandbox-card__tag mono">Event: view_promotion</p>
             <h3>Research bulletin teaser</h3>
           </header>
           <p>
             Simulates an in-page promotion module. The event communicates the name of the offer and the slot
             in which it appeared so you can evaluate placement performance.
           </p>
-          <dl class="tracked-definition">
+          <dl class="tracked-definition sandbox-card__meta">
             <div>
               <dt>Trigger</dt>
               <dd>Link interaction</dd>
@@ -76,19 +76,19 @@ import Layout from '../../../layouts/Layout.astro';
               </dd>
             </div>
           </dl>
-          <a id="ga4-promo" class="tracked-link" href="#">Preview bulletin</a>
+          <a id="ga4-promo" class="sandbox-link" href="#">Preview bulletin</a>
         </article>
 
-        <article class="tracked-card" data-event="generate_lead">
+        <article class="sandbox-card tracked-card" data-event="generate_lead">
           <header>
-            <p class="tracked-tag mono">Event: generate_lead</p>
+            <p class="sandbox-card__tag mono">Event: generate_lead</p>
             <h3>Lead qualification form</h3>
           </header>
           <p>
             Captures submissions for a lightweight lead form. The payload returns mission focus data so the
             downstream pipeline can segment follow-up efforts.
           </p>
-          <dl class="tracked-definition">
+          <dl class="tracked-definition sandbox-card__meta">
             <div>
               <dt>Trigger</dt>
               <dd>Form submit</dd>
@@ -100,10 +100,10 @@ import Layout from '../../../layouts/Layout.astro';
               </dd>
             </div>
           </dl>
-          <form id="ga4-form" class="tracked-form">
-            <label class="mono" for="ga4-mission">Mission focus</label>
+          <form id="ga4-form" class="sandbox-form tracked-form">
+            <label for="ga4-mission">Mission focus</label>
             <input id="ga4-mission" name="mission" type="text" placeholder="Deep space communications" />
-            <button type="submit" class="tracked-action">Transmit mission details</button>
+            <button type="submit" class="sandbox-action">Transmit mission details</button>
           </form>
         </article>
       </section>
@@ -260,241 +260,21 @@ import Layout from '../../../layouts/Layout.astro';
   </script>
 
   <style>
-    .ga4-sandbox {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-4);
-      padding-bottom: var(--space-5);
-    }
-
-    .sandbox-header {
-      padding-top: var(--space-4);
-      padding-bottom: var(--space-4);
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2);
-    }
-
-    .sandbox-header h1 {
-      font-size: var(--text-48);
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-    }
-
-    .supertitle {
-      font-size: var(--text-14);
-      letter-spacing: 0.14em;
-      text-transform: uppercase;
-      color: var(--color-muted);
-    }
-
-    .intro {
-      max-width: 720px;
-    }
-
-    .sandbox-meta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--space-3);
-      margin: 0;
-    }
-
-    .sandbox-meta dt {
-      font-size: var(--text-12);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--color-muted);
-    }
-
-    .sandbox-meta dd {
-      margin: 0;
-      font-size: var(--text-16);
-    }
-
-    .sandbox-grid {
-      display: grid;
-      grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-      gap: var(--space-4);
-      align-items: start;
-    }
-
-    .sandbox-playground,
-    .sandbox-console {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-3);
-    }
-
-    .playground-copy,
-    .console-copy {
+    .ga4-sandbox .playground-copy,
+    .ga4-sandbox .console-copy {
       margin-top: 0;
       color: var(--color-muted);
     }
 
-    .tracked-card {
-      border: 1px solid var(--color-rule);
-      padding: var(--space-3);
-      border-radius: var(--radius-2);
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2);
-      background: rgba(255, 255, 255, 0.45);
+    .ga4-sandbox .tracked-card {
+      background: rgba(255, 255, 255, 0.5);
     }
 
-    .tracked-card h3 {
-      margin-bottom: 0;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
-    .tracked-tag {
-      font-size: var(--text-12);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      color: var(--color-muted);
-      margin: 0 0 var(--space-1) 0;
-    }
-
-    .tracked-definition {
+    .ga4-sandbox .tracked-definition {
       margin: 0;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
       gap: var(--space-2);
-    }
-
-    .tracked-definition dt {
-      font-size: var(--text-12);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--color-muted);
-    }
-
-    .tracked-definition dd {
-      margin: 0;
-      font-family: var(--font-mono);
-      font-size: var(--text-14);
-    }
-
-    .tracked-action,
-    .tracked-link {
-      align-self: flex-start;
-      padding: var(--space-1) var(--space-2);
-      border: 1px solid var(--color-text);
-      border-radius: var(--radius-2);
-      background: transparent;
-      color: var(--color-text);
-      font-family: var(--font-sans);
-      font-size: var(--text-14);
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      cursor: pointer;
-    }
-
-    .tracked-link {
-      display: inline-block;
-      text-decoration: none;
-    }
-
-    .tracked-link:hover,
-    .tracked-action:hover,
-    .tracked-link:focus,
-    .tracked-action:focus {
-      background: var(--color-text);
-      color: var(--color-bg);
-    }
-
-    .tracked-form {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2);
-    }
-
-    .tracked-form input {
-      padding: var(--space-1);
-      border: 1px solid var(--color-rule);
-      border-radius: var(--radius-1);
-      font-size: var(--text-16);
-      font-family: var(--font-sans);
-      background: rgba(255, 255, 255, 0.75);
-    }
-
-    .sandbox-console {
-      border: 1px solid var(--color-rule);
-      border-radius: var(--radius-2);
-      padding: var(--space-3);
-      background: rgba(17, 17, 17, 0.04);
-    }
-
-    .console-stream {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2);
-      max-height: 520px;
-      overflow-y: auto;
-      padding-right: var(--space-1);
-    }
-
-    .console-empty {
-      color: var(--color-muted);
-      margin: 0;
-    }
-
-    .console-entry {
-      border: 1px solid var(--color-rule);
-      border-radius: var(--radius-2);
-      padding: var(--space-2);
-      background: rgba(255, 255, 255, 0.6);
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-1);
-    }
-
-    .console-entry__meta {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--space-1);
-      font-size: var(--text-12);
-      letter-spacing: 0.1em;
-      text-transform: uppercase;
-      color: var(--color-muted);
-    }
-
-    .console-entry__method {
-      font-weight: 700;
-    }
-
-    .console-entry__body {
-      margin: 0;
-      font-family: var(--font-mono);
-      font-size: var(--text-12);
-      white-space: pre-wrap;
-    }
-
-    .sandbox-snippet {
-      border-top: 1px solid var(--color-rule);
-      padding-top: var(--space-3);
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2);
-    }
-
-    .sandbox-snippet pre {
-      margin: 0;
-      padding: var(--space-2);
-      border: 1px solid var(--color-rule);
-      border-radius: var(--radius-2);
-      background: rgba(255, 255, 255, 0.6);
-      overflow-x: auto;
-    }
-
-    @media (max-width: 960px) {
-      .sandbox-grid {
-        grid-template-columns: 1fr;
-      }
-
-      .console-stream {
-        max-height: none;
-      }
     }
   </style>
 </Layout>

--- a/src/pages/lab/analytics/gtm-sandbox.astro
+++ b/src/pages/lab/analytics/gtm-sandbox.astro
@@ -1,75 +1,176 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
+import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="GTM Sandbox">
-  <article class="sandbox">
-    <header class="intro">
-      <p class="eyebrow">Analytics Lab / GTM</p>
+  <div class="container analytics-sandbox gtm-sandbox">
+    <header class="sandbox-header hairline-bottom">
+      <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>Google Tag Manager Sandbox</h1>
-      <p>
-        This sandbox demonstrates how a universal data layer powers Google Tag Manager implementations.
-        Explore how page context is structured, how elements declare their tracking metadata, and how
-        payloads are staged for GTM delivery.
+      <p class="intro">
+        Explore how a universal data layer powers Google Tag Manager implementations. The left column
+        documents the foundational schema and tracked interface components, while the console on the right
+        shows the normalized payloads staged for dispatch.
       </p>
+      <dl class="sandbox-meta">
+        <div>
+          <dt>Container ID</dt>
+          <dd class="mono">GTM-XXXXXXX</dd>
+        </div>
+        <div>
+          <dt>Data layer schema</dt>
+          <dd class="mono">universal-data-layer/v1</dd>
+        </div>
+      </dl>
     </header>
 
-    <section class="section">
-      <h2>Universal Data Layer Blueprint</h2>
-      <p>
-        Start every implementation with a consistent schema. Capture stable identifiers at the session,
-        user, and page level so GTM can enrich every event automatically. Interaction details are layered
-        on top when visitors engage with tracked components.
-      </p>
-      <div class="blueprint">
-        <div class="card">
-          <h3>Session Context</h3>
-          <p>Generated on first visit and persisted for the session.</p>
-          <pre><code>{`{
+    <div class="sandbox-grid">
+      <section class="sandbox-panel">
+        <section class="sandbox-card gtm-blueprint" aria-labelledby="gtm-blueprint-heading">
+          <h2 id="gtm-blueprint-heading">Universal data layer blueprint</h2>
+          <p>
+            Capture stable identifiers at the session, user, and page level. Interaction events inherit these
+            values so downstream destinations receive fully qualified payloads without redefining schema on
+            every tag.
+          </p>
+          <div class="gtm-blueprint__grid">
+            <article class="gtm-blueprint__card">
+              <h3>Session context</h3>
+              <p>Generated on first visit and persisted until the window closes.</p>
+              <pre class="mono">{`
+{
   "session": {
     "id": "c2c...",
     "timestamp": "2024-01-01T12:00:00Z",
     "source": "organic"
   }
-}`}</code></pre>
-        </div>
-        <div class="card">
-          <h3>User Context</h3>
-          <p>Anonymous profile traits that remain stable across views.</p>
-          <pre><code>{`{
+}`}</pre>
+            </article>
+            <article class="gtm-blueprint__card">
+              <h3>User context</h3>
+              <p>Anonymous profile traits that remain stable across views.</p>
+              <pre class="mono">{`
+{
   "user": {
     "authState": "anonymous",
     "persona": "marketer",
     "role": null
   }
-}`}</code></pre>
-        </div>
-        <div class="card">
-          <h3>Page Context</h3>
-          <p>Details that describe what is being viewed right now.</p>
-          <pre><code>{`{
+}`}</pre>
+            </article>
+            <article class="gtm-blueprint__card">
+              <h3>Page context</h3>
+              <p>Describes the current surface so attribution dimensions stay consistent.</p>
+              <pre class="mono">{`
+{
   "page": {
     "name": "gtm-sandbox",
     "category": "analytics-lab",
     "language": "en-US"
   }
-}`}</code></pre>
-        </div>
-      </div>
-      <p>
-        Each event extends this base payload with an <code>interaction</code> object that captures
-        what happened, where it occurred, and any business-specific values. GTM then routes the data to
-        GA4, ad platforms, or custom endpoints without redefining the structure every time.
-      </p>
-    </section>
+}`}</pre>
+            </article>
+          </div>
+          <p>
+            Each interaction extends this base object with an <code>interaction</code> node describing the
+            element, module, and any business values collected at the moment of engagement.
+          </p>
+        </section>
 
-    <section class="section">
-      <h2>Base GTM Container Snippet</h2>
+        <section class="sandbox-card gtm-interactive" aria-labelledby="gtm-interactive-heading">
+          <h2 id="gtm-interactive-heading">Interactive tracking map</h2>
+          <p>
+            Components below surface their <code>data-gtm-*</code> metadata. Activate them to see the
+            normalized payload that would be pushed into the data layer and forwarded to GTM tags.
+          </p>
+          <div class="gtm-interactive__grid">
+            <article class="gtm-interactive__item">
+              <header>
+                <h3>Primary CTA</h3>
+                <p class="mono">Event: cta_click &middot; Module: gtm-sandbox.cta</p>
+              </header>
+              <button
+                type="button"
+                class="sandbox-action gtm-trackable"
+                data-gtm-event="cta_click"
+                data-gtm-element="Launch Primary CTA"
+                data-gtm-module="gtm-sandbox.cta"
+                data-gtm-value="primary"
+              >
+                Initiate launch sequence
+              </button>
+            </article>
+
+            <article class="gtm-interactive__item">
+              <header>
+                <h3>Reference link</h3>
+                <p class="mono">Event: documentation_open &middot; Module: gtm-sandbox.navigation</p>
+              </header>
+              <a
+                href="#"
+                class="sandbox-link gtm-trackable"
+                data-gtm-event="documentation_open"
+                data-gtm-element="Sandbox Documentation Link"
+                data-gtm-module="gtm-sandbox.navigation"
+                data-gtm-trigger="click"
+              >
+                View implementation checklist
+              </a>
+            </article>
+
+            <article class="gtm-interactive__item">
+              <header>
+                <h3>Mission intake form</h3>
+                <p class="mono">Event: form_submit &middot; Module: gtm-sandbox.form</p>
+              </header>
+              <form
+                class="sandbox-form gtm-trackable"
+                data-gtm-event="form_submit"
+                data-gtm-element="Mission Intake Form"
+                data-gtm-module="gtm-sandbox.form"
+                data-gtm-method="POST"
+                data-gtm-trigger="submit"
+              >
+                <label for="mission-objective">Mission objective</label>
+                <input id="mission-objective" name="missionObjective" placeholder="Calibrate telemetry" />
+                <button type="submit" class="sandbox-action">Submit request</button>
+              </form>
+            </article>
+          </div>
+        </section>
+
+        <section class="sandbox-card gtm-checklist" aria-labelledby="gtm-checklist-heading">
+          <h2 id="gtm-checklist-heading">Deployment checklist</h2>
+          <ol class="gtm-checklist__list">
+            <li><strong>1.</strong> Publish the schema and confirm all stakeholders align on naming.</li>
+            <li><strong>2.</strong> Populate session, user, and page objects server-side or on first paint.</li>
+            <li><strong>3.</strong> Annotate interactive elements with <code>data-gtm-*</code> attributes.</li>
+            <li><strong>4.</strong> Use a helper to map DOM metadata to structured data layer pushes.</li>
+            <li><strong>5.</strong> Route payloads to GA4, ad pixels, or custom webhooks from within GTM.</li>
+          </ol>
+        </section>
+      </section>
+
+      <aside class="sandbox-console" aria-labelledby="gtm-console-heading">
+        <h2 id="gtm-console-heading">Mock GTM console</h2>
+        <p>
+          Mirrors the latest <code>dataLayer.push</code> entries and the staged network request. Entries are
+          trimmed to the eight most recent interactions.
+        </p>
+        <div class="console-stream" data-console-stream aria-live="polite">
+          <p class="console-empty" data-console-empty>No events yet. Trigger an interaction to populate the console.</p>
+        </div>
+      </aside>
+    </div>
+
+    <section class="sandbox-snippet" aria-labelledby="gtm-snippet-heading">
+      <h2 id="gtm-snippet-heading">Base GTM container snippet</h2>
       <p>
-        Paste the standard GTM bootstrap code near the top of the <code>&lt;head&gt;</code> and mirror the
-        <code>&lt;noscript&gt;</code> iframe immediately after the opening <code>&lt;body&gt;</code>. Replace
-        <code>GTM-XXXXXXX</code> with your container ID.
+        Paste the standard bootstrap near the top of <code>&lt;head&gt;</code> and mirror the
+        <code>&lt;noscript&gt;</code> iframe immediately after <code>&lt;body&gt;</code>. Replace the container ID
+        with your own value.
       </p>
-      <pre class="snippet"><code>{`&lt;script&gt;
+      <pre class="mono"><code>{`&lt;script&gt;
   (function(w,d,s,l,i){
     w[l]=w[l]||[];
     w[l].push({
@@ -85,111 +186,17 @@ import Layout from '../../../layouts/Layout.astro';
   })(window,document,'script','dataLayer','GTM-XXXXXXX');
 &lt;/script&gt;
 &lt;noscript&gt;
-  &lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX"
-    height="0" width="0" style="display:none;visibility:hidden"&gt;&lt;/iframe&gt;
+  &lt;iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX" height="0" width="0" style="display:none;visibility:hidden"&gt;&lt;/iframe&gt;
 &lt;/noscript&gt;`}</code></pre>
     </section>
-
-    <section class="section">
-      <h2>Interactive Tracking Map</h2>
-      <p>
-        Each element below carries <code>data-gtm-*</code> attributes describing the event name, the
-        module responsible for the action, and optional values. Activate them to see how the universal
-        data layer composes the outbound payload.
-      </p>
-      <div class="playground">
-        <div class="trackable-panel">
-          <figure>
-            <button
-              type="button"
-              class="trackable"
-              data-gtm-event="cta_click"
-              data-gtm-element="Launch Primary CTA"
-              data-gtm-module="gtm-sandbox.cta"
-              data-gtm-value="primary"
-            >
-              Initiate Launch Sequence
-            </button>
-            <figcaption>
-              <strong>Primary CTA</strong>
-              <span>Event: <code>cta_click</code></span>
-              <span>Module: <code>gtm-sandbox.cta</code></span>
-              <span>Value: <code>primary</code></span>
-            </figcaption>
-          </figure>
-
-          <figure>
-            <a
-              href="#"
-              class="trackable link"
-              data-gtm-event="documentation_open"
-              data-gtm-element="Sandbox Documentation Link"
-              data-gtm-module="gtm-sandbox.navigation"
-              data-gtm-trigger="click"
-            >
-              View Implementation Checklist
-            </a>
-            <figcaption>
-              <strong>Reference Link</strong>
-              <span>Event: <code>documentation_open</code></span>
-              <span>Module: <code>gtm-sandbox.navigation</code></span>
-            </figcaption>
-          </figure>
-
-          <figure>
-            <form
-              class="trackable form"
-              data-gtm-event="form_submit"
-              data-gtm-element="Mission Intake Form"
-              data-gtm-module="gtm-sandbox.form"
-              data-gtm-method="POST"
-              data-gtm-trigger="submit"
-            >
-              <label for="mission-objective">Mission Objective</label>
-              <input id="mission-objective" name="missionObjective" placeholder="Calibrate telemetry" />
-              <button type="submit">Submit Request</button>
-            </form>
-            <figcaption>
-              <strong>Intake Form</strong>
-              <span>Event: <code>form_submit</code></span>
-              <span>Module: <code>gtm-sandbox.form</code></span>
-              <span>Method: <code>POST</code></span>
-            </figcaption>
-          </figure>
-        </div>
-
-        <aside class="console" aria-live="polite" aria-label="Mock GTM console">
-          <div class="console-header">
-            <h3>Mock Console</h3>
-            <p>Shows the most recent data layer pushes and the payload staged for GTM endpoints.</p>
-          </div>
-          <div class="console-body" data-console>
-            <p data-console-empty>No events yet. Trigger an interaction to populate the console.</p>
-            <ol data-console-list></ol>
-          </div>
-        </aside>
-      </div>
-    </section>
-
-    <section class="section">
-      <h2>Deployment Checklist</h2>
-      <ul class="checklist">
-        <li><strong>1.</strong> Define the universal data layer schema and publish it for stakeholders.</li>
-        <li><strong>2.</strong> Populate session, user, and page objects server-side (or at first paint).
-        </li>
-        <li><strong>3.</strong> Annotate interactive elements with <code>data-gtm-*</code> metadata.</li>
-        <li><strong>4.</strong> Use a single helper to read those attributes and push structured events into GTM.</li>
-        <li><strong>5.</strong> Map GTM tags to destinations—GA4, ad pixels, or custom webhooks—without changing the schema.</li>
-      </ul>
-    </section>
-  </article>
+  </div>
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const dataLayer = window.dataLayer || [];
       window.dataLayer = dataLayer;
 
-      const consoleList = document.querySelector('[data-console-list]');
+      const consoleStream = document.querySelector('[data-console-stream]');
       const consoleEmpty = document.querySelector('[data-console-empty]');
       const transmissions = [];
       const MAX_ITEMS = 8;
@@ -213,28 +220,23 @@ import Layout from '../../../layouts/Layout.astro';
       };
 
       const renderConsole = () => {
-        if (!consoleList) return;
-        consoleEmpty.hidden = transmissions.length > 0;
-        consoleList.innerHTML = '';
+        if (!consoleStream) return;
+        if (consoleEmpty) {
+          consoleEmpty.hidden = transmissions.length > 0;
+        }
+        consoleStream.innerHTML = '';
         transmissions.slice(0, MAX_ITEMS).forEach((entry) => {
-          const item = document.createElement('li');
-          item.className = 'console-entry';
-
-          const header = document.createElement('div');
-          header.className = 'console-entry__header';
-          header.textContent = `${entry.timestamp} • ${entry.label}`;
-
-          const badge = document.createElement('span');
-          badge.className = 'console-entry__type';
-          badge.textContent = entry.type;
-          header.appendChild(badge);
-
-          const payload = document.createElement('pre');
-          payload.textContent = JSON.stringify(entry.payload, null, 2);
-
-          item.appendChild(header);
-          item.appendChild(payload);
-          consoleList.appendChild(item);
+          const article = document.createElement('article');
+          article.className = 'console-entry';
+          article.innerHTML = `
+            <header class="console-entry__meta">
+              <span class="console-entry__method">${entry.type}</span>
+              <span>${entry.label}</span>
+              <span>${entry.timestamp}</span>
+            </header>
+            <pre class="console-entry__body">${JSON.stringify(entry.payload, null, 2)}</pre>
+          `;
+          consoleStream.appendChild(article);
         });
       };
 
@@ -284,10 +286,7 @@ import Layout from '../../../layouts/Layout.astro';
           const trigger = node.dataset.gtmTrigger || (node.tagName === 'FORM' ? 'submit' : 'click');
 
           const handler = (event) => {
-            if (trigger === 'click') {
-              event.preventDefault();
-            }
-            if (trigger === 'submit') {
+            if (trigger === 'click' || trigger === 'submit') {
               event.preventDefault();
             }
 
@@ -330,247 +329,84 @@ import Layout from '../../../layouts/Layout.astro';
   </script>
 
   <style>
-    .sandbox {
-      padding: 4rem 1.5rem 6rem;
-      margin: 0 auto;
-      max-width: 1100px;
-      color: var(--color-text, #181818);
-      display: flex;
-      flex-direction: column;
-      gap: 3rem;
-    }
-
-    .intro {
+    .gtm-sandbox .gtm-blueprint__grid {
       display: grid;
-      gap: 1rem;
-      max-width: 720px;
-    }
-
-    .intro .eyebrow {
-      text-transform: uppercase;
-      letter-spacing: 0.18em;
-      font-size: 0.75rem;
-      color: #7e2522;
-    }
-
-    .intro h1 {
-      font-size: clamp(2rem, 4vw, 2.75rem);
-      letter-spacing: 0.04em;
-    }
-
-    .section {
-      display: grid;
-      gap: 1.5rem;
-    }
-
-    .section h2 {
-      font-size: clamp(1.5rem, 3vw, 2rem);
-      letter-spacing: 0.05em;
-    }
-
-    .blueprint {
-      display: grid;
-      gap: 1.5rem;
+      gap: var(--space-3);
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }
 
-    .card {
-      border: 1px solid rgba(24, 24, 24, 0.18);
-      background: #f3eddf;
-      padding: 1.5rem;
-      display: grid;
-      gap: 0.75rem;
-      box-shadow: 6px 6px 0 0 rgba(24, 24, 24, 0.08);
+    .gtm-sandbox .gtm-blueprint__card {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      border: 1px solid var(--color-rule);
+      border-radius: var(--radius-2);
+      padding: var(--space-2);
+      background: rgba(255, 255, 255, 0.75);
     }
 
-    .card pre,
-    .snippet {
-      background: #fffdf7;
-      border: 1px solid rgba(24, 24, 24, 0.2);
-      padding: 1rem;
+    .gtm-sandbox .gtm-blueprint__card h3 {
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .gtm-sandbox .gtm-blueprint__card pre {
+      margin: 0;
+      padding: var(--space-2);
+      border: 1px solid var(--color-rule);
+      border-radius: var(--radius-2);
+      background: rgba(0, 0, 0, 0.04);
       overflow-x: auto;
-      font-size: 0.875rem;
+      font-size: var(--text-12);
       line-height: 1.4;
     }
 
-    .snippet {
-      white-space: pre-wrap;
-    }
-
-    .playground {
+    .gtm-sandbox .gtm-interactive__grid {
       display: grid;
-      gap: 2rem;
-      grid-template-columns: minmax(0, 1fr);
+      gap: var(--space-3);
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     }
 
-    @media (min-width: 900px) {
-      .playground {
-        grid-template-columns: 1fr 1fr;
-        align-items: start;
-      }
-    }
-
-    .trackable-panel {
-      display: grid;
-      gap: 2rem;
-    }
-
-    figure {
-      margin: 0;
-      display: grid;
-      gap: 0.75rem;
-    }
-
-    figcaption {
-      border-left: 3px solid #7e2522;
-      padding-left: 1rem;
-      display: grid;
-      gap: 0.35rem;
-      font-size: 0.9rem;
-    }
-
-    .trackable {
-      border: 1px solid rgba(24, 24, 24, 0.25);
-      background: #fff;
-      padding: 0.9rem 1.2rem;
-      font-size: 1rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      cursor: pointer;
-      transition: transform 120ms ease, box-shadow 120ms ease;
-      box-shadow: 4px 4px 0 0 rgba(24, 24, 24, 0.12);
-    }
-
-    .trackable:hover,
-    .trackable:focus {
-      transform: translate(-2px, -2px);
-      box-shadow: 6px 6px 0 0 rgba(24, 24, 24, 0.18);
-      outline: none;
-    }
-
-    .trackable.link {
-      display: inline-block;
-      text-decoration: none;
-      color: inherit;
-      background: #fffdf7;
-    }
-
-    .trackable.form {
-      display: grid;
-      gap: 0.75rem;
-      text-transform: none;
-      letter-spacing: normal;
-      cursor: default;
-    }
-
-    .trackable.form label {
-      font-weight: 600;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      font-size: 0.8rem;
-    }
-
-    .trackable.form input {
-      padding: 0.65rem 0.75rem;
-      border: 1px solid rgba(24, 24, 24, 0.3);
-      background: #fff;
-      font-size: 0.95rem;
-    }
-
-    .trackable.form button {
-      justify-self: start;
-    }
-
-    .console {
-      border: 1px solid rgba(24, 24, 24, 0.3);
-      background: #0f0f0f;
-      color: #f2f0ea;
-      padding: 1.5rem;
-      display: grid;
-      gap: 1rem;
-      min-height: 100%;
-    }
-
-    .console-header h3 {
-      margin: 0;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .console-body {
-      background: #151515;
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      padding: 1rem;
-      display: grid;
-      gap: 0.75rem;
-      min-height: 260px;
-    }
-
-    .console-body p {
-      margin: 0;
-      color: rgba(242, 240, 234, 0.75);
-    }
-
-    .console-body ol {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: grid;
-      gap: 1rem;
-    }
-
-    .console-entry {
-      display: grid;
-      gap: 0.5rem;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-      padding-bottom: 0.75rem;
-    }
-
-    .console-entry:last-child {
-      border-bottom: none;
-      padding-bottom: 0;
-    }
-
-    .console-entry__header {
+    .gtm-sandbox .gtm-interactive__item {
       display: flex;
-      justify-content: space-between;
-      align-items: baseline;
-      gap: 0.5rem;
-      font-size: 0.85rem;
+      flex-direction: column;
+      gap: var(--space-2);
+      border: 1px solid var(--color-rule);
+      border-radius: var(--radius-2);
+      padding: var(--space-2);
+      background: rgba(255, 255, 255, 0.6);
     }
 
-    .console-entry__type {
-      background: #7e2522;
-      color: #f3eddf;
-      padding: 0.15rem 0.45rem;
-      font-size: 0.7rem;
-      letter-spacing: 0.08em;
+    .gtm-sandbox .gtm-interactive__item header h3 {
+      margin: 0;
       text-transform: uppercase;
-      border-radius: 999px;
+      letter-spacing: 0.08em;
     }
 
-    .console-entry pre {
+    .gtm-sandbox .gtm-interactive__item .mono {
+      color: var(--color-muted);
+      font-size: var(--text-12);
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+
+    .gtm-sandbox .gtm-checklist__list {
       margin: 0;
-      background: #1d1d1d;
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      padding: 0.75rem;
-      overflow-x: auto;
-      font-size: 0.75rem;
-      line-height: 1.45;
-    }
-
-    .checklist {
+      padding-left: var(--space-3);
       display: grid;
-      gap: 0.65rem;
-      margin: 0;
-      padding-left: 1rem;
+      gap: var(--space-1);
     }
 
-    .checklist li {
+    .gtm-sandbox .gtm-checklist__list li {
       list-style: none;
-      border-left: 3px solid rgba(24, 24, 24, 0.35);
-      padding-left: 0.75rem;
-      font-size: 0.95rem;
+      border-left: 3px solid var(--color-rule);
+      padding-left: var(--space-2);
+    }
+
+    .gtm-sandbox .gtm-checklist__list strong {
+      letter-spacing: 0.08em;
+      margin-right: var(--space-1);
     }
   </style>
 </Layout>

--- a/src/pages/lab/analytics/linkedin-pixel.astro
+++ b/src/pages/lab/analytics/linkedin-pixel.astro
@@ -1,47 +1,263 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
+import '../../../styles/analytics-sandbox.css';
 ---
-<Layout title="LinkedIn Pixel">
-  <div class="container">
-    <h1>LinkedIn Pixel Sandbox</h1>
-    <p>LinkedIn Insight Tag base snippet with event tracking.</p>
-    <button id="linkedin-button">Track Button</button>
-    <a href="#" id="linkedin-link">Track Link</a>
-    <form id="linkedin-form">
-      <input type="text" name="example" />
-      <button type="submit">Submit</button>
-    </form>
+<Layout title="LinkedIn Insight Tag Sandbox">
+  <div class="container analytics-sandbox linkedin-sandbox">
+    <header class="sandbox-header hairline-bottom">
+      <p class="supertitle mono">Analytics Lab / Instrumentation</p>
+      <h1>LinkedIn Insight Tag Sandbox</h1>
+      <p class="intro">
+        Inspect how the LinkedIn Insight Tag records conversions across key interface elements. Activate the
+        controls to see the mock payloads generated for each conversion ID.
+      </p>
+      <dl class="sandbox-meta">
+        <div>
+          <dt>Partner ID</dt>
+          <dd class="mono">LINKEDIN-ID</dd>
+        </div>
+        <div>
+          <dt>Endpoint</dt>
+          <dd class="mono">https://px.ads.linkedin.com/collect</dd>
+        </div>
+      </dl>
+    </header>
+
+    <div class="sandbox-grid">
+      <section class="sandbox-panel">
+        <article class="sandbox-card linkedin-card" data-li-card>
+          <header>
+            <p class="sandbox-card__tag mono">Conversion ID: 1</p>
+            <h3>Primary mission CTA</h3>
+          </header>
+          <p>
+            Represents the highest priority conversion on a landing surface. Includes mission metadata for
+            downstream segmentation.
+          </p>
+          <dl class="sandbox-card__meta">
+            <div>
+              <dt>Interaction</dt>
+              <dd class="mono">click</dd>
+            </div>
+            <div>
+              <dt>Label</dt>
+              <dd class="mono">Mission Brief Request</dd>
+            </div>
+          </dl>
+          <button
+            class="sandbox-action"
+            data-li-event="click"
+            data-li-conversion-id="1"
+            data-li-payload='{"content_type":"cta","cta_label":"Request Mission Brief","priority":"primary"}'
+            data-li-status="li-cta-status"
+            type="button"
+          >
+            Request mission brief
+          </button>
+          <p id="li-cta-status" class="linkedin-status">Idle — waiting for interaction.</p>
+        </article>
+
+        <article class="sandbox-card linkedin-card" data-li-card>
+          <header>
+            <p class="sandbox-card__tag mono">Conversion ID: 2</p>
+            <h3>Reference link</h3>
+          </header>
+          <p>
+            Captures mid-funnel navigation interest. Prevents navigation in this demo so you can review the
+            outbound payload.
+          </p>
+          <dl class="sandbox-card__meta">
+            <div>
+              <dt>Interaction</dt>
+              <dd class="mono">click</dd>
+            </div>
+            <div>
+              <dt>Destination</dt>
+              <dd class="mono">/resources/mission-overview</dd>
+            </div>
+          </dl>
+          <a
+            href="#"
+            class="sandbox-link"
+            data-li-event="click"
+            data-li-conversion-id="2"
+            data-li-prevent-default="true"
+            data-li-payload='{"destination":"/resources/mission-overview","link_type":"supporting"}'
+            data-li-status="li-link-status"
+          >
+            View mission overview
+          </a>
+          <p id="li-link-status" class="linkedin-status">Idle — waiting for interaction.</p>
+        </article>
+
+        <article class="sandbox-card linkedin-card" data-li-card>
+          <header>
+            <p class="sandbox-card__tag mono">Conversion ID: 3</p>
+            <h3>Lead qualification form</h3>
+          </header>
+          <p>
+            Demonstrates a lightweight lead capture flow with hashed identifiers and mission intent fields.
+          </p>
+          <dl class="sandbox-card__meta">
+            <div>
+              <dt>Interaction</dt>
+              <dd class="mono">submit</dd>
+            </div>
+            <div>
+              <dt>Mission focus</dt>
+              <dd class="mono">Dynamic (form value)</dd>
+            </div>
+          </dl>
+          <form
+            class="sandbox-form"
+            data-li-event="submit"
+            data-li-conversion-id="3"
+            data-li-prevent-default="true"
+            data-li-payload='{"lead_type":"enterprise","hashed_email":"4b825dc642cb6eb9a060e54bf8d69288"}'
+            data-li-status="li-form-status"
+          >
+            <label>
+              Mission focus
+              <select name="mission_focus">
+                <option value="orbital">Orbital research</option>
+                <option value="deep-space">Deep space comms</option>
+                <option value="earth-observation">Earth observation</option>
+              </select>
+            </label>
+            <label>
+              Mission identifier
+              <input type="text" name="mission_id" placeholder="mission-041" required />
+            </label>
+            <button type="submit" class="sandbox-action">Transmit lead</button>
+          </form>
+          <p id="li-form-status" class="linkedin-status">Idle — waiting for interaction.</p>
+        </article>
+      </section>
+
+      <aside class="sandbox-console linkedin-console" aria-labelledby="linkedin-console-heading">
+        <h2 id="linkedin-console-heading">Mock Insight Tag console</h2>
+        <p>
+          Displays the payload that would be sent to <code class="mono">https://px.ads.linkedin.com/collect</code>
+          along with a timestamp.
+        </p>
+        <div class="console-stream" data-li-console aria-live="polite">
+          <p class="console-empty" data-li-empty>Awaiting Insight Tag activity…</p>
+        </div>
+        <noscript>
+          <p class="console-empty">Enable JavaScript to observe the simulated conversions.</p>
+        </noscript>
+      </aside>
+    </div>
+
+    <section class="sandbox-snippet" aria-labelledby="linkedin-snippet-heading">
+      <h2 id="linkedin-snippet-heading">LinkedIn Insight Tag snippet</h2>
+      <p>
+        Load the Insight Tag asynchronously and configure the partner ID before firing conversions with
+        <code>lintrk('track', &#123;&#123; conversion_id &#125;&#125;)</code>.
+      </p>
+      <pre class="mono"><code>{`&lt;script type="text/javascript"&gt;
+  _linkedin_partner_id = 'LINKEDIN-ID';
+  window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+  window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+&lt;/script&gt;
+&lt;script type="text/javascript"&gt;
+  (function(l) {
+    if (!l) {
+      window.lintrk = function(a, b) { window.lintrk.q.push([a, b]); };
+      window.lintrk.q = [];
+    }
+    var s = document.getElementsByTagName('script')[0];
+    var b = document.createElement('script');
+    b.type = 'text/javascript'; b.async = true;
+    b.src = 'https://snap.licdn.com/li.lms-analytics/insight.min.js';
+    s.parentNode.insertBefore(b, s);
+  })(window.lintrk);
+&lt;/script&gt;`}</code></pre>
+    </section>
   </div>
-  <script type="text/javascript">
-    _linkedin_partner_id = "LINKEDIN-ID";
+
+  <script>
+    const partnerId = 'LINKEDIN-ID';
     window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
-    window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+    if (!window._linkedin_data_partner_ids.includes(partnerId)) {
+      window._linkedin_data_partner_ids.push(partnerId);
+    }
+
+    const consoleStream = document.querySelector('[data-li-console]');
+    const emptyState = document.querySelector('[data-li-empty]');
+
+    const pretty = (value) => JSON.stringify(value, null, 2);
+
+    const logConversion = (conversionId, payload) => {
+      if (!consoleStream) return;
+      if (emptyState && emptyState.parentElement) {
+        emptyState.remove();
+      }
+
+      const entry = document.createElement('article');
+      entry.className = 'console-entry';
+      entry.innerHTML = `
+        <header class="console-entry__meta">
+          <span class="console-entry__method">lintrk('track')</span>
+          <span>Conversion ${conversionId}</span>
+          <span>${new Date().toLocaleTimeString()}</span>
+        </header>
+        <pre class="console-entry__body">${pretty({ conversion_id: conversionId, payload })}</pre>
+      `;
+      consoleStream.prepend(entry);
+
+      const maxEntries = 8;
+      while (consoleStream.children.length > maxEntries) {
+        consoleStream.removeChild(consoleStream.lastElementChild);
+      }
+    };
+
+    const updateStatus = (statusId) => {
+      if (!statusId) return;
+      const target = document.getElementById(statusId);
+      if (!target) return;
+      target.textContent = `Last fired at ${new Date().toLocaleTimeString()}`;
+    };
+
+    const registerInteraction = (element) => {
+      const conversionId = element.dataset.liConversionId;
+      const interaction = element.dataset.liEvent || 'click';
+      const preventDefault = element.dataset.liPreventDefault === 'true';
+      const statusId = element.dataset.liStatus;
+      let payload = {};
+
+      try {
+        payload = element.dataset.liPayload ? JSON.parse(element.dataset.liPayload) : {};
+      } catch (error) {
+        payload = { error: 'Unable to parse payload', raw: element.dataset.liPayload };
+      }
+
+      element.addEventListener(interaction, (event) => {
+        if (preventDefault) {
+          event.preventDefault();
+        }
+
+        const enrichedPayload = element.tagName === 'FORM'
+          ? { ...payload, form_values: Object.fromEntries(new FormData(element)) }
+          : payload;
+
+        logConversion(conversionId, enrichedPayload);
+        updateStatus(statusId);
+
+        if (element.tagName === 'FORM') {
+          element.reset();
+        }
+      });
+    };
+
+    document.querySelectorAll('[data-li-conversion-id]').forEach(registerInteraction);
   </script>
-  <script type="text/javascript">
-    (function(l) {
-      if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
-      window.lintrk.q=[]}
-      var s = document.getElementsByTagName("script")[0];
-      var b = document.createElement("script");
-      b.type = "text/javascript";b.async = true;
-      b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
-      s.parentNode.insertBefore(b, s);
-    })(window.lintrk);
-    const button = document.getElementById('linkedin-button');
-    const link = document.getElementById('linkedin-link');
-    const form = document.getElementById('linkedin-form');
-    button.addEventListener('click', () => {
-      lintrk('track', { conversion_id: 1 });
-    });
-    link.addEventListener('click', () => {
-      lintrk('track', { conversion_id: 2 });
-    });
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      lintrk('track', { conversion_id: 3 });
-    });
-  </script>
-  <noscript>
-    <img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=LINKEDIN-ID&fmt=gif" />
-  </noscript>
+
+  <style>
+    .linkedin-sandbox .linkedin-status {
+      margin: 0;
+      font-size: var(--text-14);
+      color: var(--color-muted);
+    }
+  </style>
 </Layout>

--- a/src/pages/lab/analytics/meta-pixel.astro
+++ b/src/pages/lab/analytics/meta-pixel.astro
@@ -1,39 +1,50 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
+import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="Meta Pixel Sandbox">
-  <div class="container meta-sandbox">
-    <header class="meta-header">
-      <h1>Meta Pixel Instrumentation Sandbox</h1>
-      <p>
-        A hands-on view of how Meta Pixel events are applied to individual interface elements. Trigger any
-        interaction to inspect the exact payload that would be transmitted to the Meta Events Manager.
+  <div class="container analytics-sandbox meta-sandbox">
+    <header class="sandbox-header hairline-bottom">
+      <p class="supertitle mono">Analytics Lab / Instrumentation</p>
+      <h1>Meta Pixel Sandbox</h1>
+      <p class="intro">
+        Observe how Meta Pixel events bind to common interface elements. Trigger any interaction to inspect
+        the exact payload that would reach Events Manager in a production deployment.
       </p>
-      <div class="meta-header__details">
-        <span class="mono">Pixel ID: META-PIXEL-ID</span>
-        <span class="mono">Test Event Code: META-SANDBOX</span>
-      </div>
+      <dl class="sandbox-meta">
+        <div>
+          <dt>Pixel ID</dt>
+          <dd class="mono">META-PIXEL-ID</dd>
+        </div>
+        <div>
+          <dt>Test event code</dt>
+          <dd class="mono">META-SANDBOX</dd>
+        </div>
+        <div>
+          <dt>Endpoint</dt>
+          <dd class="mono">https://graph.facebook.com/v18.0/&lt;pixel-id&gt;/events</dd>
+        </div>
+      </dl>
     </header>
 
-    <div class="meta-grid">
-      <section class="meta-panel">
-        <h2>Tracked interface elements</h2>
+    <div class="sandbox-grid">
+      <section class="sandbox-panel meta-panel" aria-labelledby="meta-interface-heading">
+        <h2 id="meta-interface-heading">Tracked interface elements</h2>
         <p>
-          Each element below has data attributes that declare the Meta event name, interaction type, and
-          structured payload. These attributes are wired to <code>fbq('track')</code> calls inside the
-          sandbox script.
+          Each component below mirrors a production instrumentation pattern. Data attributes declare the
+          <code>fbq('track')</code> call, action source, and payload blueprint.
         </p>
 
-        <article class="meta-card" data-meta-card>
+        <article class="sandbox-card meta-card" data-meta-card>
           <header>
-            <h3>Primary Call-to-Action</h3>
-            <p class="mono" data-meta-call>fbq('track', 'LaunchCTA')</p>
+            <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'LaunchCTA')</p>
+            <h3>Primary call-to-action</h3>
           </header>
           <p>
-            Simulates the main conversion action on a mission landing page. Useful for validating revenue
-            and priority metadata before launching a campaign.
+            Simulates a mission-critical conversion button. Useful for validating revenue metadata before a
+            high-intent launch.
           </p>
-          <dl class="meta-card__meta">
+          <dl class="sandbox-card__meta">
             <div>
               <dt>Event</dt>
               <dd class="mono">LaunchCTA</dd>
@@ -43,18 +54,19 @@ import Layout from '../../../layouts/Layout.astro';
               <dd class="mono">click</dd>
             </div>
             <div>
-              <dt>Action Source</dt>
+              <dt>Action source</dt>
               <dd class="mono">website</dd>
             </div>
           </dl>
           <button
-            class="meta-action"
+            class="sandbox-action meta-action"
             data-meta-event="LaunchCTA"
             data-meta-interaction="click"
             data-meta-payload='{"component":"cta","cta_label":"Initiate Launch Sequence","priority":"primary","value":1250,"currency":"USD"}'
             data-meta-feedback="cta-status"
+            type="button"
           >
-            Initiate Launch Sequence
+            Initiate launch sequence
           </button>
           <p id="cta-status" class="meta-status">Idle — waiting for interaction.</p>
           <details>
@@ -63,16 +75,16 @@ import Layout from '../../../layouts/Layout.astro';
           </details>
         </article>
 
-        <article class="meta-card" data-meta-card>
+        <article class="sandbox-card meta-card" data-meta-card>
           <header>
-            <h3>Specification Link</h3>
-            <p class="mono" data-meta-call>fbq('track', 'ViewSpecifications')</p>
+            <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'ViewSpecifications')</p>
+            <h3>Specification link</h3>
           </header>
           <p>
-            Represents a mid-funnel click to read a technical PDF. The payload records link context and
-            document classification for downstream attribution.
+            Represents a mid-funnel content click. The payload records link context and document
+            classification for downstream attribution.
           </p>
-          <dl class="meta-card__meta">
+          <dl class="sandbox-card__meta">
             <div>
               <dt>Event</dt>
               <dd class="mono">ViewSpecifications</dd>
@@ -88,14 +100,14 @@ import Layout from '../../../layouts/Layout.astro';
           </dl>
           <a
             href="#"
-            class="meta-action meta-action--link"
+            class="sandbox-link meta-action meta-action--link"
             data-meta-event="ViewSpecifications"
             data-meta-interaction="click"
             data-meta-prevent-default="true"
             data-meta-payload='{"component":"document_link","destination":"mission-brief.pdf","content_category":"mission-overview","position":2}'
             data-meta-feedback="link-status"
           >
-            Download Mission Brief (PDF)
+            Download mission brief (PDF)
           </a>
           <p id="link-status" class="meta-status">Idle — waiting for interaction.</p>
           <details>
@@ -104,16 +116,16 @@ import Layout from '../../../layouts/Layout.astro';
           </details>
         </article>
 
-        <article class="meta-card" data-meta-card>
+        <article class="sandbox-card meta-card" data-meta-card>
           <header>
-            <h3>Qualified Lead Form</h3>
-            <p class="mono" data-meta-call>fbq('track', 'LeadSubmission')</p>
+            <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'LeadSubmission')</p>
+            <h3>Qualified lead form</h3>
           </header>
           <p>
-            Mimics a short lead capture form with hashed identifiers. Submission is intercepted so you can
-            review the outgoing payload without leaving the page.
+            Mimics a short lead capture flow with hashed identifiers. Submission is intercepted so you can
+            review the outbound payload without leaving the page.
           </p>
-          <dl class="meta-card__meta">
+          <dl class="sandbox-card__meta">
             <div>
               <dt>Event</dt>
               <dd class="mono">LeadSubmission</dd>
@@ -128,7 +140,7 @@ import Layout from '../../../layouts/Layout.astro';
             </div>
           </dl>
           <form
-            class="meta-form"
+            class="sandbox-form meta-form meta-action"
             data-meta-event="LeadSubmission"
             data-meta-interaction="submit"
             data-meta-prevent-default="true"
@@ -136,18 +148,18 @@ import Layout from '../../../layouts/Layout.astro';
             data-meta-feedback="form-status"
           >
             <label>
-              Mission Focus
+              Mission focus
               <select name="mission_focus">
-                <option value="orbital">Orbital Research</option>
-                <option value="deep-space">Deep Space Comms</option>
-                <option value="earth-observation">Earth Observation</option>
+                <option value="orbital">Orbital research</option>
+                <option value="deep-space">Deep space comms</option>
+                <option value="earth-observation">Earth observation</option>
               </select>
             </label>
             <label>
-              Mission Email (hashed)
+              Mission email (hashed)
               <input type="text" name="hashed_email" value="4b825dc642cb6eb9a060e54bf8d69288" readonly />
             </label>
-            <button type="submit" class="meta-action">Transmit Lead</button>
+            <button type="submit" class="sandbox-action">Transmit lead</button>
           </form>
           <p id="form-status" class="meta-status">Idle — waiting for interaction.</p>
           <details>
@@ -157,228 +169,41 @@ import Layout from '../../../layouts/Layout.astro';
         </article>
       </section>
 
-      <aside class="meta-console">
-        <h2>Mock transmission console</h2>
+      <aside class="sandbox-console meta-console" aria-labelledby="meta-console-heading">
+        <h2 id="meta-console-heading">Mock transmission console</h2>
         <p>
-          Shows the raw request body that would be delivered to the Meta Events API. Messages are generated
-          locally so no network traffic leaves this sandbox.
+          Displays the synthesized request body delivered to the Meta Events API. No network traffic leaves
+          this sandbox.
         </p>
-        <div class="meta-console__log" data-meta-console aria-live="polite">
-          <div class="meta-console__empty" data-meta-empty>
-            Awaiting transmissions. Trigger any element to populate this feed.
-          </div>
+        <div class="console-stream" data-meta-console aria-live="polite">
+          <p class="console-empty" data-meta-empty>Awaiting transmissions. Trigger any element to populate this feed.</p>
         </div>
       </aside>
     </div>
+
+    <section class="sandbox-snippet" aria-labelledby="meta-snippet-heading">
+      <h2 id="meta-snippet-heading">Meta Pixel base snippet</h2>
+      <p>
+        Deploy the base pixel early in the document head. Replace <code>META-PIXEL-ID</code> with your pixel
+        ID and add advanced matching parameters as needed.
+      </p>
+      <pre class="mono"><code>{`&lt;script&gt;
+  !function(f,b,e,v,n,t,s){
+    if(f.fbq) return;
+    n=f.fbq=function(){ n.callMethod ?
+      n.callMethod.apply(n,arguments) : n.queue.push(arguments);
+    };
+    if(!f._fbq) f._fbq=n;
+    n.push=n; n.loaded=!0; n.version='2.0';
+    n.queue=[]; t=b.createElement(e); t.async=!0;
+    t.src=v; s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s);
+  }(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', 'META-PIXEL-ID');
+  fbq('track', 'PageView');
+&lt;/script&gt;`}</code></pre>
+    </section>
   </div>
-
-  <style>
-    .meta-sandbox {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-4);
-      padding-top: var(--space-4);
-      padding-bottom: var(--space-5);
-    }
-
-    .meta-header {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2);
-      background: rgba(17, 17, 17, 0.04);
-      border: 1px solid var(--color-rule);
-      padding: var(--space-3);
-    }
-
-    .meta-header__details {
-      display: flex;
-      flex-wrap: wrap;
-      gap: var(--space-2);
-    }
-
-    .meta-grid {
-      display: grid;
-      grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-      gap: var(--space-4);
-    }
-
-    .meta-panel {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-3);
-    }
-
-    .meta-panel > p {
-      margin: 0;
-    }
-
-    .meta-card {
-      border: 1px solid var(--color-rule);
-      background: var(--color-bg);
-      padding: var(--space-3);
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2);
-    }
-
-    .meta-card header h3 {
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      margin-bottom: var(--space-1);
-    }
-
-    .meta-card__meta {
-      display: grid;
-      gap: var(--space-1);
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      margin: 0;
-    }
-
-    .meta-card__meta dt {
-      font-size: var(--text-12);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--color-muted);
-    }
-
-    .meta-card__meta dd {
-      margin: 0;
-    }
-
-    .meta-action {
-      font-family: var(--font-sans);
-      font-size: var(--text-16);
-      background: var(--color-text);
-      color: var(--color-bg);
-      border: none;
-      padding: var(--space-2);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      cursor: pointer;
-      transition: background 0.2s ease, transform 0.2s ease;
-    }
-
-    .meta-action:hover,
-    .meta-action:focus {
-      background: var(--color-accent);
-      outline: none;
-    }
-
-    .meta-action:focus-visible {
-      outline: 2px solid var(--color-accent);
-      outline-offset: 2px;
-    }
-
-    .meta-action--link {
-      display: inline-block;
-      text-decoration: none;
-      text-align: center;
-    }
-
-    .meta-action--fired {
-      transform: translateY(-1px);
-      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
-    }
-
-    .meta-status {
-      font-size: var(--text-14);
-      color: var(--color-muted);
-      margin: 0;
-    }
-
-    .meta-pre {
-      background: rgba(17, 17, 17, 0.06);
-      border: 1px solid var(--color-rule);
-      padding: var(--space-2);
-      overflow-x: auto;
-      font-size: var(--text-14);
-    }
-
-    .meta-form {
-      display: grid;
-      gap: var(--space-2);
-      margin-top: var(--space-1);
-    }
-
-    .meta-form label {
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-1);
-      font-size: var(--text-14);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
-    .meta-form select,
-    .meta-form input {
-      padding: var(--space-1);
-      border: 1px solid var(--color-rule);
-      background: #fff;
-      font-size: var(--text-16);
-      font-family: var(--font-sans);
-    }
-
-    .meta-console {
-      border: 1px solid var(--color-rule);
-      background: rgba(17, 17, 17, 0.02);
-      padding: var(--space-3);
-      display: flex;
-      flex-direction: column;
-      gap: var(--space-2);
-      max-height: 100%;
-      position: sticky;
-      top: var(--space-4);
-      align-self: flex-start;
-    }
-
-    .meta-console__log {
-      display: grid;
-      gap: var(--space-2);
-      max-height: 520px;
-      overflow: auto;
-      padding-right: var(--space-1);
-      border-top: 1px solid var(--color-rule);
-      padding-top: var(--space-2);
-    }
-
-    .meta-console__empty {
-      color: var(--color-muted);
-      font-size: var(--text-14);
-    }
-
-    .console-entry {
-      border: 1px solid var(--color-rule);
-      background: var(--color-bg);
-      padding: var(--space-2);
-      display: grid;
-      gap: var(--space-1);
-    }
-
-    .console-entry__header {
-      font-size: var(--text-14);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
-    .console-entry pre {
-      margin: 0;
-      font-size: var(--text-14);
-      background: rgba(17, 17, 17, 0.04);
-      border: 1px solid var(--color-rule);
-      padding: var(--space-1);
-      overflow-x: auto;
-    }
-
-    @media (max-width: 1024px) {
-      .meta-grid {
-        grid-template-columns: 1fr;
-      }
-
-      .meta-console {
-        position: static;
-      }
-    }
-  </style>
 
   <script>
     const metaPixelId = 'META-PIXEL-ID';
@@ -399,11 +224,12 @@ import Layout from '../../../layouts/Layout.astro';
       entry.className = 'console-entry';
 
       const header = document.createElement('div');
-      header.className = 'console-entry__header mono';
+      header.className = 'console-entry__meta mono';
       const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
       header.textContent = `${timestamp} · ${summary}`;
 
       const payloadBlock = document.createElement('pre');
+      payloadBlock.className = 'console-entry__body';
       payloadBlock.textContent = body;
 
       entry.append(header, payloadBlock);
@@ -516,4 +342,37 @@ import Layout from '../../../layouts/Layout.astro';
       environment: 'lab',
     });
   </script>
+
+  <style>
+    .meta-sandbox .meta-card details {
+      border-top: 1px solid var(--color-rule);
+      padding-top: var(--space-2);
+    }
+
+    .meta-sandbox .meta-status {
+      font-size: var(--text-14);
+      color: var(--color-muted);
+      margin: 0;
+    }
+
+    .meta-sandbox .meta-pre {
+      margin: 0;
+      padding: var(--space-2);
+      border: 1px solid var(--color-rule);
+      border-radius: var(--radius-2);
+      background: rgba(0, 0, 0, 0.04);
+      font-size: var(--text-12);
+      overflow-x: auto;
+    }
+
+    .meta-sandbox .meta-form select,
+    .meta-sandbox .meta-form input {
+      background: rgba(255, 255, 255, 0.85);
+    }
+
+    .meta-sandbox .meta-action--fired {
+      box-shadow: 0 0 0 2px rgba(126, 37, 34, 0.25);
+      transform: translateY(-1px);
+    }
+  </style>
 </Layout>

--- a/src/pages/lab/analytics/unified-data-layer.astro
+++ b/src/pages/lab/analytics/unified-data-layer.astro
@@ -1,34 +1,276 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
+import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="Unified Data Layer">
-  <div class="container">
-    <h1>Unified Data Layer</h1>
-    <p>Example data layer pattern with custom events.</p>
-    <button id="udl-button">Track Button</button>
-    <a href="#" id="udl-link">Track Link</a>
-    <form id="udl-form">
-      <input type="text" name="example" />
-      <button type="submit">Submit</button>
-    </form>
+  <div class="container analytics-sandbox udl-sandbox">
+    <header class="sandbox-header hairline-bottom">
+      <p class="supertitle mono">Analytics Lab / Instrumentation</p>
+      <h1>Unified Data Layer Sandbox</h1>
+      <p class="intro">
+        Prototype a normalized event model that can power any analytics or marketing endpoint. Engage with
+        the controls to observe the structured payloads delivered to <code>window.dataLayer</code>.
+      </p>
+      <dl class="sandbox-meta">
+        <div>
+          <dt>Schema</dt>
+          <dd class="mono">unified-data-layer/v2</dd>
+        </div>
+        <div>
+          <dt>Namespace</dt>
+          <dd class="mono">lab.analytics.udl</dd>
+        </div>
+      </dl>
+    </header>
+
+    <div class="sandbox-grid">
+      <section class="sandbox-panel">
+        <section class="sandbox-card udl-context" aria-labelledby="udl-context-heading">
+          <h2 id="udl-context-heading">Base context snapshot</h2>
+          <p>
+            Session, user, and page objects are seeded once per visit. Every interaction extends this payload
+            so downstream tags inherit a shared vocabulary.
+          </p>
+          <div class="udl-context__grid">
+            <article>
+              <h3>Session</h3>
+              <pre class="mono">{`{
+  "id": "session-0042",
+  "timestamp": "2024-01-01T12:00:00Z",
+  "source": "organic"
+}`}</pre>
+            </article>
+            <article>
+              <h3>User</h3>
+              <pre class="mono">{`{
+  "auth_state": "anonymous",
+  "persona": "analyst",
+  "account_tier": "explorer"
+}`}</pre>
+            </article>
+            <article>
+              <h3>Page</h3>
+              <pre class="mono">{`{
+  "template": "lab-sandbox",
+  "section": "analytics",
+  "language": "en-US"
+}`}</pre>
+            </article>
+          </div>
+        </section>
+
+        <section class="sandbox-card udl-interactions" aria-labelledby="udl-interactions-heading">
+          <h2 id="udl-interactions-heading">Tracked interactions</h2>
+          <p>
+            Buttons, links, and forms declare their instrumentation through data attributes. A helper maps the
+            DOM metadata into normalized payloads pushed into the data layer.
+          </p>
+          <div class="udl-interactions__grid">
+            <button
+              class="sandbox-action"
+              data-udl-event="cta_click"
+              data-udl-element="Launch Primary CTA"
+              data-udl-module="udl-sandbox.cta"
+              data-udl-value="primary"
+            >
+              Initiate launch sequence
+            </button>
+            <a
+              href="#"
+              class="sandbox-link"
+              data-udl-event="documentation_open"
+              data-udl-element="Sandbox Documentation Link"
+              data-udl-module="udl-sandbox.navigation"
+              data-udl-prevent-default="true"
+            >
+              View implementation checklist
+            </a>
+            <form
+              class="sandbox-form"
+              data-udl-event="form_submit"
+              data-udl-element="Mission Intake Form"
+              data-udl-module="udl-sandbox.form"
+              data-udl-trigger="submit"
+            >
+              <label for="udl-mission">Mission objective</label>
+              <input id="udl-mission" name="missionObjective" placeholder="Calibrate telemetry" />
+              <button type="submit" class="sandbox-action">Submit request</button>
+            </form>
+          </div>
+        </section>
+      </section>
+
+      <aside class="sandbox-console udl-console" aria-labelledby="udl-console-heading">
+        <h2 id="udl-console-heading">Data layer stream</h2>
+        <p>
+          Shows the most recent <code>dataLayer.push</code> operations. Newest entries appear first.
+        </p>
+        <div class="console-stream" data-udl-console aria-live="polite">
+          <p class="console-empty" data-udl-empty>No events yet. Trigger an interaction to populate the stream.</p>
+        </div>
+      </aside>
+    </div>
+
+    <section class="sandbox-snippet" aria-labelledby="udl-snippet-heading">
+      <h2 id="udl-snippet-heading">Bootstrap snippet</h2>
+      <p>
+        Initialize the data layer early and push the session, user, and page context before registering
+        interaction handlers.
+      </p>
+      <pre class="mono"><code>{`&lt;script&gt;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    schema: 'unified-data-layer/v2',
+    session: {/* ... */},
+    user: {/* ... */},
+    page: {/* ... */}
+  });
+&lt;/script&gt;`}</code></pre>
+    </section>
   </div>
+
   <script>
     window.dataLayer = window.dataLayer || [];
-    function track(eventName, detail) {
-      window.dataLayer.push({ event: eventName, ...detail });
-    }
-    const button = document.getElementById('udl-button');
-    const link = document.getElementById('udl-link');
-    const form = document.getElementById('udl-form');
-    button.addEventListener('click', () => {
-      track('button_click', { label: 'UDL Button' });
-    });
-    link.addEventListener('click', () => {
-      track('link_click', { label: 'UDL Link' });
-    });
-    form.addEventListener('submit', (e) => {
-      e.preventDefault();
-      track('form_submit', { label: 'UDL Form' });
+
+    const consoleStream = document.querySelector('[data-udl-console]');
+    const emptyState = document.querySelector('[data-udl-empty]');
+
+    const baseContext = {
+      schema: 'unified-data-layer/v2',
+      session: {
+        id: 'session-' + Math.random().toString(36).slice(2, 10),
+        timestamp: new Date().toISOString(),
+        source: 'direct',
+      },
+      user: {
+        auth_state: 'anonymous',
+        persona: 'visitor',
+        account_tier: 'explorer',
+      },
+      page: {
+        template: 'lab-sandbox',
+        section: 'analytics',
+        language: document.documentElement.lang || 'en-US',
+      },
+    };
+
+    const pushToDataLayer = (payload) => {
+      window.dataLayer.push(payload);
+      if (!consoleStream) return;
+      if (emptyState && emptyState.parentElement) {
+        emptyState.remove();
+      }
+
+      const entry = document.createElement('article');
+      entry.className = 'console-entry';
+      entry.innerHTML = `
+        <header class="console-entry__meta">
+          <span class="console-entry__method">dataLayer.push</span>
+          <span>${payload.event}</span>
+          <span>${new Date().toLocaleTimeString()}</span>
+        </header>
+        <pre class="console-entry__body">${JSON.stringify(payload, null, 2)}</pre>
+      `;
+      consoleStream.prepend(entry);
+
+      const maxEntries = 8;
+      while (consoleStream.children.length > maxEntries) {
+        consoleStream.removeChild(consoleStream.lastElementChild);
+      }
+    };
+
+    const buildInteractionPayload = (element) => {
+      const eventName = element.dataset.udlEvent;
+      const module = element.dataset.udlModule || 'udl-sandbox.component';
+      const el = element.dataset.udlElement || element.textContent?.trim() || element.tagName.toLowerCase();
+      const value = element.dataset.udlValue || null;
+      const trigger = element.dataset.udlTrigger || (element.tagName === 'FORM' ? 'submit' : 'click');
+
+      const formValues = element.tagName === 'FORM'
+        ? Object.fromEntries(new FormData(element).entries())
+        : null;
+
+      return {
+        event: eventName,
+        schema: baseContext.schema,
+        session: baseContext.session,
+        user: baseContext.user,
+        page: baseContext.page,
+        interaction: {
+          element: el,
+          module,
+          value,
+          trigger,
+          form_values: formValues,
+        },
+      };
+    };
+
+    const registerInteraction = (element) => {
+      const preventDefault = element.dataset.udlPreventDefault === 'true';
+      const trigger = element.dataset.udlTrigger || (element.tagName === 'FORM' ? 'submit' : 'click');
+
+      element.addEventListener(trigger, (event) => {
+        if (preventDefault || element.tagName === 'FORM') {
+          event.preventDefault();
+        }
+
+        const payload = buildInteractionPayload(element);
+        pushToDataLayer(payload);
+
+        if (element.tagName === 'FORM') {
+          element.reset();
+        }
+      });
+    };
+
+    document.querySelectorAll('[data-udl-event]').forEach(registerInteraction);
+
+    pushToDataLayer({
+      event: 'page_view',
+      ...baseContext,
+      interaction: {
+        element: 'Unified Data Layer Sandbox',
+        module: 'udl-sandbox.page',
+        value: null,
+        trigger: 'view',
+        form_values: null,
+      },
     });
   </script>
+
+  <style>
+    .udl-sandbox .udl-context__grid {
+      display: grid;
+      gap: var(--space-3);
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
+    .udl-sandbox .udl-context__grid article {
+      border: 1px solid var(--color-rule);
+      border-radius: var(--radius-2);
+      padding: var(--space-2);
+      background: rgba(0, 0, 0, 0.04);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .udl-sandbox .udl-context__grid h3 {
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .udl-sandbox .udl-context__grid pre {
+      margin: 0;
+      font-size: var(--text-12);
+      overflow-x: auto;
+    }
+
+    .udl-sandbox .udl-interactions__grid {
+      display: grid;
+      gap: var(--space-3);
+    }
+  </style>
 </Layout>

--- a/src/pages/lab/analytics/x-pixel.astro
+++ b/src/pages/lab/analytics/x-pixel.astro
@@ -1,111 +1,145 @@
 ---
 import Layout from '../../../layouts/Layout.astro';
+import '../../../styles/analytics-sandbox.css';
 ---
-<Layout title="X Pixel">
-  <div class="sandbox">
-    <header class="sandbox__intro">
+<Layout title="X Pixel Sandbox">
+  <div class="container analytics-sandbox x-sandbox">
+    <header class="sandbox-header hairline-bottom">
+      <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>X Pixel Sandbox</h1>
-      <p>
-        Explore how the X (Twitter) Pixel instruments on-page interactions. The left column
-        outlines the tracking metadata applied to each element, while the mock console on the
-        right shows the payloads that would be transmitted to the X endpoint.
+      <p class="intro">
+        Explore how the X (Twitter) Pixel instruments on-page interactions. The left column outlines the
+        tracking metadata applied to each element, while the console on the right shows the payloads that
+        would be transmitted to the X endpoint.
       </p>
-    </header>
-    <div class="sandbox__grid">
-      <section class="panel">
-        <h2>Instrumentation Overview</h2>
-        <p class="panel__lead">
-          Each interactive element is annotated with <code>data-twq-*</code> attributes so that
-          the tracking plan is transparent at a glance.
-        </p>
-        <dl class="tracking-map">
-          <div class="tracking-map__item">
-            <dt>Primary Call-to-Action Button</dt>
-            <dd>
-              <span class="label">Event:</span>
-              <code>button_click</code>
-            </dd>
-            <dd>
-              <span class="label">Parameters:</span>
-              <code>&#123;&quot;content_name&quot;:&quot;Sandbox CTA&quot;,&quot;value&quot;:1&#125;</code>
-            </dd>
-          </div>
-          <div class="tracking-map__item">
-            <dt>Annotated Reference Link</dt>
-            <dd>
-              <span class="label">Event:</span>
-              <code>link_click</code>
-            </dd>
-            <dd>
-              <span class="label">Parameters:</span>
-              <code>&#123;&quot;destination&quot;:&quot;/lab/analytics&quot;&#125;</code>
-            </dd>
-          </div>
-          <div class="tracking-map__item">
-            <dt>Qualification Form Submission</dt>
-            <dd>
-              <span class="label">Event:</span>
-              <code>form_submit</code>
-            </dd>
-            <dd>
-              <span class="label">Parameters:</span>
-              <code>&#123;&quot;form_name&quot;:&quot;interest_capture&quot;&#125;</code>
-            </dd>
-          </div>
-        </dl>
-      </section>
-      <section class="panel sandbox__interactive" aria-labelledby="sandbox-elements">
-        <h2 id="sandbox-elements">Interactive Elements</h2>
-        <p class="panel__lead">
-          Trigger an interaction to see a live payload appear in the mock endpoint console.
-        </p>
-        <div class="interactive-grid">
-          <button
-            id="x-button"
-            class="sandbox-element"
-            type="button"
-            data-twq-event="button_click"
-            data-twq-parameters='{"content_name":"Sandbox CTA","value":1}'
-          >
-            Initiate Launch Sequence
-          </button>
-          <a
-            id="x-link"
-            class="sandbox-element"
-            href="/lab/analytics"
-            data-twq-event="link_click"
-            data-twq-parameters='{"destination":"/lab/analytics"}'
-          >
-            View Analytics Lab Index
-          </a>
-          <form
-            id="x-form"
-            class="sandbox-element sandbox-element--form"
-            data-twq-event="form_submit"
-            data-twq-parameters='{"form_name":"interest_capture"}'
-          >
-            <label for="mission-interest">Mission Interest</label>
-            <input
-              id="mission-interest"
-              name="mission_interest"
-              type="text"
-              placeholder="Telemetry optimization"
-              required
-            />
-            <button type="submit">Submit Signal</button>
-          </form>
+      <dl class="sandbox-meta">
+        <div>
+          <dt>Pixel ID</dt>
+          <dd class="mono">TW-XXXXXXXXXX</dd>
         </div>
+        <div>
+          <dt>Endpoint</dt>
+          <dd class="mono">https://ads-api.twitter.com/</dd>
+        </div>
+      </dl>
+    </header>
+
+    <div class="sandbox-grid">
+      <section class="sandbox-panel">
+        <section class="sandbox-card x-map" aria-labelledby="x-map-heading">
+          <h2 id="x-map-heading">Instrumentation overview</h2>
+          <p>
+            Each interactive element is annotated with <code>data-twq-*</code> attributes so the tracking plan
+            is transparent at a glance.
+          </p>
+          <dl class="x-map__list">
+            <div>
+              <dt>Primary call-to-action</dt>
+              <dd>
+                <span class="label">Event</span>
+                <code>button_click</code>
+              </dd>
+              <dd>
+                <span class="label">Parameters</span>
+                <code>{`{"content_name":"Sandbox CTA","value":1}`}</code>
+              </dd>
+            </div>
+            <div>
+              <dt>Annotated reference link</dt>
+              <dd>
+                <span class="label">Event</span>
+                <code>link_click</code>
+              </dd>
+              <dd>
+                <span class="label">Parameters</span>
+                <code>{`{"destination":"/lab/analytics"}`}</code>
+              </dd>
+            </div>
+            <div>
+              <dt>Qualification form submission</dt>
+              <dd>
+                <span class="label">Event</span>
+                <code>form_submit</code>
+              </dd>
+              <dd>
+                <span class="label">Parameters</span>
+                <code>{`{"form_name":"interest_capture"}`}</code>
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="sandbox-card x-interactive" aria-labelledby="x-interactive-heading">
+          <h2 id="x-interactive-heading">Interactive elements</h2>
+          <p>Trigger an interaction to see a live payload appear in the mock endpoint console.</p>
+          <div class="x-interactive__grid">
+            <button
+              id="x-button"
+              class="sandbox-action sandbox-element"
+              type="button"
+              data-twq-event="button_click"
+              data-twq-parameters='{"content_name":"Sandbox CTA","value":1}'
+            >
+              Initiate launch sequence
+            </button>
+            <a
+              id="x-link"
+              class="sandbox-link sandbox-element"
+              href="/lab/analytics"
+              data-twq-event="link_click"
+              data-twq-parameters='{"destination":"/lab/analytics"}'
+            >
+              View analytics lab index
+            </a>
+            <form
+              id="x-form"
+              class="sandbox-form sandbox-element sandbox-element--form"
+              data-twq-event="form_submit"
+              data-twq-parameters='{"form_name":"interest_capture"}'
+            >
+              <label for="mission-interest">Mission interest</label>
+              <input
+                id="mission-interest"
+                name="mission_interest"
+                type="text"
+                placeholder="Telemetry optimization"
+                required
+              />
+              <button type="submit" class="sandbox-action">Submit signal</button>
+            </form>
+          </div>
+        </section>
       </section>
-      <aside class="panel panel--console" aria-live="polite">
-        <h2>Mock X Endpoint Payloads</h2>
-        <p class="panel__lead">
-          The payloads below are synthetic representations of what would be transmitted to the X
-          conversion endpoint for each interaction.
+
+      <aside class="sandbox-console x-console" aria-labelledby="x-console-heading">
+        <h2 id="x-console-heading">Mock X endpoint payloads</h2>
+        <p>
+          Payloads below are synthetic representations of what would be transmitted to the X conversion
+          endpoint for each interaction.
         </p>
-        <div id="mock-console" class="console" role="log"></div>
+        <div id="mock-console" class="console-stream" role="log" aria-live="polite"></div>
       </aside>
     </div>
+
+    <section class="sandbox-snippet" aria-labelledby="x-snippet-heading">
+      <h2 id="x-snippet-heading">X Pixel base snippet</h2>
+      <p>
+        Add the bootstrap script before closing <code>&lt;head&gt;</code> and call <code>twq('config')</code>
+        with your pixel ID. This sandbox decorates the queue to expose payloads locally.
+      </p>
+      <pre class="mono"><code>{`&lt;script&gt;
+  !function(e,t,n,s,u,a){
+    e.twq||(s=e.twq=function(){
+      s.exe ? s.exe.apply(s, arguments) : s.queue.push(arguments);
+    }, s.version='1.1', s.queue=[], u=t.createElement(n), u.async=!0,
+    u.src='https://static.ads-twitter.com/uwt.js', a=t.getElementsByTagName(n)[0],
+    a.parentNode.insertBefore(u,a));
+  }(window, document, 'script');
+  twq('config', 'TW-XXXXXXXXXX');
+&lt;/script&gt;`}</code></pre>
+    </section>
   </div>
+
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       !function(e,t,n,s,u,a){
@@ -122,15 +156,15 @@ import Layout from '../../../layouts/Layout.astro';
 
       const createConsoleEntry = (type, name, payload) => {
         const entry = document.createElement('article');
-        entry.className = 'console__entry';
+        entry.className = 'console-entry';
         const timestamp = new Date();
         entry.innerHTML = `
-          <header class="console__entry-header">
-            <span class="console__entry-type">${type}</span>
-            <span class="console__entry-name">${name}</span>
+          <header class="console-entry__meta">
+            <span class="console-entry__method">${type}</span>
+            <span>${name}</span>
             <time datetime="${timestamp.toISOString()}">${timestamp.toLocaleTimeString()}</time>
           </header>
-          <pre class="console__entry-body">${JSON.stringify(payload, null, 2)}</pre>
+          <pre class="console-entry__body">${JSON.stringify(payload, null, 2)}</pre>
         `;
         consolePanel.prepend(entry);
         const maxEntries = 6;
@@ -204,216 +238,63 @@ import Layout from '../../../layouts/Layout.astro';
       });
     });
   </script>
+
   <style>
-    .sandbox {
-      display: flex;
-      flex-direction: column;
-      gap: 3rem;
-      padding-block: 3rem;
-    }
-
-    .sandbox__intro h1 {
-      font-size: clamp(2rem, 5vw, 3rem);
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .sandbox__grid {
-      display: grid;
-      gap: 2rem;
-      grid-template-columns: 1fr;
-    }
-
-    .panel {
-      background: var(--color-surface, #f6f1e3);
-      border: 1px solid var(--color-border, #d7c9a7);
-      border-radius: 0.5rem;
-      padding: 1.75rem;
-      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.05);
-    }
-
-    .panel__lead {
-      font-size: 0.95rem;
-      color: rgba(24, 24, 24, 0.72);
-      max-width: 60ch;
-    }
-
-    .tracking-map {
-      display: grid;
-      gap: 1.5rem;
-      margin: 2rem 0 0;
-    }
-
-    .tracking-map__item {
-      border-left: 3px solid #7e2522;
-      padding-left: 1rem;
-    }
-
-    .tracking-map__item dt {
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      margin-bottom: 0.5rem;
-    }
-
-    .tracking-map__item dd {
-      margin: 0.1rem 0;
-      display: flex;
-      gap: 0.5rem;
-      align-items: baseline;
-      font-family: 'IBM Plex Mono', 'Courier New', monospace;
-      font-size: 0.9rem;
-    }
-
-    .tracking-map__item .label {
-      color: rgba(24, 24, 24, 0.6);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      font-size: 0.75rem;
-    }
-
-    .interactive-grid {
-      display: grid;
-      gap: 1.5rem;
-    }
-
-    .sandbox-element {
-      display: flex;
-      flex-direction: column;
-      gap: 0.75rem;
-      border: 2px solid #181818;
-      border-radius: 0.4rem;
-      padding: 1.25rem;
-      text-align: left;
-      background: #fff;
-      font-size: 1rem;
-      font-weight: 600;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-    }
-
-    .sandbox-element:focus-visible {
-      outline: 3px solid #7e2522;
-      outline-offset: 2px;
-    }
-
-    .sandbox-element--form {
-      gap: 1rem;
-      text-transform: none;
-      font-weight: 400;
-      letter-spacing: 0;
-    }
-
-    .sandbox-element--form label {
-      font-family: 'IBM Plex Mono', 'Courier New', monospace;
-      font-size: 0.85rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    .sandbox-element--form input {
-      border: 1px solid #b39b74;
-      border-radius: 0.35rem;
-      padding: 0.75rem;
-      font-size: 1rem;
-    }
-
-    .sandbox-element--form button {
-      align-self: flex-start;
-      border: 2px solid #7e2522;
-      background: #7e2522;
-      color: #fff;
-      padding: 0.65rem 1.5rem;
-      border-radius: 999px;
-      font-size: 0.95rem;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
-    }
-
-    .sandbox-element--active {
-      border-color: #7e2522;
-      box-shadow: 0 0 0 3px rgba(126, 37, 34, 0.2);
-      transform: translateY(-2px);
-    }
-
-    .panel--console {
-      background: #101010;
-      color: #f6f1e3;
-      border-color: #383838;
-    }
-
-    .panel--console .panel__lead {
-      color: rgba(246, 241, 227, 0.78);
-    }
-
-    .console {
-      margin-top: 1.5rem;
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-      max-height: 28rem;
-      overflow-y: auto;
-      padding-right: 0.5rem;
-    }
-
-    .console__entry {
-      border: 1px solid rgba(246, 241, 227, 0.25);
-      border-radius: 0.35rem;
-      padding: 1rem;
-      background: rgba(8, 8, 8, 0.65);
-      font-family: 'IBM Plex Mono', 'Courier New', monospace;
-    }
-
-    .console__entry-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: baseline;
-      gap: 0.75rem;
-      font-size: 0.85rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-bottom: 0.75rem;
-    }
-
-    .console__entry-type {
-      color: #bb8537;
-    }
-
-    .console__entry-name {
-      color: #f6f1e3;
-      font-weight: 600;
-    }
-
-    .console__entry-body {
+    .x-sandbox .x-map__list {
       margin: 0;
-      font-size: 0.85rem;
-      line-height: 1.4;
-      white-space: pre-wrap;
+      display: grid;
+      gap: var(--space-2);
     }
 
-    @media (min-width: 64rem) {
-      .sandbox__grid {
-        grid-template-columns: 1fr 1fr;
-        grid-template-areas:
-          'overview console'
-          'interactive console';
-      }
+    .x-sandbox .x-map__list div {
+      border-left: 3px solid #7e2522;
+      padding-left: var(--space-2);
+      display: grid;
+      gap: 4px;
+    }
 
-      .sandbox__grid > .panel:nth-child(1) {
-        grid-area: overview;
-      }
+    .x-sandbox .x-map__list dt {
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      margin: 0;
+    }
 
-      .sandbox__grid > .panel:nth-child(2) {
-        grid-area: interactive;
-      }
+    .x-sandbox .x-map__list dd {
+      margin: 0;
+      display: flex;
+      gap: var(--space-1);
+      align-items: baseline;
+      font-family: var(--font-mono);
+      font-size: var(--text-12);
+    }
 
-      .panel--console {
-        grid-area: console;
-        position: sticky;
-        top: 6rem;
-        align-self: start;
-      }
+    .x-sandbox .x-map__list .label {
+      color: var(--color-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: var(--text-12);
+    }
+
+    .x-sandbox .x-interactive__grid {
+      display: grid;
+      gap: var(--space-3);
+    }
+
+    .x-sandbox .sandbox-element--form {
+      gap: var(--space-2);
+    }
+
+    .x-sandbox .sandbox-element--form label {
+      font-family: var(--font-mono);
+      font-size: var(--text-12);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .x-sandbox .sandbox-element--active {
+      box-shadow: 0 0 0 2px rgba(126, 37, 34, 0.25);
+      transform: translateY(-2px);
     }
   </style>
 </Layout>

--- a/src/styles/analytics-sandbox.css
+++ b/src/styles/analytics-sandbox.css
@@ -1,0 +1,298 @@
+.analytics-sandbox {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-5);
+}
+
+.sandbox-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-bottom: var(--space-3);
+}
+
+.sandbox-header h1 {
+  font-size: clamp(2.25rem, 3vw, 3rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.supertitle {
+  font-size: var(--text-14);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.intro {
+  max-width: 72ch;
+}
+
+.sandbox-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+}
+
+.sandbox-meta div {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.sandbox-meta dt {
+  font-size: var(--text-12);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.sandbox-meta dd {
+  margin: 0;
+  font-size: var(--text-16);
+}
+
+.sandbox-grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+  align-items: start;
+}
+
+.sandbox-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sandbox-panel h2,
+.sandbox-console h2,
+.sandbox-snippet h2,
+.sandbox-appendix h2 {
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.sandbox-panel > p,
+.sandbox-console > p,
+.sandbox-snippet > p,
+.sandbox-appendix > p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.sandbox-card,
+.sandbox-callout {
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-2);
+  background: rgba(255, 255, 255, 0.6);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sandbox-card header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.sandbox-card h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sandbox-card__tag {
+  font-size: var(--text-12);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.sandbox-card__meta {
+  display: grid;
+  gap: var(--space-2);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin: 0;
+}
+
+.sandbox-card__meta div {
+  display: grid;
+  gap: 4px;
+}
+
+.sandbox-card__meta dt {
+  font-size: var(--text-12);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.sandbox-card__meta dd {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-14);
+}
+
+.sandbox-action,
+.sandbox-link {
+  align-self: flex-start;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-text);
+  border-radius: var(--radius-2);
+  background: transparent;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--text-14);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sandbox-action:hover,
+.sandbox-action:focus,
+.sandbox-link:hover,
+.sandbox-link:focus {
+  background: var(--color-text);
+  color: var(--color-bg);
+}
+
+.sandbox-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sandbox-form label {
+  font-family: var(--font-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: var(--text-12);
+}
+
+.sandbox-form input,
+.sandbox-form select,
+.sandbox-form textarea {
+  padding: var(--space-1);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-1);
+  font-size: var(--text-16);
+  font-family: var(--font-sans);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.sandbox-console {
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-2);
+  background: rgba(17, 17, 17, 0.04);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.console-stream {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  max-height: 520px;
+  overflow-y: auto;
+  padding-right: var(--space-1);
+}
+
+.console-empty {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.console-entry {
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-2);
+  padding: var(--space-2);
+  background: rgba(255, 255, 255, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.console-entry__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  font-size: var(--text-12);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.console-entry__method {
+  font-weight: 700;
+}
+
+.console-entry__body {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-12);
+  white-space: pre-wrap;
+}
+
+.sandbox-snippet {
+  border-top: 1px solid var(--color-rule);
+  padding-top: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sandbox-snippet pre {
+  margin: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-2);
+  background: rgba(255, 255, 255, 0.6);
+  overflow-x: auto;
+}
+
+.sandbox-list {
+  margin: 0;
+  padding-left: var(--space-3);
+  display: grid;
+  gap: var(--space-1);
+}
+
+@media (max-width: 1024px) {
+  .sandbox-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .console-stream {
+    max-height: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .sandbox-card,
+  .sandbox-callout,
+  .console-entry,
+  .sandbox-snippet pre {
+    background: rgba(13, 13, 13, 0.6);
+  }
+
+  .sandbox-console {
+    background: rgba(255, 255, 255, 0.04);
+  }
+}


### PR DESCRIPTION
## Summary
- establish a shared analytics sandbox design system and update all lab/analytics sandboxes to use it
- refresh GA4, GTM, Adobe, Meta, LinkedIn, X Pixel, and unified data layer demos with consistent layouts, copy, and interactive logging
- add documentation-style snippets and metadata panels so each sandbox reflects the NASA-inspired presentation

## Testing
- npm test *(fails: missing script)*
- npm run lint *(fails: missing script)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e300e439988323b4ea3e329fb8ef5a