### PR TITLE
Improve analytics sandbox console UX

### DIFF
--- a/src/pages/lab/analytics/adobe-analytics.astro
+++ b/src/pages/lab/analytics/adobe-analytics.astro
@@ -168,17 +168,25 @@ import '../../../styles/analytics-sandbox.css';
         </section>
       </section>
 
-      <aside class="sandbox-console adobe-console" aria-labelledby="adobe-console-heading">
-        <div class="adobe-console__header">
-          <h2 id="adobe-console-heading">Beacon payloads</h2>
-          <button type="button" class="sandbox-action adobe-reset" data-aa-reset>Clear log</button>
-        </div>
+      <aside class="sandbox-console adobe-console" data-console-panel aria-labelledby="adobe-console-heading">
+        <h2 id="adobe-console-heading">Beacon payloads</h2>
         <p>
           Simulated requests to <code class="mono">https://metrics-demo.sc.omtrdc.net/b/ss/jwiedeman.sandbox/1/JS-2.23.0/s</code>.
           Entries render the raw query string along with the structured JSON payload.
         </p>
-        <div class="console-stream" data-aa-console role="log" aria-live="polite" aria-relevant="additions">
-          <p class="console-empty">Awaiting Adobe Analytics activity…</p>
+        <div class="sandbox-console__toolbar" role="group" aria-label="Adobe Analytics console controls">
+          <button type="button" class="console-control" data-console-scroll disabled>Jump to latest</button>
+          <button type="button" class="console-control" data-console-clear disabled>Clear console</button>
+        </div>
+        <div
+          class="console-stream"
+          data-console-stream
+          role="log"
+          aria-live="polite"
+          aria-relevant="additions"
+          tabindex="0"
+        >
+          <p class="console-empty" data-console-empty>Awaiting Adobe Analytics activity…</p>
         </div>
         <noscript>
           <p class="console-empty">Enable JavaScript to observe the simulated beacon output.</p>
@@ -188,57 +196,105 @@ import '../../../styles/analytics-sandbox.css';
   </div>
 
   <script type="module">
-    const consoleWindow = document.querySelector('[data-aa-console]');
-    const resetButton = document.querySelector('[data-aa-reset]');
     const endpoint = 'https://metrics-demo.sc.omtrdc.net/b/ss/jwiedeman.sandbox/1/JS-2.23.0/s';
+    const MAX_ENTRIES = 8;
 
-    const removeEmptyState = () => {
-      const empty = consoleWindow?.querySelector('.console-empty');
-      if (empty) {
-        empty.remove();
+    function createSandboxConsole({ limit = MAX_ENTRIES } = {}) {
+      const panel = document.querySelector('[data-console-panel]');
+      const stream = panel ? panel.querySelector('[data-console-stream]') : null;
+      const empty = stream ? stream.querySelector('[data-console-empty]') : null;
+      const clearButton = panel ? panel.querySelector('[data-console-clear]') : null;
+      const scrollButton = panel ? panel.querySelector('[data-console-scroll]') : null;
+
+      if (!panel || !stream) {
+        return null;
       }
-    };
 
-    const addEmptyState = () => {
-      if (!consoleWindow) return;
-      if (consoleWindow.querySelector('.console-empty')) {
-        return;
+      const hideEmpty = () => {
+        if (empty) {
+          empty.hidden = true;
+        }
+      };
+
+      const showEmpty = () => {
+        if (empty) {
+          empty.hidden = false;
+        }
+      };
+
+      const updateControls = () => {
+        const hasEntries = !!stream.querySelector('.console-entry');
+        if (clearButton) {
+          clearButton.disabled = !hasEntries;
+        }
+        if (scrollButton) {
+          scrollButton.disabled = !hasEntries;
+        }
+      };
+
+      const focusPanel = () => {
+        const rect = panel.getBoundingClientRect();
+        const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+        if (!fullyVisible) {
+          panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      };
+
+      if (clearButton) {
+        clearButton.addEventListener('click', () => {
+          stream.querySelectorAll('.console-entry').forEach((entry) => entry.remove());
+          showEmpty();
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          if (typeof stream.focus === 'function') {
+            stream.focus();
+          }
+        });
       }
-      const paragraph = document.createElement('p');
-      paragraph.className = 'console-empty';
-      paragraph.textContent = 'Awaiting Adobe Analytics activity…';
-      consoleWindow.append(paragraph);
-    };
 
-    const appendConsoleEntry = (payload) => {
-      if (!consoleWindow) return;
-      removeEmptyState();
-
-      const entry = document.createElement('article');
-      entry.className = 'console-entry';
-
-      const header = document.createElement('div');
-      header.className = 'console-entry__meta mono';
-      const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
-      header.textContent = `${timestamp} · ${payload.summary}`;
-
-      const requestBlock = document.createElement('pre');
-      requestBlock.className = 'console-entry__body';
-      requestBlock.textContent = payload.request;
-
-      const dataBlock = document.createElement('pre');
-      dataBlock.className = 'console-entry__body';
-      dataBlock.textContent = JSON.stringify(payload.data, null, 2);
-
-      entry.append(header, requestBlock, dataBlock);
-      consoleWindow.prepend(entry);
-
-      const maxEntries = 8;
-      const entries = consoleWindow.querySelectorAll('.console-entry');
-      if (entries.length > maxEntries) {
-        entries[entries.length - 1].remove();
+      if (scrollButton) {
+        scrollButton.addEventListener('click', () => {
+          focusPanel();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+        });
       }
-    };
+
+      updateControls();
+
+      return {
+        append(entry) {
+          hideEmpty();
+          entry.classList.add('console-entry--recent');
+          entry.addEventListener(
+            'animationend',
+            () => entry.classList.remove('console-entry--recent'),
+            { once: true }
+          );
+          stream.prepend(entry);
+          const entries = Array.from(stream.querySelectorAll('.console-entry'));
+          if (limit && entries.length > limit) {
+            entries.slice(limit).forEach((oldEntry) => oldEntry.remove());
+          }
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          focusPanel();
+        }
+      };
+    }
+
+    const consoleUI = createSandboxConsole({ limit: MAX_ENTRIES });
 
     const buildPayload = (linkName, linkType, attributes) => {
       const query = new URLSearchParams({
@@ -246,23 +302,43 @@ import '../../../styles/analytics-sandbox.css';
         AQE: '1',
         pe: linkType,
         pev2: linkName,
-        ...attributes,
+        ...attributes
       });
 
       return {
+        method: 'GET',
         summary: `${linkType.toUpperCase()} · ${linkName}`,
         request: `${endpoint}?${query.toString()}`,
         data: {
           linkName,
           linkType,
-          ...attributes,
-        },
+          ...attributes
+        }
       };
+    };
+
+    const logPayload = (payload) => {
+      if (!consoleUI) {
+        return;
+      }
+      const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
+      const entry = document.createElement('article');
+      entry.className = 'console-entry';
+      entry.innerHTML = `
+        <header class="console-entry__meta">
+          <span class="console-entry__method">${payload.method}</span>
+          <span>${payload.summary}</span>
+          <span>${timestamp}</span>
+        </header>
+        <pre class="console-entry__body">${payload.request}</pre>
+        <pre class="console-entry__body">${JSON.stringify(payload.data, null, 2)}</pre>
+      `;
+      consoleUI.append(entry);
     };
 
     const fireLinkTracking = (linkName, linkType, attributes) => {
       const payload = buildPayload(linkName, linkType, attributes);
-      appendConsoleEntry(payload);
+      logPayload(payload);
     };
 
     const bindingMap = {
@@ -274,8 +350,8 @@ import '../../../styles/analytics-sandbox.css';
           prop4: 'launch:cta',
           eVar4: 'Launch — Primary',
           'contextData.component': 'mission-controls',
-          'contextData.priority': 'primary',
-        },
+          'contextData.priority': 'primary'
+        }
       },
       nav: {
         linkName: 'nav:telemetry-logs',
@@ -285,8 +361,8 @@ import '../../../styles/analytics-sandbox.css';
           prop6: 'nav:telemetry',
           eVar6: 'Navigation Link',
           'contextData.component': 'global-nav',
-          'contextData.destination': 'telemetry',
-        },
+          'contextData.destination': 'telemetry'
+        }
       },
       form: {
         linkName: 'form:telemetry-upload',
@@ -296,9 +372,9 @@ import '../../../styles/analytics-sandbox.css';
           prop9: 'form:telemetry',
           eVar9: 'Telemetry Upload',
           'contextData.component': 'telemetry',
-          'contextData.submission': 'form',
-        },
-      },
+          'contextData.submission': 'form'
+        }
+      }
     };
 
     document.getElementById('aa-primary-cta')?.addEventListener('click', () => {
@@ -316,12 +392,6 @@ import '../../../styles/analytics-sandbox.css';
       event.currentTarget.reset();
     });
 
-    resetButton?.addEventListener('click', () => {
-      if (!consoleWindow) return;
-      consoleWindow.innerHTML = '';
-      addEmptyState();
-    });
-
     const pageViewPayload = buildPayload('page:view', 't', {
       events: 'event1',
       pageName: 'lab:analytics:adobe-analytics',
@@ -329,9 +399,9 @@ import '../../../styles/analytics-sandbox.css';
       prop1: 'lab:analytics',
       eVar1: 'Adobe Analytics Sandbox',
       'contextData.page.missionPhase': 'demo',
-      'contextData.page.template': 'sandbox',
+      'contextData.page.template': 'sandbox'
     });
-    appendConsoleEntry(pageViewPayload);
+    logPayload(pageViewPayload);
   </script>
 
   <style>
@@ -348,18 +418,6 @@ import '../../../styles/analytics-sandbox.css';
 
     .adobe-sandbox .adobe-console {
       gap: var(--space-2);
-    }
-
-    .adobe-sandbox .adobe-console__header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: var(--space-2);
-    }
-
-    .adobe-sandbox .adobe-reset {
-      font-size: var(--text-12);
-      letter-spacing: 0.12em;
     }
   </style>
 </Layout>

--- a/src/pages/lab/analytics/ga4-sandbox.astro
+++ b/src/pages/lab/analytics/ga4-sandbox.astro
@@ -109,12 +109,22 @@ import '../../../styles/analytics-sandbox.css';
         </article>
       </section>
 
-      <aside class="sandbox-console" aria-labelledby="ga4-console-heading">
+      <aside class="sandbox-console" data-console-panel aria-labelledby="ga4-console-heading">
         <h2 id="ga4-console-heading">Mock GA4 console</h2>
         <p class="console-copy">
           Payloads are formatted to match Measurement Protocol requests. Newest events appear at the top.
         </p>
-        <div class="console-stream" data-console-stream aria-live="polite">
+        <div class="sandbox-console__toolbar" role="group" aria-label="GA4 console controls">
+          <button type="button" class="console-control" data-console-scroll disabled>Jump to latest</button>
+          <button type="button" class="console-control" data-console-clear disabled>Clear console</button>
+        </div>
+        <div
+          class="console-stream"
+          data-console-stream
+          aria-live="polite"
+          role="log"
+          tabindex="0"
+        >
           <p class="console-empty" data-console-empty>Interact with the sandbox to emit GA4 traffic.</p>
         </div>
       </aside>
@@ -142,8 +152,102 @@ import '../../../styles/analytics-sandbox.css';
     const endpoint = 'https://www.google-analytics.com/mp/collect';
     window.dataLayer = window.dataLayer || [];
 
-    const logContainer = document.querySelector('[data-console-stream]');
-    const emptyState = logContainer ? logContainer.querySelector('[data-console-empty]') : null;
+    function createSandboxConsole({ limit = 12 } = {}) {
+      const panel = document.querySelector('[data-console-panel]');
+      const stream = panel ? panel.querySelector('[data-console-stream]') : null;
+      const empty = stream ? stream.querySelector('[data-console-empty]') : null;
+      const clearButton = panel ? panel.querySelector('[data-console-clear]') : null;
+      const scrollButton = panel ? panel.querySelector('[data-console-scroll]') : null;
+
+      if (!panel || !stream) {
+        return null;
+      }
+
+      const hideEmpty = () => {
+        if (empty) {
+          empty.hidden = true;
+        }
+      };
+
+      const showEmpty = () => {
+        if (empty) {
+          empty.hidden = false;
+        }
+      };
+
+      const updateControls = () => {
+        const hasEntries = !!stream.querySelector('.console-entry');
+        if (clearButton) {
+          clearButton.disabled = !hasEntries;
+        }
+        if (scrollButton) {
+          scrollButton.disabled = !hasEntries;
+        }
+      };
+
+      const focusPanel = () => {
+        const rect = panel.getBoundingClientRect();
+        const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+        if (!fullyVisible) {
+          panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      };
+
+      if (clearButton) {
+        clearButton.addEventListener('click', () => {
+          stream.querySelectorAll('.console-entry').forEach((entry) => entry.remove());
+          showEmpty();
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          if (typeof stream.focus === 'function') {
+            stream.focus();
+          }
+        });
+      }
+
+      if (scrollButton) {
+        scrollButton.addEventListener('click', () => {
+          focusPanel();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+        });
+      }
+
+      updateControls();
+
+      return {
+        append(entry) {
+          hideEmpty();
+          entry.classList.add('console-entry--recent');
+          entry.addEventListener(
+            'animationend',
+            () => entry.classList.remove('console-entry--recent'),
+            { once: true }
+          );
+          stream.prepend(entry);
+          const entries = Array.from(stream.querySelectorAll('.console-entry'));
+          if (limit && entries.length > limit) {
+            entries.slice(limit).forEach((oldEntry) => oldEntry.remove());
+          }
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          focusPanel();
+        }
+      };
+    }
+
+    const consoleUI = createSandboxConsole({ limit: 12 });
 
     function formatPayload(args) {
       const [command, param1, param2] = args;
@@ -183,12 +287,8 @@ import '../../../styles/analytics-sandbox.css';
     }
 
     function appendLog(args) {
-      if (!logContainer) {
+      if (!consoleUI) {
         return;
-      }
-
-      if (emptyState && emptyState.parentElement) {
-        emptyState.remove();
       }
 
       const payload = formatPayload(args);
@@ -202,7 +302,7 @@ import '../../../styles/analytics-sandbox.css';
         </header>
         <pre class="console-entry__body">${payload.preformatted}</pre>
       `;
-      logContainer.prepend(entry);
+      consoleUI.append(entry);
     }
 
     function gtag() {

--- a/src/pages/lab/analytics/gtm-sandbox.astro
+++ b/src/pages/lab/analytics/gtm-sandbox.astro
@@ -151,13 +151,23 @@ import '../../../styles/analytics-sandbox.css';
         </section>
       </section>
 
-      <aside class="sandbox-console" aria-labelledby="gtm-console-heading">
+      <aside class="sandbox-console" data-console-panel aria-labelledby="gtm-console-heading">
         <h2 id="gtm-console-heading">Mock GTM console</h2>
         <p>
           Mirrors the latest <code>dataLayer.push</code> entries and the staged network request. Entries are
           trimmed to the eight most recent interactions.
         </p>
-        <div class="console-stream" data-console-stream aria-live="polite">
+        <div class="sandbox-console__toolbar" role="group" aria-label="GTM console controls">
+          <button type="button" class="console-control" data-console-scroll disabled>Jump to latest</button>
+          <button type="button" class="console-control" data-console-clear disabled>Clear console</button>
+        </div>
+        <div
+          class="console-stream"
+          data-console-stream
+          aria-live="polite"
+          role="log"
+          tabindex="0"
+        >
           <p class="console-empty" data-console-empty>No events yet. Trigger an interaction to populate the console.</p>
         </div>
       </aside>
@@ -195,11 +205,104 @@ import '../../../styles/analytics-sandbox.css';
     document.addEventListener('DOMContentLoaded', () => {
       const dataLayer = window.dataLayer || [];
       window.dataLayer = dataLayer;
-
-      const consoleStream = document.querySelector('[data-console-stream]');
-      const consoleEmpty = document.querySelector('[data-console-empty]');
-      const transmissions = [];
       const MAX_ITEMS = 8;
+
+      function createSandboxConsole({ limit = MAX_ITEMS } = {}) {
+        const panel = document.querySelector('[data-console-panel]');
+        const stream = panel ? panel.querySelector('[data-console-stream]') : null;
+        const empty = stream ? stream.querySelector('[data-console-empty]') : null;
+        const clearButton = panel ? panel.querySelector('[data-console-clear]') : null;
+        const scrollButton = panel ? panel.querySelector('[data-console-scroll]') : null;
+
+        if (!panel || !stream) {
+          return null;
+        }
+
+        const hideEmpty = () => {
+          if (empty) {
+            empty.hidden = true;
+          }
+        };
+
+        const showEmpty = () => {
+          if (empty) {
+            empty.hidden = false;
+          }
+        };
+
+        const updateControls = () => {
+          const hasEntries = !!stream.querySelector('.console-entry');
+          if (clearButton) {
+            clearButton.disabled = !hasEntries;
+          }
+          if (scrollButton) {
+            scrollButton.disabled = !hasEntries;
+          }
+        };
+
+        const focusPanel = () => {
+          const rect = panel.getBoundingClientRect();
+          const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+          if (!fullyVisible) {
+            panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+        };
+
+        if (clearButton) {
+          clearButton.addEventListener('click', () => {
+            stream.querySelectorAll('.console-entry').forEach((entry) => entry.remove());
+            showEmpty();
+            updateControls();
+            if (typeof stream.scrollTo === 'function') {
+              stream.scrollTo({ top: 0, behavior: 'smooth' });
+            } else {
+              stream.scrollTop = 0;
+            }
+            if (typeof stream.focus === 'function') {
+              stream.focus();
+            }
+          });
+        }
+
+        if (scrollButton) {
+          scrollButton.addEventListener('click', () => {
+            focusPanel();
+            if (typeof stream.scrollTo === 'function') {
+              stream.scrollTo({ top: 0, behavior: 'smooth' });
+            } else {
+              stream.scrollTop = 0;
+            }
+          });
+        }
+
+        updateControls();
+
+        return {
+          append(entry) {
+            hideEmpty();
+            entry.classList.add('console-entry--recent');
+            entry.addEventListener(
+              'animationend',
+              () => entry.classList.remove('console-entry--recent'),
+              { once: true }
+            );
+            stream.prepend(entry);
+            const entries = Array.from(stream.querySelectorAll('.console-entry'));
+            if (limit && entries.length > limit) {
+              entries.slice(limit).forEach((oldEntry) => oldEntry.remove());
+            }
+            updateControls();
+            if (typeof stream.scrollTo === 'function') {
+              stream.scrollTo({ top: 0, behavior: 'smooth' });
+            } else {
+              stream.scrollTop = 0;
+            }
+            focusPanel();
+          }
+        };
+      }
+
+      const consoleUI = createSandboxConsole({ limit: MAX_ITEMS });
 
       const baseContext = {
         session: {
@@ -219,35 +322,21 @@ import '../../../styles/analytics-sandbox.css';
         }
       };
 
-      const renderConsole = () => {
-        if (!consoleStream) return;
-        if (consoleEmpty) {
-          consoleEmpty.hidden = transmissions.length > 0;
-        }
-        consoleStream.innerHTML = '';
-        transmissions.slice(0, MAX_ITEMS).forEach((entry) => {
-          const article = document.createElement('article');
-          article.className = 'console-entry';
-          article.innerHTML = `
-            <header class="console-entry__meta">
-              <span class="console-entry__method">${entry.type}</span>
-              <span>${entry.label}</span>
-              <span>${entry.timestamp}</span>
-            </header>
-            <pre class="console-entry__body">${JSON.stringify(entry.payload, null, 2)}</pre>
-          `;
-          consoleStream.appendChild(article);
-        });
-      };
-
       const recordTransmission = (type, label, payload) => {
-        transmissions.unshift({
-          type,
-          label,
-          payload,
-          timestamp: new Date().toLocaleTimeString()
-        });
-        renderConsole();
+        if (!consoleUI) {
+          return;
+        }
+        const article = document.createElement('article');
+        article.className = 'console-entry';
+        article.innerHTML = `
+          <header class="console-entry__meta">
+            <span class="console-entry__method">${type}</span>
+            <span>${label}</span>
+            <span>${new Date().toLocaleTimeString()}</span>
+          </header>
+          <pre class="console-entry__body">${JSON.stringify(payload, null, 2)}</pre>
+        `;
+        consoleUI.append(article);
       };
 
       const buildPayload = ({ eventName, element, module, value, method, formData }) => ({

--- a/src/pages/lab/analytics/linkedin-pixel.astro
+++ b/src/pages/lab/analytics/linkedin-pixel.astro
@@ -134,14 +134,24 @@ import '../../../styles/analytics-sandbox.css';
         </article>
       </section>
 
-      <aside class="sandbox-console linkedin-console" aria-labelledby="linkedin-console-heading">
+      <aside class="sandbox-console linkedin-console" data-console-panel aria-labelledby="linkedin-console-heading">
         <h2 id="linkedin-console-heading">Mock Insight Tag console</h2>
         <p>
           Displays the payload that would be sent to <code class="mono">https://px.ads.linkedin.com/collect</code>
           along with a timestamp.
         </p>
-        <div class="console-stream" data-li-console aria-live="polite">
-          <p class="console-empty" data-li-empty>Awaiting Insight Tag activity…</p>
+        <div class="sandbox-console__toolbar" role="group" aria-label="LinkedIn console controls">
+          <button type="button" class="console-control" data-console-scroll disabled>Jump to latest</button>
+          <button type="button" class="console-control" data-console-clear disabled>Clear console</button>
+        </div>
+        <div
+          class="console-stream"
+          data-console-stream
+          aria-live="polite"
+          role="log"
+          tabindex="0"
+        >
+          <p class="console-empty" data-console-empty>Awaiting Insight Tag activity…</p>
         </div>
         <noscript>
           <p class="console-empty">Enable JavaScript to observe the simulated conversions.</p>
@@ -183,17 +193,107 @@ import '../../../styles/analytics-sandbox.css';
       window._linkedin_data_partner_ids.push(partnerId);
     }
 
-    const consoleStream = document.querySelector('[data-li-console]');
-    const emptyState = document.querySelector('[data-li-empty]');
+    function createSandboxConsole({ limit = 8 } = {}) {
+      const panel = document.querySelector('[data-console-panel]');
+      const stream = panel ? panel.querySelector('[data-console-stream]') : null;
+      const empty = stream ? stream.querySelector('[data-console-empty]') : null;
+      const clearButton = panel ? panel.querySelector('[data-console-clear]') : null;
+      const scrollButton = panel ? panel.querySelector('[data-console-scroll]') : null;
+
+      if (!panel || !stream) {
+        return null;
+      }
+
+      const hideEmpty = () => {
+        if (empty) {
+          empty.hidden = true;
+        }
+      };
+
+      const showEmpty = () => {
+        if (empty) {
+          empty.hidden = false;
+        }
+      };
+
+      const updateControls = () => {
+        const hasEntries = !!stream.querySelector('.console-entry');
+        if (clearButton) {
+          clearButton.disabled = !hasEntries;
+        }
+        if (scrollButton) {
+          scrollButton.disabled = !hasEntries;
+        }
+      };
+
+      const focusPanel = () => {
+        const rect = panel.getBoundingClientRect();
+        const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+        if (!fullyVisible) {
+          panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      };
+
+      if (clearButton) {
+        clearButton.addEventListener('click', () => {
+          stream.querySelectorAll('.console-entry').forEach((entry) => entry.remove());
+          showEmpty();
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          if (typeof stream.focus === 'function') {
+            stream.focus();
+          }
+        });
+      }
+
+      if (scrollButton) {
+        scrollButton.addEventListener('click', () => {
+          focusPanel();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+        });
+      }
+
+      updateControls();
+
+      return {
+        append(entry) {
+          hideEmpty();
+          entry.classList.add('console-entry--recent');
+          entry.addEventListener(
+            'animationend',
+            () => entry.classList.remove('console-entry--recent'),
+            { once: true }
+          );
+          stream.prepend(entry);
+          const entries = Array.from(stream.querySelectorAll('.console-entry'));
+          if (limit && entries.length > limit) {
+            entries.slice(limit).forEach((oldEntry) => oldEntry.remove());
+          }
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          focusPanel();
+        }
+      };
+    }
+
+    const consoleUI = createSandboxConsole({ limit: 8 });
 
     const pretty = (value) => JSON.stringify(value, null, 2);
 
     const logConversion = (conversionId, payload) => {
-      if (!consoleStream) return;
-      if (emptyState && emptyState.parentElement) {
-        emptyState.remove();
-      }
-
+      if (!consoleUI) return;
       const entry = document.createElement('article');
       entry.className = 'console-entry';
       entry.innerHTML = `
@@ -204,12 +304,7 @@ import '../../../styles/analytics-sandbox.css';
         </header>
         <pre class="console-entry__body">${pretty({ conversion_id: conversionId, payload })}</pre>
       `;
-      consoleStream.prepend(entry);
-
-      const maxEntries = 8;
-      while (consoleStream.children.length > maxEntries) {
-        consoleStream.removeChild(consoleStream.lastElementChild);
-      }
+      consoleUI.append(entry);
     };
 
     const updateStatus = (statusId) => {

--- a/src/pages/lab/analytics/meta-pixel.astro
+++ b/src/pages/lab/analytics/meta-pixel.astro
@@ -169,14 +169,24 @@ import '../../../styles/analytics-sandbox.css';
         </article>
       </section>
 
-      <aside class="sandbox-console meta-console" aria-labelledby="meta-console-heading">
+      <aside class="sandbox-console meta-console" data-console-panel aria-labelledby="meta-console-heading">
         <h2 id="meta-console-heading">Mock transmission console</h2>
         <p>
           Displays the synthesized request body delivered to the Meta Events API. No network traffic leaves
           this sandbox.
         </p>
-        <div class="console-stream" data-meta-console aria-live="polite">
-          <p class="console-empty" data-meta-empty>Awaiting transmissions. Trigger any element to populate this feed.</p>
+        <div class="sandbox-console__toolbar" role="group" aria-label="Meta console controls">
+          <button type="button" class="console-control" data-console-scroll disabled>Jump to latest</button>
+          <button type="button" class="console-control" data-console-clear disabled>Clear console</button>
+        </div>
+        <div
+          class="console-stream"
+          data-console-stream
+          aria-live="polite"
+          role="log"
+          tabindex="0"
+        >
+          <p class="console-empty" data-console-empty>Awaiting transmissions. Trigger any element to populate this feed.</p>
         </div>
       </aside>
     </div>
@@ -210,35 +220,121 @@ import '../../../styles/analytics-sandbox.css';
     const metaEndpoint = `https://graph.facebook.com/v18.0/${metaPixelId}/events`;
     const testEventCode = 'META-SANDBOX';
 
-    const consoleLog = document.querySelector('[data-meta-console]');
-    const emptyState = document.querySelector('[data-meta-empty]');
+    function createSandboxConsole({ limit = 8 } = {}) {
+      const panel = document.querySelector('[data-console-panel]');
+      const stream = panel ? panel.querySelector('[data-console-stream]') : null;
+      const empty = stream ? stream.querySelector('[data-console-empty]') : null;
+      const clearButton = panel ? panel.querySelector('[data-console-clear]') : null;
+      const scrollButton = panel ? panel.querySelector('[data-console-scroll]') : null;
+
+      if (!panel || !stream) {
+        return null;
+      }
+
+      const hideEmpty = () => {
+        if (empty) {
+          empty.hidden = true;
+        }
+      };
+
+      const showEmpty = () => {
+        if (empty) {
+          empty.hidden = false;
+        }
+      };
+
+      const updateControls = () => {
+        const hasEntries = !!stream.querySelector('.console-entry');
+        if (clearButton) {
+          clearButton.disabled = !hasEntries;
+        }
+        if (scrollButton) {
+          scrollButton.disabled = !hasEntries;
+        }
+      };
+
+      const focusPanel = () => {
+        const rect = panel.getBoundingClientRect();
+        const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+        if (!fullyVisible) {
+          panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      };
+
+      if (clearButton) {
+        clearButton.addEventListener('click', () => {
+          stream.querySelectorAll('.console-entry').forEach((entry) => entry.remove());
+          showEmpty();
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          if (typeof stream.focus === 'function') {
+            stream.focus();
+          }
+        });
+      }
+
+      if (scrollButton) {
+        scrollButton.addEventListener('click', () => {
+          focusPanel();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+        });
+      }
+
+      updateControls();
+
+      return {
+        append(entry) {
+          hideEmpty();
+          entry.classList.add('console-entry--recent');
+          entry.addEventListener(
+            'animationend',
+            () => entry.classList.remove('console-entry--recent'),
+            { once: true }
+          );
+          stream.prepend(entry);
+          const entries = Array.from(stream.querySelectorAll('.console-entry'));
+          if (limit && entries.length > limit) {
+            entries.slice(limit).forEach((oldEntry) => oldEntry.remove());
+          }
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          focusPanel();
+        }
+      };
+    }
+
+    const consoleUI = createSandboxConsole({ limit: 8 });
 
     const prettyJson = (value) => JSON.stringify(value, null, 2);
 
-    const pushConsoleEntry = (summary, body) => {
-      if (emptyState) {
-        emptyState.remove();
+    const pushConsoleEntry = ({ method, label, body }) => {
+      if (!consoleUI) {
+        return;
       }
-
+      const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
       const entry = document.createElement('article');
       entry.className = 'console-entry';
-
-      const header = document.createElement('div');
-      header.className = 'console-entry__meta mono';
-      const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false });
-      header.textContent = `${timestamp} · ${summary}`;
-
-      const payloadBlock = document.createElement('pre');
-      payloadBlock.className = 'console-entry__body';
-      payloadBlock.textContent = body;
-
-      entry.append(header, payloadBlock);
-      consoleLog.prepend(entry);
-
-      const entries = consoleLog.querySelectorAll('.console-entry');
-      if (entries.length > 8) {
-        entries[entries.length - 1].remove();
-      }
+      entry.innerHTML = `
+        <header class="console-entry__meta">
+          <span class="console-entry__method">${method}</span>
+          <span>${label}</span>
+          <span>${timestamp}</span>
+        </header>
+        <pre class="console-entry__body">${body}</pre>
+      `;
+      consoleUI.append(entry);
     };
 
     const fbq = (command, ...args) => {
@@ -257,21 +353,24 @@ import '../../../styles/analytics-sandbox.css';
           test_event_code: testEventCode,
         };
 
-        pushConsoleEntry(
-          `POST ${eventName}`,
-          prettyJson({ method: 'POST', url: metaEndpoint, body: payload })
-        );
+        pushConsoleEntry({
+          method: 'POST',
+          label: eventName,
+          body: prettyJson({ method: 'POST', url: metaEndpoint, body: payload })
+        });
       } else if (command === 'init') {
         const [pixelId, advancedMatching = {}] = args;
-        pushConsoleEntry(
-          "fbq('init')",
-          prettyJson({ pixelId, advancedMatching })
-        );
+        pushConsoleEntry({
+          method: "fbq('init')",
+          label: 'Bootstrap',
+          body: prettyJson({ pixelId, advancedMatching })
+        });
       } else {
-        pushConsoleEntry(
-          `fbq('${command}')`,
-          prettyJson({ command, args })
-        );
+        pushConsoleEntry({
+          method: `fbq('${command}')`,
+          label: 'Meta pixel callback',
+          body: prettyJson({ command, args })
+        });
       }
     };
 

--- a/src/pages/lab/analytics/unified-data-layer.astro
+++ b/src/pages/lab/analytics/unified-data-layer.astro
@@ -100,13 +100,23 @@ import '../../../styles/analytics-sandbox.css';
         </section>
       </section>
 
-      <aside class="sandbox-console udl-console" aria-labelledby="udl-console-heading">
+      <aside class="sandbox-console udl-console" data-console-panel aria-labelledby="udl-console-heading">
         <h2 id="udl-console-heading">Data layer stream</h2>
         <p>
           Shows the most recent <code>dataLayer.push</code> operations. Newest entries appear first.
         </p>
-        <div class="console-stream" data-udl-console aria-live="polite">
-          <p class="console-empty" data-udl-empty>No events yet. Trigger an interaction to populate the stream.</p>
+        <div class="sandbox-console__toolbar" role="group" aria-label="Data layer console controls">
+          <button type="button" class="console-control" data-console-scroll disabled>Jump to latest</button>
+          <button type="button" class="console-control" data-console-clear disabled>Clear console</button>
+        </div>
+        <div
+          class="console-stream"
+          data-console-stream
+          aria-live="polite"
+          role="log"
+          tabindex="0"
+        >
+          <p class="console-empty" data-console-empty>No events yet. Trigger an interaction to populate the stream.</p>
         </div>
       </aside>
     </div>
@@ -132,8 +142,102 @@ import '../../../styles/analytics-sandbox.css';
   <script>
     window.dataLayer = window.dataLayer || [];
 
-    const consoleStream = document.querySelector('[data-udl-console]');
-    const emptyState = document.querySelector('[data-udl-empty]');
+    function createSandboxConsole({ limit = 8 } = {}) {
+      const panel = document.querySelector('[data-console-panel]');
+      const stream = panel ? panel.querySelector('[data-console-stream]') : null;
+      const empty = stream ? stream.querySelector('[data-console-empty]') : null;
+      const clearButton = panel ? panel.querySelector('[data-console-clear]') : null;
+      const scrollButton = panel ? panel.querySelector('[data-console-scroll]') : null;
+
+      if (!panel || !stream) {
+        return null;
+      }
+
+      const hideEmpty = () => {
+        if (empty) {
+          empty.hidden = true;
+        }
+      };
+
+      const showEmpty = () => {
+        if (empty) {
+          empty.hidden = false;
+        }
+      };
+
+      const updateControls = () => {
+        const hasEntries = !!stream.querySelector('.console-entry');
+        if (clearButton) {
+          clearButton.disabled = !hasEntries;
+        }
+        if (scrollButton) {
+          scrollButton.disabled = !hasEntries;
+        }
+      };
+
+      const focusPanel = () => {
+        const rect = panel.getBoundingClientRect();
+        const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+        if (!fullyVisible) {
+          panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      };
+
+      if (clearButton) {
+        clearButton.addEventListener('click', () => {
+          stream.querySelectorAll('.console-entry').forEach((entry) => entry.remove());
+          showEmpty();
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          if (typeof stream.focus === 'function') {
+            stream.focus();
+          }
+        });
+      }
+
+      if (scrollButton) {
+        scrollButton.addEventListener('click', () => {
+          focusPanel();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+        });
+      }
+
+      updateControls();
+
+      return {
+        append(entry) {
+          hideEmpty();
+          entry.classList.add('console-entry--recent');
+          entry.addEventListener(
+            'animationend',
+            () => entry.classList.remove('console-entry--recent'),
+            { once: true }
+          );
+          stream.prepend(entry);
+          const entries = Array.from(stream.querySelectorAll('.console-entry'));
+          if (limit && entries.length > limit) {
+            entries.slice(limit).forEach((oldEntry) => oldEntry.remove());
+          }
+          updateControls();
+          if (typeof stream.scrollTo === 'function') {
+            stream.scrollTo({ top: 0, behavior: 'smooth' });
+          } else {
+            stream.scrollTop = 0;
+          }
+          focusPanel();
+        }
+      };
+    }
+
+    const consoleUI = createSandboxConsole({ limit: 8 });
 
     const baseContext = {
       schema: 'unified-data-layer/v2',
@@ -156,10 +260,7 @@ import '../../../styles/analytics-sandbox.css';
 
     const pushToDataLayer = (payload) => {
       window.dataLayer.push(payload);
-      if (!consoleStream) return;
-      if (emptyState && emptyState.parentElement) {
-        emptyState.remove();
-      }
+      if (!consoleUI) return;
 
       const entry = document.createElement('article');
       entry.className = 'console-entry';
@@ -171,12 +272,7 @@ import '../../../styles/analytics-sandbox.css';
         </header>
         <pre class="console-entry__body">${JSON.stringify(payload, null, 2)}</pre>
       `;
-      consoleStream.prepend(entry);
-
-      const maxEntries = 8;
-      while (consoleStream.children.length > maxEntries) {
-        consoleStream.removeChild(consoleStream.lastElementChild);
-      }
+      consoleUI.append(entry);
     };
 
     const buildInteractionPayload = (element) => {

--- a/src/pages/lab/analytics/x-pixel.astro
+++ b/src/pages/lab/analytics/x-pixel.astro
@@ -111,13 +111,25 @@ import '../../../styles/analytics-sandbox.css';
         </section>
       </section>
 
-      <aside class="sandbox-console x-console" aria-labelledby="x-console-heading">
+      <aside class="sandbox-console x-console" data-console-panel aria-labelledby="x-console-heading">
         <h2 id="x-console-heading">Mock X endpoint payloads</h2>
         <p>
           Payloads below are synthetic representations of what would be transmitted to the X conversion
           endpoint for each interaction.
         </p>
-        <div id="mock-console" class="console-stream" role="log" aria-live="polite"></div>
+        <div class="sandbox-console__toolbar" role="group" aria-label="X pixel console controls">
+          <button type="button" class="console-control" data-console-scroll disabled>Jump to latest</button>
+          <button type="button" class="console-control" data-console-clear disabled>Clear console</button>
+        </div>
+        <div
+          class="console-stream"
+          data-console-stream
+          role="log"
+          aria-live="polite"
+          tabindex="0"
+        >
+          <p class="console-empty" data-console-empty>Engage the interface to emit simulated X pixel payloads.</p>
+        </div>
       </aside>
     </div>
 
@@ -151,13 +163,110 @@ import '../../../styles/analytics-sandbox.css';
       }(window, document, 'script');
 
       const baseTwq = window.twq;
-      const consolePanel = document.getElementById('mock-console');
+
+      function createSandboxConsole({ limit = 6 } = {}) {
+        const panel = document.querySelector('[data-console-panel]');
+        const stream = panel ? panel.querySelector('[data-console-stream]') : null;
+        const empty = stream ? stream.querySelector('[data-console-empty]') : null;
+        const clearButton = panel ? panel.querySelector('[data-console-clear]') : null;
+        const scrollButton = panel ? panel.querySelector('[data-console-scroll]') : null;
+
+        if (!panel || !stream) {
+          return null;
+        }
+
+        const hideEmpty = () => {
+          if (empty) {
+            empty.hidden = true;
+          }
+        };
+
+        const showEmpty = () => {
+          if (empty) {
+            empty.hidden = false;
+          }
+        };
+
+        const updateControls = () => {
+          const hasEntries = !!stream.querySelector('.console-entry');
+          if (clearButton) {
+            clearButton.disabled = !hasEntries;
+          }
+          if (scrollButton) {
+            scrollButton.disabled = !hasEntries;
+          }
+        };
+
+        const focusPanel = () => {
+          const rect = panel.getBoundingClientRect();
+          const fullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+          if (!fullyVisible) {
+            panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }
+        };
+
+        if (clearButton) {
+          clearButton.addEventListener('click', () => {
+            stream.querySelectorAll('.console-entry').forEach((entry) => entry.remove());
+            showEmpty();
+            updateControls();
+            if (typeof stream.scrollTo === 'function') {
+              stream.scrollTo({ top: 0, behavior: 'smooth' });
+            } else {
+              stream.scrollTop = 0;
+            }
+            if (typeof stream.focus === 'function') {
+              stream.focus();
+            }
+          });
+        }
+
+        if (scrollButton) {
+          scrollButton.addEventListener('click', () => {
+            focusPanel();
+            if (typeof stream.scrollTo === 'function') {
+              stream.scrollTo({ top: 0, behavior: 'smooth' });
+            } else {
+              stream.scrollTop = 0;
+            }
+          });
+        }
+
+        updateControls();
+
+        return {
+          append(entry) {
+            hideEmpty();
+            entry.classList.add('console-entry--recent');
+            entry.addEventListener(
+              'animationend',
+              () => entry.classList.remove('console-entry--recent'),
+              { once: true }
+            );
+            stream.prepend(entry);
+            const entries = Array.from(stream.querySelectorAll('.console-entry'));
+            if (limit && entries.length > limit) {
+              entries.slice(limit).forEach((oldEntry) => oldEntry.remove());
+            }
+            updateControls();
+            if (typeof stream.scrollTo === 'function') {
+              stream.scrollTo({ top: 0, behavior: 'smooth' });
+            } else {
+              stream.scrollTop = 0;
+            }
+            focusPanel();
+          }
+        };
+      }
+
+      const consoleUI = createSandboxConsole({ limit: 6 });
       const sandboxElements = document.querySelectorAll('.sandbox-element');
 
       const createConsoleEntry = (type, name, payload) => {
+        if (!consoleUI) return;
+        const timestamp = new Date();
         const entry = document.createElement('article');
         entry.className = 'console-entry';
-        const timestamp = new Date();
         entry.innerHTML = `
           <header class="console-entry__meta">
             <span class="console-entry__method">${type}</span>
@@ -166,11 +275,7 @@ import '../../../styles/analytics-sandbox.css';
           </header>
           <pre class="console-entry__body">${JSON.stringify(payload, null, 2)}</pre>
         `;
-        consolePanel.prepend(entry);
-        const maxEntries = 6;
-        while (consolePanel.children.length > maxEntries) {
-          consolePanel.removeChild(consolePanel.lastElementChild);
-        }
+        consoleUI.append(entry);
       };
 
       const highlightElement = (element) => {

--- a/src/styles/analytics-sandbox.css
+++ b/src/styles/analytics-sandbox.css
@@ -196,6 +196,9 @@
 }
 
 .sandbox-console {
+  position: sticky;
+  top: clamp(1.5rem, 4vw, 3rem);
+  align-self: flex-start;
   border: 1px solid var(--color-rule);
   border-radius: var(--radius-2);
   background: rgba(17, 17, 17, 0.04);
@@ -203,15 +206,57 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  max-height: calc(100vh - clamp(5rem, 16vw, 10rem));
+  overflow: hidden;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.06);
+}
+
+.sandbox-console__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+.console-control {
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-1);
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--text-12);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: calc(var(--space-1) * 0.75) var(--space-2);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.console-control:hover,
+.console-control:focus-visible {
+  background: var(--color-text);
+  color: var(--color-bg);
+  border-color: transparent;
+}
+
+.console-control:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+  background: rgba(255, 255, 255, 0.4);
+  color: var(--color-muted);
 }
 
 .console-stream {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  max-height: 520px;
+  flex: 1 1 auto;
+  min-height: 240px;
+  max-height: none;
   overflow-y: auto;
   padding-right: var(--space-1);
+  scroll-behavior: smooth;
+  scrollbar-gutter: stable;
 }
 
 .console-empty {
@@ -227,6 +272,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
+}
+
+.console-entry--recent {
+  animation: console-entry-flash 1.2s ease;
 }
 
 .console-entry__meta {
@@ -279,8 +328,10 @@
     grid-template-columns: 1fr;
   }
 
-  .console-stream {
+  .sandbox-console {
+    position: static;
     max-height: none;
+    box-shadow: none;
   }
 }
 
@@ -294,5 +345,31 @@
 
   .sandbox-console {
     background: rgba(255, 255, 255, 0.04);
+  }
+
+  .console-control {
+    background: rgba(13, 13, 13, 0.6);
+    border-color: rgba(255, 255, 255, 0.24);
+    color: var(--color-bg);
+  }
+
+  .console-control:hover,
+  .console-control:focus-visible {
+    background: var(--color-bg);
+    color: var(--color-text);
+  }
+}
+
+@keyframes console-entry-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(190, 133, 55, 0.45);
+  }
+
+  60% {
+    box-shadow: 0 0 0 12px rgba(190, 133, 55, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(190, 133, 55, 0);
   }
 }


### PR DESCRIPTION
## Summary
- make the analytics sandbox console sticky and add a shared control toolbar for jumping to the latest entry or clearing the feed
- unify the console markup and helper logic across the GA4, GTM, Adobe, Meta, LinkedIn, Unified Data Layer, and X sandboxes for consistent empty states, entry limits, and highlighting
- refresh console logging for Adobe, Meta, and X demos so payload metadata renders with the new layout without losing context

## Testing
- npm test *(fails: Missing script)*
- npm run lint *(fails: Missing script)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e306838dec832387fa73437acb2e2d