### PR TITLE
Add workflow to force merge all pull requests

### DIFF
--- a/.github/workflows/force-automerge.yml
+++ b/.github/workflows/force-automerge.yml
@@ -1,0 +1,51 @@
+name: Force Auto Merge All PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+
+jobs:
+  merge-immediately:
+    name: Merge pull request without waiting for checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Merge PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            if (!pr) {
+              core.warning('No pull request payload available.');
+              return;
+            }
+
+            if (pr.merged) {
+              core.info(`Pull request #${pr.number} is already merged.`);
+              return;
+            }
+
+            if (pr.state !== 'open') {
+              core.info(`Pull request #${pr.number} is not open (state: ${pr.state}).`);
+              return;
+            }
+
+            try {
+              await github.rest.pulls.merge({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                merge_method: 'squash',
+              });
+              core.notice(`Pull request #${pr.number} merged automatically without waiting for checks.`);
+            } catch (error) {
+              core.warning(`Failed to merge pull request #${pr.number}: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary
- add a workflow that immediately merges any opened pull request without waiting for checks or labels

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4173 *(manually terminated with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68e33b5d11d0832398a8c2175e4f19ec