### PR TITLE
style: align lab surfaces with site theme

### DIFF
--- a/src/styles/analytics-sandbox.css
+++ b/src/styles/analytics-sandbox.css
@@ -91,13 +91,14 @@
 
 .sandbox-card,
 .sandbox-callout {
-  border: 1px solid var(--color-rule);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--surface-raised);
   padding: var(--space-3);
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  box-shadow: 0 10px 24px rgba(24, 24, 24, 0.06);
 }
 
 .sandbox-card header {
@@ -188,27 +189,27 @@
 .sandbox-form select,
 .sandbox-form textarea {
   padding: var(--space-1);
-  border: 1px solid var(--color-rule);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-1);
   font-size: var(--text-16);
   font-family: var(--font-sans);
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--surface-raised);
 }
 
 .sandbox-console {
   position: sticky;
   top: clamp(1.5rem, 4vw, 3rem);
   align-self: flex-start;
-  border: 1px solid var(--color-rule);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
-  background: rgba(17, 17, 17, 0.04);
+  background: var(--surface-panel);
   padding: var(--space-3);
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
   max-height: calc(100vh - clamp(5rem, 16vw, 10rem));
   overflow: hidden;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-soft);
 }
 
 .sandbox-console__toolbar {
@@ -219,9 +220,9 @@
 }
 
 .console-control {
-  border: 1px solid var(--color-rule);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 75%, transparent);
   border-radius: var(--radius-1);
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--surface-raised);
   color: var(--color-text);
   font-family: var(--font-mono);
   font-size: var(--text-12);
@@ -229,7 +230,7 @@
   text-transform: uppercase;
   padding: calc(var(--space-1) * 0.75) var(--space-2);
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform var(--transition-base);
 }
 
 .console-control:hover,
@@ -237,13 +238,15 @@
   background: var(--color-text);
   color: var(--color-bg);
   border-color: transparent;
+  transform: translateY(-1px);
 }
 
 .console-control:disabled {
   cursor: not-allowed;
-  opacity: 0.4;
-  background: rgba(255, 255, 255, 0.4);
-  color: var(--color-muted);
+  background: color-mix(in srgb, var(--surface-raised) 80%, transparent);
+  color: color-mix(in srgb, var(--color-muted) 70%, transparent);
+  border-color: color-mix(in srgb, var(--color-rule) 50%, transparent);
+  transform: none;
 }
 
 .console-stream {
@@ -265,10 +268,10 @@
 }
 
 .console-entry {
-  border: 1px solid var(--color-rule);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
   padding: var(--space-2);
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--surface-raised);
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
@@ -310,9 +313,9 @@
 .sandbox-snippet pre {
   margin: 0;
   padding: var(--space-2);
-  border: 1px solid var(--color-rule);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--surface-raised);
   overflow-x: auto;
 }
 
@@ -340,22 +343,22 @@
   .sandbox-callout,
   .console-entry,
   .sandbox-snippet pre {
-    background: rgba(13, 13, 13, 0.6);
+    background: var(--surface-raised);
   }
 
   .sandbox-console {
-    background: rgba(255, 255, 255, 0.04);
+    background: var(--surface-panel);
   }
 
   .console-control {
-    background: rgba(13, 13, 13, 0.6);
-    border-color: rgba(255, 255, 255, 0.24);
-    color: var(--color-bg);
+    background: var(--surface-raised);
+    border-color: color-mix(in srgb, var(--color-rule) 65%, transparent);
+    color: var(--color-text);
   }
 
   .console-control:hover,
   .console-control:focus-visible {
-    background: var(--color-bg);
+    background: var(--surface-tint);
     color: var(--color-text);
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,6 +44,10 @@
   --color-accent: #b00000;
   --color-link: var(--color-accent);
   --color-muted: #666666;
+  --surface-raised: color-mix(in srgb, var(--color-bg) 90%, #ffffff 10%);
+  --surface-panel: color-mix(in srgb, var(--color-bg) 86%, #ffffff 14%);
+  --surface-tint: color-mix(in srgb, var(--color-accent) 8%, var(--color-bg));
+  --shadow-soft: 0 18px 42px rgba(24, 24, 24, 0.12);
 }
 
 /* dark theme - CRT */
@@ -54,6 +58,10 @@
   --color-accent: #8bd3dd;
   --color-link: var(--color-accent);
   --color-muted: #8899aa;
+  --surface-raised: color-mix(in srgb, #1a1c21 70%, var(--color-bg) 30%);
+  --surface-panel: color-mix(in srgb, #23262d 70%, var(--color-bg) 30%);
+  --surface-tint: color-mix(in srgb, var(--color-accent) 16%, var(--color-bg));
+  --shadow-soft: 0 20px 48px rgba(0, 0, 0, 0.45);
 }
 
 html {
@@ -433,14 +441,15 @@ input[type='search']::placeholder {
   outline: 1px solid var(--color-rule);
   outline-offset: -1px;
   border-radius: var(--radius-1);
-  background: color-mix(in srgb, var(--color-bg) 92%, #ffffff 8%);
-  transition: outline-color var(--transition-base), box-shadow var(--transition-base);
+  background: var(--surface-raised);
+  box-shadow: 0 14px 32px rgba(24, 24, 24, 0.05);
+  transition: outline-color var(--transition-base), box-shadow var(--transition-base), background-color var(--transition-base);
 }
 
 .card:hover,
 .card:focus-within {
   outline-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-soft);
 }
 
 .card .label {


### PR DESCRIPTION
## Summary
- introduce shared surface tokens for light and dark themes to support consistent elevated backgrounds
- refresh the lab analytics sandbox surfaces and controls to use the lighter palette and softer shadows

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e30fd1a86c8323bfe7c5460bbf1983