### PR TITLE
Improve hero navigation and site-wide styling

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -14,22 +14,29 @@ const { title } = Astro.props;
       <span class="compass w mono">W</span>
     </div>
   </div>
-  <nav class="hero-nav">
-    <a href="/" class="brand" data-astro-prefetch>{title}</a>
-    <ul>
-      <li><a href="/work" data-astro-prefetch>Work</a></li>
-      <li><a href="/blog" data-astro-prefetch>Blog</a></li>
-      <li><a href="/lab" data-astro-prefetch>Lab</a></li>
-      <li><a href="/about" data-astro-prefetch>About</a></li>
-    </ul>
+  <nav class="hero-nav" aria-label="Primary navigation">
+    <div class="hero-nav__inner">
+      <a href="/" class="brand" data-astro-prefetch>{title}</a>
+      <ul>
+        <li><a href="/work" data-astro-prefetch>Work</a></li>
+        <li><a href="/blog" data-astro-prefetch>Blog</a></li>
+        <li><a href="/lab" data-astro-prefetch>Lab</a></li>
+        <li><a href="/about" data-astro-prefetch>About</a></li>
+      </ul>
+    </div>
   </nav>
   <script type="module" src="/topo.js"></script>
   <script type="module">
     const hero = document.querySelector('.topo-hero');
-    const nav = hero.querySelector('.hero-nav');
-    const navHeight = nav.offsetHeight;
-    hero.style.setProperty('--nav-height', `${navHeight}px`);
-    function onScroll() {
+    const nav = hero?.querySelector('.hero-nav');
+    if (!hero || !nav) return;
+
+    const setNavHeight = () => {
+      hero.style.setProperty('--nav-height', `${nav.offsetHeight}px`);
+    };
+
+    const onScroll = () => {
+      const navHeight = nav.offsetHeight;
       if (window.scrollY > hero.offsetHeight - navHeight) {
         hero.classList.add('collapsed');
         nav.classList.add('sticky');
@@ -37,8 +44,18 @@ const { title } = Astro.props;
         hero.classList.remove('collapsed');
         nav.classList.remove('sticky');
       }
-    }
-    window.addEventListener('scroll', onScroll);
+    };
+
+    const onResize = () => {
+      setNavHeight();
+      onScroll();
+    };
+
+    setNavHeight();
+    onScroll();
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onResize);
   </script>
   <style>
     .topo-hero {
@@ -99,34 +116,68 @@ const { title } = Astro.props;
     .hero-nav {
       position: absolute;
       bottom: var(--space-2);
-      left: var(--space-2);
+      left: 50%;
+      transform: translateX(-50%);
+      width: min(var(--layout-max-width), calc(100% - var(--space-4) * 2));
+      color: var(--frame-color);
+      background: var(--color-bg);
+      border: 1px solid color-mix(in srgb, var(--frame-color) 35%, transparent);
+      border-radius: var(--radius-1);
+      padding: var(--space-1);
+      transition: box-shadow var(--transition-base), border-color var(--transition-base);
+    }
+    .hero-nav__inner {
       display: flex;
       align-items: center;
+      justify-content: space-between;
       gap: var(--space-2);
-      color: var(--frame-color);
-
-      background: var(--color-bg);
-      padding: var(--space-1) var(--space-2);
-
+      padding: 0 var(--space-2);
     }
-    .hero-nav ul {
+    .hero-nav__inner ul {
       display: flex;
       gap: var(--space-2);
       list-style: none;
       margin: 0;
       padding: 0;
     }
+    .hero-nav__inner a {
+      color: inherit;
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .hero-nav__inner a:focus-visible,
+    .hero-nav__inner a:hover {
+      text-decoration: underline;
+    }
+    .hero-nav ul {
+      font-size: var(--text-14);
+    }
+    .hero-nav .brand {
+      font-size: clamp(var(--text-24), 6vw, var(--text-48));
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+    }
+    .hero-nav li a {
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
     .hero-nav.sticky {
       position: fixed;
       top: 0;
-      left: 0;
-      right: 0;
-
+      left: 50%;
+      right: auto;
+      transform: translateX(-50%);
+      width: min(var(--layout-max-width), calc(100% - var(--space-4) * 2));
       background: var(--color-bg);
-
-      padding: var(--space-2);
-      justify-content: space-between;
+      background: color-mix(in srgb, var(--color-bg) 96%, transparent);
+      border-radius: 0 0 var(--radius-1) var(--radius-1);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+      border-color: color-mix(in srgb, var(--frame-color) 20%, transparent);
+      backdrop-filter: blur(6px);
       z-index: 1000;
+    }
+    .hero-nav.sticky .hero-nav__inner {
+      padding-block: var(--space-1);
     }
     .topo-hero.collapsed {
       height: var(--nav-height);
@@ -136,12 +187,30 @@ const { title } = Astro.props;
 
     @media (max-width: 600px) {
       .hero-nav {
+        width: calc(100% - var(--space-2) * 2);
+        padding: var(--space-1);
+      }
+      .hero-nav__inner {
         flex-direction: column;
         align-items: flex-start;
+        width: 100%;
       }
       .hero-nav ul {
         flex-direction: column;
         width: 100%;
+      }
+      .hero-nav li {
+        width: 100%;
+      }
+      .hero-nav a {
+        display: inline-block;
+        width: 100%;
+      }
+      .hero-nav .brand {
+        letter-spacing: 0.12em;
+      }
+      .hero-nav.sticky {
+        width: calc(100% - var(--space-2) * 2);
       }
     }
   </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -67,7 +67,7 @@ const shouldShowBreadcrumbs = showNav && breadcrumbs.length > 0;
         </div>
       </nav>
     )}
-    <main>
+    <main class:list={{ 'site-main': true, 'site-main--flush': !showNav }}>
       <slot />
     </main>
     {showFooter && <Footer />}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,6 +10,8 @@
   --space-4: 32px;
   --space-5: 40px;
   --space-6: 48px;
+  --space-7: 56px;
+  --space-8: 64px;
 
   /* typography */
   --font-sans: 'Helvetica Neue', Helvetica, Arial, system-ui, -apple-system, 'Segoe UI', Roboto, 'Noto Sans', 'Liberation Sans', sans-serif;
@@ -22,6 +24,9 @@
   --text-24: 24px;
   --text-32: 32px;
   --text-48: 48px;
+
+  --layout-max-width: 1080px;
+  --transition-base: 150ms ease;
 
   /* radius */
   --radius-0: 0;
@@ -58,6 +63,8 @@ html {
   font-family: var(--font-sans);
   font-size: var(--text-16);
   line-height: 1.33;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
 }
 
 *, *::before, *::after {
@@ -69,11 +76,14 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 
 a {
   color: var(--color-link);
   text-decoration: underline;
+  text-decoration-thickness: 1px;
 }
 
 hr {
@@ -87,32 +97,80 @@ article {
   padding: var(--space-2);
 }
 
+h1, h2, h3, h4, h5, h6, p, ul, ol, figure {
+  margin-block: 0;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-sans);
   margin-top: 0;
   line-height: 1.1;
 }
 
+.page-title,
+h1 {
+  font-size: clamp(var(--text-32), 6vw, 56px);
+  letter-spacing: 0.02em;
+}
+
+p + p {
+  margin-top: var(--space-2);
+}
+
+ul, ol {
+  padding-left: var(--space-3);
+  margin-top: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
 .mono {
   font-family: var(--font-mono);
+}
+
+img, picture, video {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 main {
   flex: 1;
 }
 
+.site-main {
+  padding-block: var(--space-6);
+}
+
+.site-main--flush {
+  padding-block: 0;
+}
+
 /* Container and grid system */
 .container {
-  max-width: 1200px;
+  width: min(100%, var(--layout-max-width));
+  max-width: var(--layout-max-width);
   margin-left: auto;
   margin-right: auto;
-  padding: var(--space-2);
+  padding: 0 var(--space-2);
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  gap: var(--space-2);
+  gap: var(--space-3);
+  align-items: start;
 }
 
 @media (max-width: 900px) {
@@ -155,6 +213,41 @@ main {
   background-position: bottom;
 }
 
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+}
+
+input[type='search'],
+input[type='text'],
+textarea {
+  width: min(100%, 420px);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 85%, transparent);
+  background: var(--color-bg);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-1);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+input[type='search']:focus-visible,
+input[type='text']:focus-visible,
+textarea:focus-visible {
+  border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
+input[type='search']::placeholder {
+  color: color-mix(in srgb, var(--color-muted) 70%, transparent);
+}
+
 /* Navigation */
 .primary-nav .container {
   display: flex;
@@ -163,6 +256,8 @@ main {
   font-size: var(--text-14);
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
+  gap: var(--space-2);
+  flex-wrap: wrap;
 }
 
 /* Credibility strip */
@@ -183,22 +278,33 @@ main {
 .primary-nav ul {
   list-style: none;
   display: flex;
+  align-items: center;
   gap: var(--space-2);
   margin: 0;
   padding: 0;
+  flex-wrap: wrap;
 }
 
 .primary-nav a {
   color: var(--color-text);
   text-decoration: none;
   font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: opacity var(--transition-base);
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus-visible {
+  opacity: 0.7;
 }
 
 .primary-nav .brand {
   font-weight: 700;
-  font-size: var(--text-32);
+  font-size: clamp(var(--text-24), 6vw, var(--text-32));
   text-transform: uppercase;
   text-decoration: none;
+  letter-spacing: 0.16em;
 }
 
 .primary-nav .mode {
@@ -320,13 +426,21 @@ main {
 /* Card */
 .card {
   display: grid;
-  grid-template-columns: 1fr 3fr;
-  gap: var(--space-2);
-  padding: var(--space-2);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 3fr);
+  gap: var(--space-3);
+  padding: var(--space-3);
   background-clip: padding-box;
   outline: 1px solid var(--color-rule);
   outline-offset: -1px;
   border-radius: var(--radius-1);
+  background: color-mix(in srgb, var(--color-bg) 92%, #ffffff 8%);
+  transition: outline-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.card:hover,
+.card:focus-within {
+  outline-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.08);
 }
 
 .card .label {
@@ -421,17 +535,38 @@ footer .container {
   border: 1px solid var(--color-rule);
   border-radius: var(--radius-1);
   cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base);
 }
+.tag:hover,
+.tag:focus-visible {
+  border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
+}
+
 .tag.active {
   background: var(--color-accent);
   color: var(--color-bg);
+  border-color: transparent;
 }
+
+.featured {
+  margin-bottom: var(--space-6);
+}
+
+.featured .card {
+  margin-top: var(--space-2);
+}
+
+#results-status {
+  margin-top: var(--space-2);
+}
+
 .pagination {
   display: flex;
   gap: var(--space-1);
   justify-content: center;
-  margin-top: var(--space-3);
+  margin-top: var(--space-4);
 }
+
 .page-btn {
   font-family: var(--font-mono);
   font-size: var(--text-14);
@@ -441,8 +576,32 @@ footer .container {
   border: 1px solid var(--color-rule);
   border-radius: var(--radius-1);
   cursor: pointer;
+  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base);
 }
+
+.page-btn:hover,
+.page-btn:focus-visible {
+  border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
+}
+
 .page-btn.active {
   background: var(--color-accent);
   color: var(--color-bg);
+  border-color: transparent;
+}
+
+@media (max-width: 900px) {
+  .site-main {
+    padding-block: var(--space-5);
+  }
+
+  .card {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+    padding: var(--space-2);
+  }
+
+  .card .label {
+    order: -1;
+  }
 }


### PR DESCRIPTION
## Summary
- restructure the home hero navigation markup and sticky behavior to keep spacing consistent, recalc height on resize, and improve mobile accessibility
- expand the global design system with additional tokens, layout spacing, focus/form states, and refreshed card/blog styles for a cohesive QA pass
- allow the shared layout to toggle main padding so the landing page hero stays flush while subpages retain comfortable breathing room

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e30c43221c8323a7397e10cdc53ce4