### PR TITLE
Expand analytics lab sandboxes

### DIFF
--- a/src/pages/lab/analytics/linkedin-pixel.astro
+++ b/src/pages/lab/analytics/linkedin-pixel.astro
@@ -24,114 +24,341 @@ import '../../../styles/analytics-sandbox.css';
     </header>
 
     <div class="sandbox-grid">
-      <section class="sandbox-panel">
-        <article class="sandbox-card linkedin-card" data-li-card>
-          <header>
-            <p class="sandbox-card__tag mono">Conversion ID: 1</p>
-            <h3>Primary mission CTA</h3>
-          </header>
-          <p>
-            Represents the highest priority conversion on a landing surface. Includes mission metadata for
-            downstream segmentation.
-          </p>
-          <dl class="sandbox-card__meta">
-            <div>
-              <dt>Interaction</dt>
-              <dd class="mono">click</dd>
-            </div>
-            <div>
-              <dt>Label</dt>
-              <dd class="mono">Mission Brief Request</dd>
-            </div>
-          </dl>
-          <button
-            class="sandbox-action"
-            data-li-event="click"
-            data-li-conversion-id="1"
-            data-li-payload='{"content_type":"cta","cta_label":"Request Mission Brief","priority":"primary"}'
-            data-li-status="li-cta-status"
-            type="button"
-          >
-            Request mission brief
-          </button>
-          <p id="li-cta-status" class="linkedin-status">Idle — waiting for interaction.</p>
-        </article>
+      <section class="sandbox-panel" aria-labelledby="linkedin-interface-heading">
+        <h2 id="linkedin-interface-heading">Tracked interface elements</h2>
+        <p>
+          Trigger each conversion to observe how <code>lintrk('track')</code> payloads are constructed for the
+          Insight Tag. The sections below cover acquisition CTAs, engagement signals, and revenue events.
+        </p>
 
-        <article class="sandbox-card linkedin-card" data-li-card>
-          <header>
-            <p class="sandbox-card__tag mono">Conversion ID: 2</p>
-            <h3>Reference link</h3>
-          </header>
-          <p>
-            Captures mid-funnel navigation interest. Prevents navigation in this demo so you can review the
-            outbound payload.
+        <div class="linkedin-section">
+          <h3 class="linkedin-section__title">High-priority conversions</h3>
+          <p class="linkedin-section__intro">
+            Buttons and forms that map directly to your core demand-generation KPIs.
           </p>
-          <dl class="sandbox-card__meta">
-            <div>
-              <dt>Interaction</dt>
-              <dd class="mono">click</dd>
-            </div>
-            <div>
-              <dt>Destination</dt>
-              <dd class="mono">/resources/mission-overview</dd>
-            </div>
-          </dl>
-          <a
-            href="#"
-            class="sandbox-link"
-            data-li-event="click"
-            data-li-conversion-id="2"
-            data-li-prevent-default="true"
-            data-li-payload='{"destination":"/resources/mission-overview","link_type":"supporting"}'
-            data-li-status="li-link-status"
-          >
-            View mission overview
-          </a>
-          <p id="li-link-status" class="linkedin-status">Idle — waiting for interaction.</p>
-        </article>
+          <div class="linkedin-grid">
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 1</p>
+                <h3>Primary mission CTA</h3>
+              </header>
+              <p>
+                Represents the highest priority conversion on a landing surface. Includes mission metadata for
+                downstream segmentation.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">click</dd>
+                </div>
+                <div>
+                  <dt>Label</dt>
+                  <dd class="mono">Mission Brief Request</dd>
+                </div>
+              </dl>
+              <button
+                class="sandbox-action"
+                data-li-event="click"
+                data-li-conversion-id="1"
+                data-li-payload='{"content_type":"cta","cta_label":"Request Mission Brief","priority":"primary"}'
+                data-li-status="li-cta-status"
+                type="button"
+              >
+                Request mission brief
+              </button>
+              <p id="li-cta-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
 
-        <article class="sandbox-card linkedin-card" data-li-card>
-          <header>
-            <p class="sandbox-card__tag mono">Conversion ID: 3</p>
-            <h3>Lead qualification form</h3>
-          </header>
-          <p>
-            Demonstrates a lightweight lead capture flow with hashed identifiers and mission intent fields.
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 4</p>
+                <h3>Strategy consultation</h3>
+              </header>
+              <p>
+                Fires when a visitor books a mission strategy call. Useful for validating offline conversions
+                piped in via Conversions API.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">click</dd>
+                </div>
+                <div>
+                  <dt>Value</dt>
+                  <dd class="mono">0 (lead)</dd>
+                </div>
+              </dl>
+              <button
+                class="sandbox-action"
+                data-li-event="click"
+                data-li-conversion-id="4"
+                data-li-payload='{"content_type":"cta","cta_label":"Schedule Strategy Call","mission_window":"Q3","priority":"secondary"}'
+                data-li-status="li-strategy-status"
+                type="button"
+              >
+                Schedule strategy call
+              </button>
+              <p id="li-strategy-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 3</p>
+                <h3>Lead qualification form</h3>
+              </header>
+              <p>
+                Demonstrates a lightweight lead capture flow with hashed identifiers and mission intent fields.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">submit</dd>
+                </div>
+                <div>
+                  <dt>Mission focus</dt>
+                  <dd class="mono">Dynamic (form value)</dd>
+                </div>
+              </dl>
+              <form
+                class="sandbox-form"
+                data-li-event="submit"
+                data-li-conversion-id="3"
+                data-li-prevent-default="true"
+                data-li-payload='{"lead_type":"enterprise","hashed_email":"4b825dc642cb6eb9a060e54bf8d69288"}'
+                data-li-status="li-form-status"
+              >
+                <label>
+                  Mission focus
+                  <select name="mission_focus">
+                    <option value="orbital">Orbital research</option>
+                    <option value="deep-space">Deep space comms</option>
+                    <option value="earth-observation">Earth observation</option>
+                  </select>
+                </label>
+                <label>
+                  Mission identifier
+                  <input type="text" name="mission_id" placeholder="mission-041" required />
+                </label>
+                <button type="submit" class="sandbox-action">Transmit lead</button>
+              </form>
+              <p id="li-form-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
+          </div>
+        </div>
+
+        <div class="linkedin-section">
+          <h3 class="linkedin-section__title">Content &amp; community</h3>
+          <p class="linkedin-section__intro">
+            Mid-funnel interactions used for audience building, nurture, and engagement scoring.
           </p>
-          <dl class="sandbox-card__meta">
-            <div>
-              <dt>Interaction</dt>
-              <dd class="mono">submit</dd>
-            </div>
-            <div>
-              <dt>Mission focus</dt>
-              <dd class="mono">Dynamic (form value)</dd>
-            </div>
-          </dl>
-          <form
-            class="sandbox-form"
-            data-li-event="submit"
-            data-li-conversion-id="3"
-            data-li-prevent-default="true"
-            data-li-payload='{"lead_type":"enterprise","hashed_email":"4b825dc642cb6eb9a060e54bf8d69288"}'
-            data-li-status="li-form-status"
-          >
-            <label>
-              Mission focus
-              <select name="mission_focus">
-                <option value="orbital">Orbital research</option>
-                <option value="deep-space">Deep space comms</option>
-                <option value="earth-observation">Earth observation</option>
-              </select>
-            </label>
-            <label>
-              Mission identifier
-              <input type="text" name="mission_id" placeholder="mission-041" required />
-            </label>
-            <button type="submit" class="sandbox-action">Transmit lead</button>
-          </form>
-          <p id="li-form-status" class="linkedin-status">Idle — waiting for interaction.</p>
-        </article>
+          <div class="linkedin-grid">
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 2</p>
+                <h3>Reference link</h3>
+              </header>
+              <p>
+                Captures mid-funnel navigation interest. Prevents navigation in this demo so you can review the
+                outbound payload.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">click</dd>
+                </div>
+                <div>
+                  <dt>Destination</dt>
+                  <dd class="mono">/resources/mission-overview</dd>
+                </div>
+              </dl>
+              <a
+                href="#"
+                class="sandbox-link"
+                data-li-event="click"
+                data-li-conversion-id="2"
+                data-li-prevent-default="true"
+                data-li-payload='{"destination":"/resources/mission-overview","link_type":"supporting"}'
+                data-li-status="li-link-status"
+              >
+                View mission overview
+              </a>
+              <p id="li-link-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 5</p>
+                <h3>Video milestone</h3>
+              </header>
+              <p>
+                Logs when a visitor watches at least half of a mission briefing video. Ideal for creating
+                high-intent retargeting audiences.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">click</dd>
+                </div>
+                <div>
+                  <dt>Threshold</dt>
+                  <dd class="mono">50% completion</dd>
+                </div>
+              </dl>
+              <button
+                class="sandbox-action"
+                data-li-event="click"
+                data-li-conversion-id="5"
+                data-li-payload='{"content_type":"video","video_title":"Mission Brief 01","milestone":"50%"}'
+                data-li-status="li-video-status"
+                type="button"
+              >
+                Log 50% milestone
+              </button>
+              <p id="li-video-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 6</p>
+                <h3>Newsletter opt-in</h3>
+              </header>
+              <p>
+                Mimics a content subscription flow that passes hashed identifiers and preference metadata to the
+                Insight Tag.
+              </p>
+              <form
+                class="sandbox-form"
+                data-li-event="submit"
+                data-li-conversion-id="6"
+                data-li-prevent-default="true"
+                data-li-payload='{"subscription_tier":"mission-updates","hashed_email":"bd2b1aaf7ef4f70f20caba940c19"}'
+                data-li-status="li-subscribe-status"
+              >
+                <label>
+                  Preferred cadence
+                  <select name="cadence">
+                    <option value="weekly">Weekly</option>
+                    <option value="monthly">Monthly</option>
+                  </select>
+                </label>
+                <label>
+                  Mission speciality
+                  <input type="text" name="mission_speciality" placeholder="Orbital telemetry" />
+                </label>
+                <button type="submit" class="sandbox-action">Record opt-in</button>
+              </form>
+              <p id="li-subscribe-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
+          </div>
+        </div>
+
+        <div class="linkedin-section">
+          <h3 class="linkedin-section__title">Commerce &amp; pipeline</h3>
+          <p class="linkedin-section__intro">
+            Commerce events reflecting catalog engagement and completed transactions.
+          </p>
+          <div class="linkedin-grid">
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 7</p>
+                <h3>Add to cart</h3>
+              </header>
+              <p>
+                Signals a piece of mission hardware has been staged in the cart. Includes value and currency for
+                ROI calculations.
+              </p>
+              <button
+                class="sandbox-action"
+                data-li-event="click"
+                data-li-conversion-id="7"
+                data-li-payload='{"content_type":"product","content_id":"telemetry-kit","value":199,"currency":"USD"}'
+                data-li-status="li-cart-status"
+                type="button"
+              >
+                Add telemetry kit
+              </button>
+              <p id="li-cart-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 8</p>
+                <h3>Checkout start</h3>
+              </header>
+              <p>
+                Tracks when a visitor initiates checkout, unlocking optimisation for drop-off analysis.
+              </p>
+              <button
+                class="sandbox-action"
+                data-li-event="click"
+                data-li-conversion-id="8"
+                data-li-payload='{"content_type":"checkout","cart_size":1,"value":199,"currency":"USD"}'
+                data-li-status="li-checkout-status"
+                type="button"
+              >
+                Begin secure checkout
+              </button>
+              <p id="li-checkout-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card linkedin-card" data-li-card>
+              <header>
+                <p class="sandbox-card__tag mono">Conversion ID: 9</p>
+                <h3>Purchase confirmation</h3>
+              </header>
+              <p>
+                Finalises the transaction with order identifiers that can be reconciled against backend systems.
+              </p>
+              <button
+                class="sandbox-action"
+                data-li-event="click"
+                data-li-conversion-id="9"
+                data-li-payload='{"content_type":"order","order_id":"LI-DEMO-001","value":199,"currency":"USD"}'
+                data-li-status="li-purchase-status"
+                type="button"
+              >
+                Log completed purchase
+              </button>
+              <p id="li-purchase-status" class="linkedin-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="linkedin-pre" data-li-payload-preview></pre>
+              </details>
+            </article>
+          </div>
+        </div>
       </section>
 
       <aside class="sandbox-console linkedin-console" data-console-panel aria-labelledby="linkedin-console-heading">
@@ -327,6 +554,14 @@ import '../../../styles/analytics-sandbox.css';
         payload = { error: 'Unable to parse payload', raw: element.dataset.liPayload };
       }
 
+      const card = element.closest('[data-li-card]');
+      if (card) {
+        const preview = card.querySelector('[data-li-payload-preview]');
+        if (preview) {
+          preview.textContent = pretty(payload);
+        }
+      }
+
       element.addEventListener(interaction, (event) => {
         if (preventDefault) {
           event.preventDefault();
@@ -349,6 +584,52 @@ import '../../../styles/analytics-sandbox.css';
   </script>
 
   <style>
+    .linkedin-sandbox .linkedin-section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .linkedin-sandbox .linkedin-section + .linkedin-section {
+      margin-top: var(--space-4);
+      padding-top: var(--space-3);
+      border-top: 1px solid color-mix(in srgb, var(--color-rule) 60%, transparent);
+    }
+
+    .linkedin-sandbox .linkedin-section__title {
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: var(--text-16);
+    }
+
+    .linkedin-sandbox .linkedin-section__intro {
+      margin: 0;
+      color: var(--color-muted);
+      max-width: 68ch;
+    }
+
+    .linkedin-sandbox .linkedin-grid {
+      display: grid;
+      gap: var(--space-3);
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .linkedin-sandbox .linkedin-card details {
+      border-top: 1px solid var(--color-rule);
+      padding-top: var(--space-2);
+    }
+
+    .linkedin-sandbox .linkedin-pre {
+      margin: 0;
+      padding: var(--space-2);
+      border: 1px solid var(--color-rule);
+      border-radius: var(--radius-2);
+      background: rgba(0, 0, 0, 0.04);
+      font-size: var(--text-12);
+      overflow-x: auto;
+    }
+
     .linkedin-sandbox .linkedin-status {
       margin: 0;
       font-size: var(--text-14);

--- a/src/pages/lab/analytics/meta-pixel.astro
+++ b/src/pages/lab/analytics/meta-pixel.astro
@@ -32,141 +32,368 @@ import '../../../styles/analytics-sandbox.css';
         <h2 id="meta-interface-heading">Tracked interface elements</h2>
         <p>
           Each component below mirrors a production instrumentation pattern. Data attributes declare the
-          <code>fbq('track')</code> call, action source, and payload blueprint.
+          <code>fbq</code> command, action source, and payload blueprint so you can map the UI directly to the
+          Events Manager feed.
         </p>
 
-        <article class="sandbox-card meta-card" data-meta-card>
-          <header>
-            <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'LaunchCTA')</p>
-            <h3>Primary call-to-action</h3>
-          </header>
-          <p>
-            Simulates a mission-critical conversion button. Useful for validating revenue metadata before a
-            high-intent launch.
+        <div class="meta-section">
+          <h3 class="meta-section__title">Mission-critical conversions</h3>
+          <p class="meta-section__intro">
+            Buttons and forms that power acquisition programmes. These examples cover hero CTAs, meeting
+            bookings, and lead capture flows.
           </p>
-          <dl class="sandbox-card__meta">
-            <div>
-              <dt>Event</dt>
-              <dd class="mono">LaunchCTA</dd>
-            </div>
-            <div>
-              <dt>Interaction</dt>
-              <dd class="mono">click</dd>
-            </div>
-            <div>
-              <dt>Action source</dt>
-              <dd class="mono">website</dd>
-            </div>
-          </dl>
-          <button
-            class="sandbox-action meta-action"
-            data-meta-event="LaunchCTA"
-            data-meta-interaction="click"
-            data-meta-payload='{"component":"cta","cta_label":"Initiate Launch Sequence","priority":"primary","value":1250,"currency":"USD"}'
-            data-meta-feedback="cta-status"
-            type="button"
-          >
-            Initiate launch sequence
-          </button>
-          <p id="cta-status" class="meta-status">Idle — waiting for interaction.</p>
-          <details>
-            <summary class="mono">Payload blueprint</summary>
-            <pre class="meta-pre" data-meta-payload-preview></pre>
-          </details>
-        </article>
+          <div class="meta-grid">
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'LaunchCTA')</p>
+                <h3>Primary call-to-action</h3>
+              </header>
+              <p>
+                Simulates a mission-critical conversion button. Useful for validating revenue metadata before a
+                high-intent launch.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Event</dt>
+                  <dd class="mono">LaunchCTA</dd>
+                </div>
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">click</dd>
+                </div>
+                <div>
+                  <dt>Action source</dt>
+                  <dd class="mono">website</dd>
+                </div>
+              </dl>
+              <button
+                class="sandbox-action meta-action"
+                data-meta-event="LaunchCTA"
+                data-meta-interaction="click"
+                data-meta-payload='{"component":"cta","cta_label":"Initiate Launch Sequence","priority":"primary","value":1250,"currency":"USD"}'
+                data-meta-feedback="cta-status"
+                type="button"
+              >
+                Initiate launch sequence
+              </button>
+              <p id="cta-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
 
-        <article class="sandbox-card meta-card" data-meta-card>
-          <header>
-            <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'ViewSpecifications')</p>
-            <h3>Specification link</h3>
-          </header>
-          <p>
-            Represents a mid-funnel content click. The payload records link context and document
-            classification for downstream attribution.
-          </p>
-          <dl class="sandbox-card__meta">
-            <div>
-              <dt>Event</dt>
-              <dd class="mono">ViewSpecifications</dd>
-            </div>
-            <div>
-              <dt>Interaction</dt>
-              <dd class="mono">click</dd>
-            </div>
-            <div>
-              <dt>Prevent default</dt>
-              <dd class="mono">true (demo only)</dd>
-            </div>
-          </dl>
-          <a
-            href="#"
-            class="sandbox-link meta-action meta-action--link"
-            data-meta-event="ViewSpecifications"
-            data-meta-interaction="click"
-            data-meta-prevent-default="true"
-            data-meta-payload='{"component":"document_link","destination":"mission-brief.pdf","content_category":"mission-overview","position":2}'
-            data-meta-feedback="link-status"
-          >
-            Download mission brief (PDF)
-          </a>
-          <p id="link-status" class="meta-status">Idle — waiting for interaction.</p>
-          <details>
-            <summary class="mono">Payload blueprint</summary>
-            <pre class="meta-pre" data-meta-payload-preview></pre>
-          </details>
-        </article>
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'ScheduleConsultation')</p>
+                <h3>Consultation scheduling</h3>
+              </header>
+              <p>
+                Demonstrates a meeting-booking CTA that passes context about the requested mission review. Use it
+                to validate custom conversion goals before launch.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Event</dt>
+                  <dd class="mono">ScheduleConsultation</dd>
+                </div>
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">click</dd>
+                </div>
+                <div>
+                  <dt>Action source</dt>
+                  <dd class="mono">website</dd>
+                </div>
+              </dl>
+              <button
+                class="sandbox-action meta-action"
+                data-meta-event="ScheduleConsultation"
+                data-meta-interaction="click"
+                data-meta-payload='{"component":"cta","cta_label":"Book Flight Readiness Review","priority":"secondary","mission_window":"Q3","value":0}'
+                data-meta-feedback="schedule-status"
+                type="button"
+              >
+                Book readiness review
+              </button>
+              <p id="schedule-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
 
-        <article class="sandbox-card meta-card" data-meta-card>
-          <header>
-            <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'LeadSubmission')</p>
-            <h3>Qualified lead form</h3>
-          </header>
-          <p>
-            Mimics a short lead capture flow with hashed identifiers. Submission is intercepted so you can
-            review the outbound payload without leaving the page.
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'LeadSubmission')</p>
+                <h3>Qualified lead form</h3>
+              </header>
+              <p>
+                Mimics a short lead capture flow with hashed identifiers. Submission is intercepted so you can
+                review the outbound payload without leaving the page.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Event</dt>
+                  <dd class="mono">LeadSubmission</dd>
+                </div>
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">submit</dd>
+                </div>
+                <div>
+                  <dt>Identifiers</dt>
+                  <dd class="mono">SHA-256 placeholders</dd>
+                </div>
+              </dl>
+              <form
+                class="sandbox-form meta-form meta-action"
+                data-meta-event="LeadSubmission"
+                data-meta-interaction="submit"
+                data-meta-prevent-default="true"
+                data-meta-payload='{"form_id":"lead-capture-sandbox","lead_type":"enterprise","advanced_matching":{"email":"4b825dc642cb6eb9a060e54bf8d69288","external_id":"9f5738f9c2d64f7fa2cb"}}'
+                data-meta-feedback="form-status"
+              >
+                <label>
+                  Mission focus
+                  <select name="mission_focus">
+                    <option value="orbital">Orbital research</option>
+                    <option value="deep-space">Deep space comms</option>
+                    <option value="earth-observation">Earth observation</option>
+                  </select>
+                </label>
+                <label>
+                  Mission email (hashed)
+                  <input type="text" name="hashed_email" value="4b825dc642cb6eb9a060e54bf8d69288" readonly />
+                </label>
+                <button type="submit" class="sandbox-action">Transmit lead</button>
+              </form>
+              <p id="form-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
+          </div>
+        </div>
+
+        <div class="meta-section">
+          <h3 class="meta-section__title">Content engagement</h3>
+          <p class="meta-section__intro">
+            Mid-funnel behaviors spanning resource downloads, media milestones, and newsletter sign-ups. These
+            events power retargeting and propensity models.
           </p>
-          <dl class="sandbox-card__meta">
-            <div>
-              <dt>Event</dt>
-              <dd class="mono">LeadSubmission</dd>
-            </div>
-            <div>
-              <dt>Interaction</dt>
-              <dd class="mono">submit</dd>
-            </div>
-            <div>
-              <dt>Identifiers</dt>
-              <dd class="mono">SHA-256 placeholders</dd>
-            </div>
-          </dl>
-          <form
-            class="sandbox-form meta-form meta-action"
-            data-meta-event="LeadSubmission"
-            data-meta-interaction="submit"
-            data-meta-prevent-default="true"
-            data-meta-payload='{"form_id":"lead-capture-sandbox","lead_type":"enterprise","advanced_matching":{"email":"4b825dc642cb6eb9a060e54bf8d69288","external_id":"9f5738f9c2d64f7fa2cb"}}'
-            data-meta-feedback="form-status"
-          >
-            <label>
-              Mission focus
-              <select name="mission_focus">
-                <option value="orbital">Orbital research</option>
-                <option value="deep-space">Deep space comms</option>
-                <option value="earth-observation">Earth observation</option>
-              </select>
-            </label>
-            <label>
-              Mission email (hashed)
-              <input type="text" name="hashed_email" value="4b825dc642cb6eb9a060e54bf8d69288" readonly />
-            </label>
-            <button type="submit" class="sandbox-action">Transmit lead</button>
-          </form>
-          <p id="form-status" class="meta-status">Idle — waiting for interaction.</p>
-          <details>
-            <summary class="mono">Payload blueprint</summary>
-            <pre class="meta-pre" data-meta-payload-preview></pre>
-          </details>
-        </article>
+          <div class="meta-grid">
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'ViewSpecifications')</p>
+                <h3>Specification link</h3>
+              </header>
+              <p>
+                Represents a mid-funnel content click. The payload records link context and document
+                classification for downstream attribution.
+              </p>
+              <dl class="sandbox-card__meta">
+                <div>
+                  <dt>Event</dt>
+                  <dd class="mono">ViewSpecifications</dd>
+                </div>
+                <div>
+                  <dt>Interaction</dt>
+                  <dd class="mono">click</dd>
+                </div>
+                <div>
+                  <dt>Prevent default</dt>
+                  <dd class="mono">true (demo only)</dd>
+                </div>
+              </dl>
+              <a
+                href="#"
+                class="sandbox-link meta-action meta-action--link"
+                data-meta-event="ViewSpecifications"
+                data-meta-interaction="click"
+                data-meta-prevent-default="true"
+                data-meta-payload='{"component":"document_link","destination":"mission-brief.pdf","content_category":"mission-overview","position":2}'
+                data-meta-feedback="link-status"
+              >
+                Download mission brief (PDF)
+              </a>
+              <p id="link-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'VideoView')</p>
+                <h3>Video milestones</h3>
+              </header>
+              <p>
+                Trigger start, midpoint, and completion signals for a mission briefing. Mid-roll checkpoints use
+                <code>trackCustom</code> to avoid polluting standard reporting.
+              </p>
+              <div class="meta-milestones">
+                <button
+                  class="sandbox-action meta-action"
+                  type="button"
+                  data-meta-event="VideoView"
+                  data-meta-payload='{"content_type":"mission_briefing","video_title":"Mission Brief 01","position":"hero","value":0}'
+                  data-meta-feedback="video-status"
+                >
+                  Start playback
+                </button>
+                <button
+                  class="sandbox-action meta-action"
+                  type="button"
+                  data-meta-command="trackCustom"
+                  data-meta-event="VideoMidpoint"
+                  data-meta-payload='{"content_type":"mission_briefing","video_title":"Mission Brief 01","percent":50}'
+                  data-meta-feedback="video-status"
+                >
+                  Hit 50% milestone
+                </button>
+                <button
+                  class="sandbox-action meta-action"
+                  type="button"
+                  data-meta-command="trackCustom"
+                  data-meta-event="VideoComplete"
+                  data-meta-payload='{"content_type":"mission_briefing","video_title":"Mission Brief 01","duration":185}'
+                  data-meta-feedback="video-status"
+                >
+                  Complete playback
+                </button>
+              </div>
+              <p id="video-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'Subscribe')</p>
+                <h3>Newsletter subscription</h3>
+              </header>
+              <p>
+                Captures lifecycle engagement by logging a newsletter opt-in. The payload includes consent and
+                topic preferences for downstream syncing.
+              </p>
+              <form
+                class="sandbox-form meta-form meta-action"
+                data-meta-event="Subscribe"
+                data-meta-interaction="submit"
+                data-meta-prevent-default="true"
+                data-meta-payload='{"form_id":"newsletter-opt-in","topics":["analytics","mission-updates"],"consent":"granted"}'
+                data-meta-feedback="subscribe-status"
+              >
+                <label>
+                  Email (hashed)
+                  <input type="text" name="hashed_email" value="bd2b1aaf7ef4f70f20caba940c19" readonly />
+                </label>
+                <label>
+                  Preferred cadence
+                  <select name="cadence">
+                    <option value="weekly">Weekly</option>
+                    <option value="monthly">Monthly</option>
+                  </select>
+                </label>
+                <button type="submit" class="sandbox-action">Record subscription</button>
+              </form>
+              <p id="subscribe-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
+          </div>
+        </div>
+
+        <div class="meta-section">
+          <h3 class="meta-section__title">Commerce &amp; lifecycle</h3>
+          <p class="meta-section__intro">
+            Full-funnel commerce events for catalog optimisation. Fire each step to validate attribution and
+            ensure value and currency properties map correctly.
+          </p>
+          <div class="meta-grid">
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'AddToCart')</p>
+                <h3>Add to cart</h3>
+              </header>
+              <p>
+                Signals that a payload containing mission hardware has been staged for purchase. Includes
+                product category metadata for catalog segmentation.
+              </p>
+              <button
+                class="sandbox-action meta-action"
+                type="button"
+                data-meta-event="AddToCart"
+                data-meta-payload='{"content_type":"product","content_ids":["telemetry-kit"],"content_category":"hardware","value":199,"currency":"USD"}'
+                data-meta-feedback="cart-status"
+              >
+                Add telemetry kit
+              </button>
+              <p id="cart-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'InitiateCheckout')</p>
+                <h3>Checkout initiation</h3>
+              </header>
+              <p>
+                Represents a cart advancing to checkout. The payload mirrors required parameters for the Meta
+                Conversions API including item IDs and order value.
+              </p>
+              <button
+                class="sandbox-action meta-action"
+                type="button"
+                data-meta-event="InitiateCheckout"
+                data-meta-payload='{"content_type":"product","num_items":1,"value":199,"currency":"USD","checkout_step":1}'
+                data-meta-feedback="checkout-status"
+              >
+                Begin secure checkout
+              </button>
+              <p id="checkout-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
+
+            <article class="sandbox-card meta-card" data-meta-card>
+              <header>
+                <p class="sandbox-card__tag mono" data-meta-call>fbq('track', 'Purchase')</p>
+                <h3>Purchase confirmation</h3>
+              </header>
+              <p>
+                Completes the funnel with a simulated purchase event. Toggle it last to confirm deduplication
+                logic downstream.
+              </p>
+              <button
+                class="sandbox-action meta-action"
+                type="button"
+                data-meta-event="Purchase"
+                data-meta-payload='{"content_type":"product","content_ids":["telemetry-kit"],"value":199,"currency":"USD","order_id":"META-DEMO-001"}'
+                data-meta-feedback="purchase-status"
+              >
+                Log purchase
+              </button>
+              <p id="purchase-status" class="meta-status">Idle — waiting for interaction.</p>
+              <details>
+                <summary class="mono">Payload blueprint</summary>
+                <pre class="meta-pre" data-meta-payload-preview></pre>
+              </details>
+            </article>
+          </div>
+        </div>
       </section>
 
       <aside class="sandbox-console meta-console" data-console-panel aria-labelledby="meta-console-heading">
@@ -387,7 +614,8 @@ import '../../../styles/analytics-sandbox.css';
       if (!card) return;
       const callLabel = card.querySelector('[data-meta-call]');
       if (callLabel) {
-        callLabel.textContent = `fbq('track', '${element.dataset.metaEvent}', ${prettyJson(payload)})`;
+        const command = element.dataset.metaCommand || 'track';
+        callLabel.textContent = `fbq('${command}', '${element.dataset.metaEvent}', ${prettyJson(payload)})`;
       }
       const previewBlock = card.querySelector('[data-meta-payload-preview]');
       if (previewBlock) {
@@ -396,7 +624,7 @@ import '../../../styles/analytics-sandbox.css';
     };
 
     const registerInteraction = (element) => {
-      const { metaEvent, metaInteraction, metaPreventDefault, metaFeedback } = element.dataset;
+      const { metaEvent, metaInteraction, metaPreventDefault, metaFeedback, metaCommand } = element.dataset;
       let payload = {};
       try {
         payload = element.dataset.metaPayload ? JSON.parse(element.dataset.metaPayload) : {};
@@ -412,7 +640,8 @@ import '../../../styles/analytics-sandbox.css';
           event.preventDefault();
         }
 
-        fbq('track', metaEvent, payload);
+        const command = metaCommand || 'track';
+        fbq(command, metaEvent, payload);
 
         element.classList.add('meta-action--fired');
         window.setTimeout(() => {
@@ -443,6 +672,43 @@ import '../../../styles/analytics-sandbox.css';
   </script>
 
   <style>
+    .meta-sandbox .meta-section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .meta-sandbox .meta-section + .meta-section {
+      margin-top: var(--space-4);
+      padding-top: var(--space-3);
+      border-top: 1px solid color-mix(in srgb, var(--color-rule) 65%, transparent);
+    }
+
+    .meta-sandbox .meta-section__title {
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: var(--text-16);
+    }
+
+    .meta-sandbox .meta-section__intro {
+      margin: 0;
+      color: var(--color-muted);
+      max-width: 68ch;
+    }
+
+    .meta-sandbox .meta-grid {
+      display: grid;
+      gap: var(--space-3);
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .meta-sandbox .meta-milestones {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-2);
+    }
+
     .meta-sandbox .meta-card details {
       border-top: 1px solid var(--color-rule);
       padding-top: var(--space-2);

--- a/src/pages/lab/analytics/unified-data-layer.astro
+++ b/src/pages/lab/analytics/unified-data-layer.astro
@@ -65,37 +65,159 @@ import '../../../styles/analytics-sandbox.css';
             Buttons, links, and forms declare their instrumentation through data attributes. A helper maps the
             DOM metadata into normalized payloads pushed into the data layer.
           </p>
-          <div class="udl-interactions__grid">
-            <button
-              class="sandbox-action"
-              data-udl-event="cta_click"
-              data-udl-element="Launch Primary CTA"
-              data-udl-module="udl-sandbox.cta"
-              data-udl-value="primary"
-            >
-              Initiate launch sequence
-            </button>
-            <a
-              href="#"
-              class="sandbox-link"
-              data-udl-event="documentation_open"
-              data-udl-element="Sandbox Documentation Link"
-              data-udl-module="udl-sandbox.navigation"
-              data-udl-prevent-default="true"
-            >
-              View implementation checklist
-            </a>
-            <form
-              class="sandbox-form"
-              data-udl-event="form_submit"
-              data-udl-element="Mission Intake Form"
-              data-udl-module="udl-sandbox.form"
-              data-udl-trigger="submit"
-            >
-              <label for="udl-mission">Mission objective</label>
-              <input id="udl-mission" name="missionObjective" placeholder="Calibrate telemetry" />
-              <button type="submit" class="sandbox-action">Submit request</button>
-            </form>
+
+          <div class="udl-interactions__section">
+            <h3>Acquisition &amp; navigation</h3>
+            <p class="udl-interactions__intro">Hero CTAs, navigation links, and internal search queries.</p>
+            <div class="udl-interactions__grid">
+              <button
+                class="sandbox-action"
+                data-udl-event="cta_click"
+                data-udl-element="Launch Primary CTA"
+                data-udl-module="udl-sandbox.cta"
+                data-udl-value="primary"
+                data-udl-metadata='{"placement":"hero","priority":"primary"}'
+              >
+                Initiate launch sequence
+              </button>
+              <a
+                href="#"
+                class="sandbox-link"
+                data-udl-event="documentation_open"
+                data-udl-element="Sandbox Documentation Link"
+                data-udl-module="udl-sandbox.navigation"
+                data-udl-prevent-default="true"
+                data-udl-metadata='{"destination":"/docs/implementation","link_type":"supporting"}'
+              >
+                View implementation checklist
+              </a>
+              <form
+                class="sandbox-form"
+                data-udl-event="search_execute"
+                data-udl-element="Knowledge Base Search"
+                data-udl-module="udl-sandbox.search"
+                data-udl-trigger="submit"
+                data-udl-metadata='{"search_type":"site","results_returned":12}'
+              >
+                <label for="udl-search">Search query</label>
+                <input id="udl-search" name="search_query" placeholder="Telemetry protocols" required />
+                <button type="submit" class="sandbox-action">Run search</button>
+              </form>
+            </div>
+          </div>
+
+          <div class="udl-interactions__section">
+            <h3>Media &amp; documents</h3>
+            <p class="udl-interactions__intro">Video milestones and download tracking for resource hubs.</p>
+            <div class="udl-interactions__grid">
+              <button
+                class="sandbox-action"
+                data-udl-event="media_start"
+                data-udl-element="Mission Briefing Video"
+                data-udl-module="udl-sandbox.media"
+                data-udl-metadata='{"media_type":"video","media_title":"Mission Brief 01","position":"hero"}'
+              >
+                Start mission briefing
+              </button>
+              <button
+                class="sandbox-action"
+                data-udl-event="media_milestone"
+                data-udl-element="Mission Briefing Video"
+                data-udl-module="udl-sandbox.media"
+                data-udl-metadata='{"media_type":"video","media_title":"Mission Brief 01","percent":50}'
+              >
+                Log 50% milestone
+              </button>
+              <a
+                href="#"
+                class="sandbox-link"
+                data-udl-event="asset_download"
+                data-udl-element="Telemetry Specification PDF"
+                data-udl-module="udl-sandbox.downloads"
+                data-udl-prevent-default="true"
+                data-udl-metadata='{"file_name":"mission-telemetry-kit.pdf","file_size":2480,"file_type":"pdf"}'
+              >
+                Download telemetry kit (PDF)
+              </a>
+            </div>
+          </div>
+
+          <div class="udl-interactions__section">
+            <h3>Commerce &amp; pipeline</h3>
+            <p class="udl-interactions__intro">Add to cart through purchase confirmation using shared product IDs.</p>
+            <div class="udl-interactions__grid">
+              <button
+                class="sandbox-action"
+                data-udl-event="commerce_add"
+                data-udl-element="Telemetry Kit"
+                data-udl-module="udl-sandbox.commerce"
+                data-udl-metadata='{"sku":"telemetry-kit","value":199,"currency":"USD"}'
+              >
+                Add telemetry kit
+              </button>
+              <button
+                class="sandbox-action"
+                data-udl-event="commerce_checkout"
+                data-udl-element="Telemetry Kit"
+                data-udl-module="udl-sandbox.commerce"
+                data-udl-metadata='{"sku":"telemetry-kit","step":1,"value":199,"currency":"USD"}'
+              >
+                Begin secure checkout
+              </button>
+              <button
+                class="sandbox-action"
+                data-udl-event="commerce_purchase"
+                data-udl-element="Telemetry Kit"
+                data-udl-module="udl-sandbox.commerce"
+                data-udl-metadata='{"sku":"telemetry-kit","order_id":"UDL-DEMO-001","value":199,"currency":"USD"}'
+              >
+                Confirm purchase
+              </button>
+            </div>
+          </div>
+
+          <div class="udl-interactions__section">
+            <h3>Experience signals</h3>
+            <p class="udl-interactions__intro">Feedback loops that monitor quality, consent, and reliability.</p>
+            <div class="udl-interactions__grid">
+              <label class="udl-rating">
+                <span>Module clarity score</span>
+                <input
+                  type="range"
+                  min="1"
+                  max="5"
+                  value="3"
+                  data-udl-event="content_rate"
+                  data-udl-element="Analytics Module"
+                  data-udl-module="udl-sandbox.feedback"
+                  data-udl-trigger="change"
+                  data-udl-dynamic="range"
+                  data-udl-metadata='{"scale_max":5}'
+                />
+              </label>
+              <label class="udl-toggle">
+                <input
+                  type="checkbox"
+                  checked
+                  data-udl-event="consent_update"
+                  data-udl-element="Mission Communications Opt-in"
+                  data-udl-module="udl-sandbox.consent"
+                  data-udl-trigger="change"
+                  data-udl-dynamic="toggle"
+                  data-udl-metadata='{"consent_channel":"email"}'
+                />
+                <span>Email mission updates</span>
+              </label>
+              <button
+                class="sandbox-action"
+                data-udl-event="exception_raise"
+                data-udl-element="Telemetry Feed"
+                data-udl-module="udl-sandbox.reliability"
+                data-udl-metadata='{"exception_code":"telemetry-timeout","severity":"warning"}'
+              >
+                Simulate timeout exception
+              </button>
+            </div>
           </div>
         </section>
       </section>
@@ -286,7 +408,32 @@ import '../../../styles/analytics-sandbox.css';
         ? Object.fromEntries(new FormData(element).entries())
         : null;
 
-      return {
+      let detail = {};
+      if (element.dataset.udlMetadata) {
+        try {
+          detail = JSON.parse(element.dataset.udlMetadata) || {};
+        } catch (error) {
+          detail = { parse_error: 'Unable to parse data-udl-metadata', raw: element.dataset.udlMetadata };
+        }
+      }
+
+      const dynamicType = element.dataset.udlDynamic;
+      if (dynamicType === 'range') {
+        const numericValue = Number(element.value);
+        detail = {
+          ...detail,
+          selected_value: Number.isFinite(numericValue) ? numericValue : element.value,
+        };
+      }
+
+      if (dynamicType === 'toggle') {
+        detail = {
+          ...detail,
+          consent_granted: element.checked,
+        };
+      }
+
+      const basePayload = {
         event: eventName,
         schema: baseContext.schema,
         session: baseContext.session,
@@ -299,7 +446,14 @@ import '../../../styles/analytics-sandbox.css';
           trigger,
           form_values: formValues,
         },
+        detail: Object.keys(detail).length ? detail : null,
       };
+
+      if (basePayload.detail === null) {
+        delete basePayload.detail;
+      }
+
+      return basePayload;
     };
 
     const registerInteraction = (element) => {
@@ -356,6 +510,72 @@ import '../../../styles/analytics-sandbox.css';
       margin: 0;
       text-transform: uppercase;
       letter-spacing: 0.08em;
+    }
+
+    .udl-sandbox .udl-interactions__section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .udl-sandbox .udl-interactions__section + .udl-interactions__section {
+      margin-top: var(--space-3);
+      padding-top: var(--space-3);
+      border-top: 1px solid color-mix(in srgb, var(--color-rule) 60%, transparent);
+    }
+
+    .udl-sandbox .udl-interactions__section h3 {
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: var(--text-16);
+    }
+
+    .udl-sandbox .udl-interactions__intro {
+      margin: 0;
+      color: var(--color-muted);
+      max-width: 68ch;
+    }
+
+    .udl-sandbox .udl-interactions__grid {
+      display: grid;
+      gap: var(--space-3);
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      align-items: start;
+    }
+
+    .udl-sandbox .udl-interactions__grid .sandbox-form {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .udl-sandbox .udl-rating {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      font-family: var(--font-mono);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: var(--text-12);
+    }
+
+    .udl-sandbox .udl-rating span {
+      color: var(--color-muted);
+    }
+
+    .udl-sandbox .udl-rating input {
+      width: 100%;
+    }
+
+    .udl-sandbox .udl-toggle {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+      font-family: var(--font-mono);
+      font-size: var(--text-12);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
     }
 
     .udl-sandbox .udl-context__grid pre {

--- a/src/pages/lab/analytics/x-pixel.astro
+++ b/src/pages/lab/analytics/x-pixel.astro
@@ -45,6 +45,17 @@ import '../../../styles/analytics-sandbox.css';
               </dd>
             </div>
             <div>
+              <dt>Strategy consultation CTA</dt>
+              <dd>
+                <span class="label">Event</span>
+                <code>schedule_call</code>
+              </dd>
+              <dd>
+                <span class="label">Parameters</span>
+                <code>{`{"content_name":"Strategy Call","value":0}`}</code>
+              </dd>
+            </div>
+            <div>
               <dt>Annotated reference link</dt>
               <dd>
                 <span class="label">Event</span>
@@ -53,6 +64,39 @@ import '../../../styles/analytics-sandbox.css';
               <dd>
                 <span class="label">Parameters</span>
                 <code>{`{"destination":"/lab/analytics"}`}</code>
+              </dd>
+            </div>
+            <div>
+              <dt>Video milestone</dt>
+              <dd>
+                <span class="label">Event</span>
+                <code>video_progress</code>
+              </dd>
+              <dd>
+                <span class="label">Parameters</span>
+                <code>{`{"video_title":"Mission Brief","percent":50}`}</code>
+              </dd>
+            </div>
+            <div>
+              <dt>Add to cart</dt>
+              <dd>
+                <span class="label">Event</span>
+                <code>add_to_cart</code>
+              </dd>
+              <dd>
+                <span class="label">Parameters</span>
+                <code>{`{"content_ids":["telemetry-kit"],"value":199}`}</code>
+              </dd>
+            </div>
+            <div>
+              <dt>Purchase confirmation</dt>
+              <dd>
+                <span class="label">Event</span>
+                <code>purchase</code>
+              </dd>
+              <dd>
+                <span class="label">Parameters</span>
+                <code>{`{"order_id":"TW-DEMO-001","value":199}`}</code>
               </dd>
             </div>
             <div>
@@ -72,41 +116,137 @@ import '../../../styles/analytics-sandbox.css';
         <section class="sandbox-card x-interactive" aria-labelledby="x-interactive-heading">
           <h2 id="x-interactive-heading">Interactive elements</h2>
           <p>Trigger an interaction to see a live payload appear in the mock endpoint console.</p>
-          <div class="x-interactive__grid">
-            <button
-              id="x-button"
-              class="sandbox-action sandbox-element"
-              type="button"
-              data-twq-event="button_click"
-              data-twq-parameters='{"content_name":"Sandbox CTA","value":1}'
-            >
-              Initiate launch sequence
-            </button>
-            <a
-              id="x-link"
-              class="sandbox-link sandbox-element"
-              href="/lab/analytics"
-              data-twq-event="link_click"
-              data-twq-parameters='{"destination":"/lab/analytics"}'
-            >
-              View analytics lab index
-            </a>
-            <form
-              id="x-form"
-              class="sandbox-form sandbox-element sandbox-element--form"
-              data-twq-event="form_submit"
-              data-twq-parameters='{"form_name":"interest_capture"}'
-            >
-              <label for="mission-interest">Mission interest</label>
-              <input
-                id="mission-interest"
-                name="mission_interest"
-                type="text"
-                placeholder="Telemetry optimization"
-                required
-              />
-              <button type="submit" class="sandbox-action">Submit signal</button>
-            </form>
+
+          <div class="x-interactive__section">
+            <h3>High-intent conversions</h3>
+            <p class="x-interactive__intro">Hero CTAs and meeting bookings mapped to lead-focused events.</p>
+            <div class="x-interactive__actions">
+              <button
+                id="x-button"
+                class="sandbox-action sandbox-element"
+                type="button"
+                data-twq-event="button_click"
+                data-twq-parameters='{"content_name":"Sandbox CTA","value":1,"placement":"hero"}'
+              >
+                Initiate launch sequence
+              </button>
+              <button
+                class="sandbox-action sandbox-element"
+                type="button"
+                data-twq-event="schedule_call"
+                data-twq-parameters='{"content_name":"Strategy Call","value":0,"mission_window":"Q3"}'
+              >
+                Schedule strategy call
+              </button>
+            </div>
+          </div>
+
+          <div class="x-interactive__section">
+            <h3>Content &amp; navigation</h3>
+            <p class="x-interactive__intro">Links and media milestones used for audience building.</p>
+            <div class="x-interactive__actions">
+              <a
+                id="x-link"
+                class="sandbox-link sandbox-element"
+                href="/lab/analytics"
+                data-twq-event="link_click"
+                data-twq-parameters='{"destination":"/lab/analytics","link_type":"internal"}'
+              >
+                View analytics lab index
+              </a>
+              <button
+                class="sandbox-action sandbox-element"
+                type="button"
+                data-twq-event="video_play"
+                data-twq-parameters='{"video_title":"Mission Brief","position":"hero"}'
+              >
+                Start mission briefing
+              </button>
+              <button
+                class="sandbox-action sandbox-element"
+                type="button"
+                data-twq-event="video_progress"
+                data-twq-parameters='{"video_title":"Mission Brief","percent":50,"seconds":72}'
+              >
+                Log 50% milestone
+              </button>
+              <a
+                class="sandbox-link sandbox-element"
+                href="#"
+                data-twq-event="download_manual"
+                data-twq-parameters='{"asset":"mission-brief.pdf","content_type":"pdf"}'
+              >
+                Download mission brief (PDF)
+              </a>
+            </div>
+          </div>
+
+          <div class="x-interactive__section">
+            <h3>Commerce funnel</h3>
+            <p class="x-interactive__intro">Sequential events that measure product consideration to purchase.</p>
+            <div class="x-interactive__actions">
+              <button
+                class="sandbox-action sandbox-element"
+                type="button"
+                data-twq-event="add_to_cart"
+                data-twq-parameters='{"content_ids":["telemetry-kit"],"content_type":"product","value":199,"currency":"USD"}'
+              >
+                Add telemetry kit
+              </button>
+              <button
+                class="sandbox-action sandbox-element"
+                type="button"
+                data-twq-event="begin_checkout"
+                data-twq-parameters='{"num_items":1,"value":199,"currency":"USD"}'
+              >
+                Begin secure checkout
+              </button>
+              <button
+                class="sandbox-action sandbox-element"
+                type="button"
+                data-twq-event="purchase"
+                data-twq-parameters='{"order_id":"TW-DEMO-001","value":199,"currency":"USD","content_ids":["telemetry-kit"]}'
+              >
+                Log purchase
+              </button>
+            </div>
+          </div>
+
+          <div class="x-interactive__section">
+            <h3>Forms &amp; preferences</h3>
+            <p class="x-interactive__intro">Lead qualification and newsletter subscriptions.</p>
+            <div class="x-interactive__actions x-interactive__actions--column">
+              <form
+                id="x-form"
+                class="sandbox-form sandbox-element sandbox-element--form"
+                data-twq-event="form_submit"
+                data-twq-parameters='{"form_name":"interest_capture","priority":"hot"}'
+              >
+                <label for="mission-interest">Mission interest</label>
+                <input
+                  id="mission-interest"
+                  name="mission_interest"
+                  type="text"
+                  placeholder="Telemetry optimization"
+                  required
+                />
+                <label for="mission-size">Team size</label>
+                <select id="mission-size" name="mission_size">
+                  <option value="1-10">1-10</option>
+                  <option value="11-50">11-50</option>
+                  <option value="51+">51+</option>
+                </select>
+                <button type="submit" class="sandbox-action">Submit signal</button>
+              </form>
+              <button
+                class="sandbox-action sandbox-element"
+                type="button"
+                data-twq-event="newsletter_signup"
+                data-twq-parameters='{"list":"mission-updates","method":"inline","value":0}'
+              >
+                Record newsletter signup
+              </button>
+            </div>
           </div>
         </section>
       </section>
@@ -381,8 +521,39 @@ import '../../../styles/analytics-sandbox.css';
       font-size: var(--text-12);
     }
 
-    .x-sandbox .x-interactive__grid {
+    .x-sandbox .x-interactive__section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .x-sandbox .x-interactive__section + .x-interactive__section {
+      margin-top: var(--space-3);
+      padding-top: var(--space-3);
+      border-top: 1px solid color-mix(in srgb, var(--color-rule) 60%, transparent);
+    }
+
+    .x-sandbox .x-interactive__section h3 {
+      margin: 0;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-size: var(--text-16);
+    }
+
+    .x-sandbox .x-interactive__intro {
+      margin: 0;
+      color: var(--color-muted);
+      max-width: 68ch;
+    }
+
+    .x-sandbox .x-interactive__actions {
       display: grid;
+      gap: var(--space-2);
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .x-sandbox .x-interactive__actions--column {
+      grid-template-columns: 1fr;
       gap: var(--space-3);
     }
 


### PR DESCRIPTION
## Summary
- Expand the Meta Pixel sandbox with mission-critical, engagement, and commerce interaction groups plus command-aware console logging
- Extend the LinkedIn Insight Tag page with additional conversion scenarios, payload previews, and commerce events
- Enrich the X Pixel and unified data layer sandboxes with comprehensive interaction sections and metadata-aware helpers

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build
- npm run preview

------
https://chatgpt.com/codex/tasks/task_e_68e33817b6b8832397080c694f6ff6a3