### PR TITLE
Fix GA4 sandbox frontmatter to restore styling

### DIFF
--- a/src/pages/lab/analytics/ga4-sandbox.astro
+++ b/src/pages/lab/analytics/ga4-sandbox.astro
@@ -1,3 +1,4 @@
+---
 import Layout from '../../../layouts/Layout.astro';
 import '../../../styles/analytics-sandbox.css';
 ---


### PR DESCRIPTION
## Summary
- restore the Astro frontmatter block in the GA4 sandbox page so its layout and scoped stylesheet load correctly

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e305084aac8323941bd5dec2ad696b