### PR TITLE
Expand GA4 sandbox coverage and add analytics indexes

### DIFF
--- a/src/components/HeadingTracker.astro
+++ b/src/components/HeadingTracker.astro
@@ -1,0 +1,236 @@
+---
+interface HeadingTrackerProps {
+  containerClass?: string;
+  contentId?: string;
+  headingsSelector?: string;
+  topLabel?: string;
+  sideLabel?: string;
+  minHeadings?: number;
+}
+
+const {
+  containerClass = '',
+  contentId = 'tracked-content',
+  headingsSelector = 'h2, h3',
+  topLabel = 'Page index',
+  sideLabel = 'Now viewing',
+  minHeadings = 2,
+} = Astro.props as HeadingTrackerProps;
+
+const wrapperClasses = ['heading-tracker'];
+if (containerClass) {
+  wrapperClasses.push(containerClass);
+}
+
+const topListId = `${contentId}-top`; 
+const sideListId = `${contentId}-rail`;
+---
+<div
+  class={wrapperClasses.join(' ')}
+  data-heading-tracker
+  data-heading-selector={headingsSelector}
+  data-min-headings={String(minHeadings)}
+>
+  <aside
+    class="heading-tracker__rail"
+    aria-label={sideLabel}
+    data-heading-rail
+    hidden
+  >
+    <p class="heading-tracker__rail-label mono">{sideLabel}</p>
+    <nav aria-label={sideLabel}>
+      <ol id={sideListId} class="heading-tracker__list" data-heading-rail-list></ol>
+    </nav>
+  </aside>
+  <div class="heading-tracker__main">
+    <div class="heading-tracker__top hairline-bottom" data-heading-top hidden>
+      <p class="heading-tracker__top-label mono">{topLabel}</p>
+      <nav aria-label={topLabel}>
+        <ol id={topListId} class="heading-tracker__list" data-heading-top-list></ol>
+      </nav>
+    </div>
+    <div id={contentId} class="heading-tracker__content">
+      <slot />
+    </div>
+  </div>
+</div>
+<script type="module">
+  const wrapper = document.currentScript?.closest('[data-heading-tracker]');
+  if (!wrapper) {
+    return;
+  }
+
+  const contentId = {JSON.stringify(contentId)};
+  const selectorFallback = {JSON.stringify(headingsSelector)};
+  const topList = wrapper.querySelector('[data-heading-top-list]');
+  const railList = wrapper.querySelector('[data-heading-rail-list]');
+  const topSection = wrapper.querySelector('[data-heading-top]');
+  const railSection = wrapper.querySelector('[data-heading-rail]');
+  const escapeSelector = (value) => {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+      return CSS.escape(value);
+    }
+    return String(value).replace(/([ #;?%&,.+*~':"!^$\\[\\]()=>|\/=])/g, '\\$1');
+  };
+
+  const content = wrapper.querySelector(`#${escapeSelector(contentId)}`);
+
+  if (!content || !topList || !railList || !topSection || !railSection) {
+    return;
+  }
+
+  const selector = wrapper.dataset.headingSelector || selectorFallback;
+  const minHeadings = Number(wrapper.dataset.minHeadings || '2');
+
+  const headings = Array.from(content.querySelectorAll(selector))
+    .filter((heading) => heading instanceof HTMLElement)
+    .map((heading) => heading);
+
+  if (headings.length < minHeadings) {
+    wrapper.classList.add('heading-tracker--empty');
+    return;
+  }
+
+  const slugCounts = new Map();
+
+  const slugify = (value) => {
+    return value
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .replace(/\s+/g, '-');
+  };
+
+  const records = headings.map((heading) => {
+    let title = heading.textContent ? heading.textContent.trim() : '';
+    if (!title) {
+      title = heading.dataset?.headingTitle || 'Section';
+    }
+
+    let id = heading.id;
+    if (!id) {
+      const base = slugify(title || 'section') || 'section';
+      const count = slugCounts.get(base) || 0;
+      slugCounts.set(base, count + 1);
+      id = count ? `${base}-${count + 1}` : base;
+      heading.id = id;
+    }
+
+    const levelMatch = /^h(\d)$/i.exec(heading.tagName);
+    const level = levelMatch ? parseInt(levelMatch[1], 10) : 2;
+
+    heading.setAttribute('data-heading-source', 'tracker');
+
+    return {
+      id,
+      title,
+      level,
+      element: heading,
+    };
+  });
+
+  const filtered = records.filter((record) => record.level >= 2 && record.level <= 4);
+
+  if (!filtered.length) {
+    wrapper.classList.add('heading-tracker--empty');
+    return;
+  }
+
+  const createLink = (record) => {
+    const link = document.createElement('a');
+    link.href = `#${record.id}`;
+    link.textContent = record.title;
+    link.className = 'heading-tracker__link';
+    link.dataset.headingId = record.id;
+    link.setAttribute('data-heading-link', record.id);
+    return link;
+  };
+
+  const buildLists = (container, items) => {
+    container.innerHTML = '';
+    let currentParent = null;
+
+    items.forEach((record) => {
+      const li = document.createElement('li');
+      li.className = `heading-tracker__item heading-tracker__item--level${record.level}`;
+      const link = createLink(record);
+      li.appendChild(link);
+
+      if (record.level <= 2 || !currentParent) {
+        container.appendChild(li);
+        if (record.level <= 2) {
+          currentParent = li;
+        }
+      } else {
+        let parent = currentParent;
+        if (record.level === 2) {
+          container.appendChild(li);
+          currentParent = li;
+        } else {
+          if (!parent) {
+            container.appendChild(li);
+          } else {
+            let nested = parent.querySelector('ol');
+            if (!nested) {
+              nested = document.createElement('ol');
+              nested.className = 'heading-tracker__list heading-tracker__list--nested';
+              parent.appendChild(nested);
+            }
+            nested.appendChild(li);
+          }
+        }
+      }
+
+      if (record.level === 2) {
+        currentParent = li;
+      }
+    });
+  };
+
+  buildLists(topList, filtered);
+  buildLists(railList, filtered);
+
+  topSection.hidden = false;
+  railSection.hidden = false;
+
+  const links = Array.from(wrapper.querySelectorAll('[data-heading-link]'));
+
+  const setActive = (id) => {
+    links.forEach((link) => {
+      if (link.dataset.headingId === id) {
+        link.setAttribute('aria-current', 'true');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    });
+  };
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      const visible = entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+      if (visible.length > 0) {
+        const active = visible[0].target.id;
+        setActive(active);
+        return;
+      }
+
+      const fallback = entries
+        .slice()
+        .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0];
+      if (fallback && fallback.target && fallback.target.id) {
+        setActive(fallback.target.id);
+      }
+    },
+    {
+      rootMargin: '-45% 0px -40% 0px',
+      threshold: [0.05, 0.25, 0.5, 0.75],
+    }
+  );
+
+  filtered.forEach((record) => {
+    observer.observe(record.element);
+  });
+})();
+</script>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -2,14 +2,16 @@
 import Layout from './Layout.astro';
 const { title, pubDate, updatedDate, tags = [] } = Astro.props;
 ---
-<Layout title={title}>
-  <div class="container">
-    <article>
-      <h1>{title}</h1>
-      <p class="mono">{pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}{updatedDate && ` (updated ${updatedDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })})`}</p>
-      {tags.length > 0 && <p class="mono">Tags: {tags.join(', ')}</p>}
-      <slot />
-      <p><a href="/blog">← Back to blog</a></p>
-    </article>
-  </div>
+<Layout title={title} headingTracker={{ containerClass: 'container', minHeadings: 1 }}>
+  <article>
+    <h1>{title}</h1>
+    <p class="mono">
+      {pubDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
+      {updatedDate &&
+        ` (updated ${updatedDate.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })})`}
+    </p>
+    {tags.length > 0 && <p class="mono">Tags: {tags.join(', ')}</p>}
+    <slot />
+    <p><a href="/blog">← Back to blog</a></p>
+  </article>
 </Layout>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,13 +2,15 @@
 import '../styles/global.css';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import HeadingTracker from '../components/HeadingTracker.astro';
 
 const {
   title: propTitle,
   description: propDescription,
   showNav = true,
   showFooter = true,
-  frontmatter = {}
+  frontmatter = {},
+  headingTracker: headingTrackerProp,
 } = Astro.props;
 
 const title = propTitle ?? frontmatter.title ?? 'JWiedeman';
@@ -39,6 +41,41 @@ const breadcrumbs = rawSegments
   .filter(({ label }) => label.length > 0);
 
 const shouldShowBreadcrumbs = showNav && breadcrumbs.length > 0;
+
+const normalizeTrackerConfig = (value: any) => {
+  if (value === null || value === undefined) {
+    return {};
+  }
+  if (typeof value === 'boolean') {
+    return { enabled: value };
+  }
+  if (typeof value === 'object') {
+    return value;
+  }
+  return {};
+};
+
+const path = Astro.url.pathname;
+const isBlogArticle = path.startsWith('/blog/') && path !== '/blog';
+const isLabPage = path.startsWith('/lab');
+
+const defaultTrackerConfig = {
+  enabled: isBlogArticle || isLabPage,
+  containerClass: 'container',
+  headingsSelector: 'h2, h3',
+  topLabel: isBlogArticle ? 'Article index' : 'On this page',
+  sideLabel: isLabPage ? 'Current module' : 'Current section',
+  minHeadings: 2,
+};
+
+const trackerConfig = {
+  ...defaultTrackerConfig,
+  ...normalizeTrackerConfig(frontmatter.headingTracker),
+  ...normalizeTrackerConfig(headingTrackerProp),
+};
+
+const trackerContentId = trackerConfig.contentId ?? 'tracked-content';
+const showHeadingTracker = Boolean(trackerConfig.enabled);
 ---
 <!DOCTYPE html>
 <html lang="en" class="theme-light">
@@ -68,7 +105,20 @@ const shouldShowBreadcrumbs = showNav && breadcrumbs.length > 0;
       </nav>
     )}
     <main class:list={{ 'site-main': true, 'site-main--flush': !showNav }}>
-      <slot />
+      {showHeadingTracker ? (
+        <HeadingTracker
+          containerClass={trackerConfig.containerClass ?? ''}
+          contentId={trackerContentId}
+          headingsSelector={trackerConfig.headingsSelector ?? 'h2, h3'}
+          topLabel={trackerConfig.topLabel ?? (isBlogArticle ? 'Article index' : 'On this page')}
+          sideLabel={trackerConfig.sideLabel ?? (isLabPage ? 'Current module' : 'Current section')}
+          minHeadings={Number(trackerConfig.minHeadings ?? 2)}
+        >
+          <slot />
+        </HeadingTracker>
+      ) : (
+        <slot />
+      )}
     </main>
     {showFooter && <Footer />}
   </body>

--- a/src/pages/lab/ads/index.md
+++ b/src/pages/lab/ads/index.md
@@ -2,8 +2,6 @@
 layout: ../../../layouts/Layout.astro
 title: "Ads"
 ---
-<div class="container">
-  <h1>Ads</h1>
-  <div class="grid">
-  </div>
+<h1>Ads</h1>
+<div class="grid">
 </div>

--- a/src/pages/lab/ai/index.md
+++ b/src/pages/lab/ai/index.md
@@ -2,10 +2,9 @@
 layout: ../../../layouts/Layout.astro
 title: "AI"
 ---
-<div class="container">
-  <h1>AI</h1>
-  <p class="mono">Explorations in applied machine intelligence for real-world sensing, classification, and play.</p>
-  <div class="grid">
+<h1>AI</h1>
+<p class="mono">Explorations in applied machine intelligence for real-world sensing, classification, and play.</p>
+<div class="grid">
     <article class="card span-6">
       <div class="label mono">AI-001</div>
       <div>
@@ -76,5 +75,4 @@ title: "AI"
         </ul>
       </div>
     </article>
-  </div>
 </div>

--- a/src/pages/lab/analytics/adobe-analytics.astro
+++ b/src/pages/lab/analytics/adobe-analytics.astro
@@ -3,7 +3,7 @@ import Layout from '../../../layouts/Layout.astro';
 import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="Adobe Analytics Sandbox">
-  <div class="container analytics-sandbox adobe-sandbox">
+  <div class="analytics-sandbox adobe-sandbox">
     <header class="sandbox-header hairline-bottom">
       <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>Adobe Analytics Sandbox</h1>
@@ -23,9 +23,19 @@ import '../../../styles/analytics-sandbox.css';
       </dl>
     </header>
 
+    <nav class="sandbox-outline" aria-label="Interaction index">
+      <h2 class="sandbox-outline__title">Interaction index</h2>
+      <ol class="sandbox-outline__list">
+        <li><a href="#adobe-cta-card">Primary CTA — Launch sequence</a></li>
+        <li><a href="#adobe-link-card">Secondary link — Telemetry logs</a></li>
+        <li><a href="#adobe-form-card">Telemetry upload form</a></li>
+        <li><a href="#adobe-pageview-card">Page load variables</a></li>
+      </ol>
+    </nav>
+
     <div class="sandbox-grid">
       <section class="sandbox-panel">
-        <article class="sandbox-card adobe-card" aria-labelledby="adobe-cta-title">
+        <article id="adobe-cta-card" class="sandbox-card adobe-card" aria-labelledby="adobe-cta-title">
           <header>
             <p id="adobe-cta-title" class="sandbox-card__tag mono">linkName: cta:launch-sequence · linkType: o</p>
             <h3>Primary CTA — Launch sequence</h3>
@@ -64,7 +74,7 @@ import '../../../styles/analytics-sandbox.css';
           <pre class="adobe-code mono">{`s.tl(this, 'o', 'cta:launch-sequence', { events: 'event5', prop4: 'launch:cta', eVar4: 'Launch — Primary', contextData: { component: 'mission-controls', priority: 'primary' } });`}</pre>
         </article>
 
-        <article class="sandbox-card adobe-card" aria-labelledby="adobe-link-title">
+        <article id="adobe-link-card" class="sandbox-card adobe-card" aria-labelledby="adobe-link-title">
           <header>
             <p id="adobe-link-title" class="sandbox-card__tag mono">linkName: nav:telemetry-logs · linkType: o</p>
             <h3>Secondary link — Telemetry logs</h3>
@@ -103,7 +113,7 @@ import '../../../styles/analytics-sandbox.css';
           <pre class="adobe-code mono">{`s.tl(this, 'o', 'nav:telemetry-logs', { events: 'event8', prop6: 'nav:telemetry', eVar6: 'Navigation Link', contextData: { component: 'global-nav', destination: 'telemetry' } });`}</pre>
         </article>
 
-        <article class="sandbox-card adobe-card" aria-labelledby="adobe-form-title">
+        <article id="adobe-form-card" class="sandbox-card adobe-card" aria-labelledby="adobe-form-title">
           <header>
             <p id="adobe-form-title" class="sandbox-card__tag mono">linkName: form:telemetry-upload · linkType: o</p>
             <h3>Telemetry upload form</h3>
@@ -149,7 +159,7 @@ import '../../../styles/analytics-sandbox.css';
           <pre class="adobe-code mono">{`s.tl(this, 'o', 'form:telemetry-upload', { events: 'event12', prop9: 'form:telemetry', eVar9: 'Telemetry Upload', contextData: { component: 'telemetry', submission: 'form' } });`}</pre>
         </article>
 
-        <section class="sandbox-card adobe-card adobe-pageview" aria-labelledby="adobe-pageview-title">
+        <section id="adobe-pageview-card" class="sandbox-card adobe-card adobe-pageview" aria-labelledby="adobe-pageview-title">
           <h2 id="adobe-pageview-title">Page load variables</h2>
           <p>
             Initial <code>s.t()</code> call seeds persistent classification variables for this sandbox view.

--- a/src/pages/lab/analytics/ga4-sandbox.astro
+++ b/src/pages/lab/analytics/ga4-sandbox.astro
@@ -133,10 +133,98 @@ const scrollDepthParams = {
   viewport_height: 'desktop'
 };
 
+const dragManifestParams = {
+  interaction_type: 'drag_drop',
+  drop_zone: 'telemetry_console',
+  content_type: 'manifest_hand_off'
+};
+
+const fileUploadParams = {
+  content_type: 'mission_log',
+  content_id: 'uplink-diagnostics',
+  upload_method: 'manual'
+};
+
+const commandPaletteParams = {
+  interface: 'command_palette',
+  interaction_type: 'hotkey',
+  surface: 'keyboard'
+};
+
+const formFocusParams = {
+  form_id: 'call-sign-intake',
+  form_name: 'Call sign capture'
+};
+
 const modalViewParams = {
   content_type: 'modal',
   content_id: 'mission-alert',
   content_name: 'Mission readiness alert'
+};
+
+const tableSortParams = {
+  content_type: 'data_table',
+  content_id: 'crew-roster',
+  interaction_type: 'sort'
+};
+
+const tableFilterParams = {
+  content_type: 'data_table',
+  content_id: 'crew-roster',
+  interaction_type: 'filter_toggle'
+};
+
+const inlineEditParams = {
+  content_type: 'data_table',
+  content_id: 'crew-roster',
+  interaction_type: 'inline_edit'
+};
+
+const rangeCalibrationParams = {
+  control_type: 'range_slider',
+  control_id: 'throttle-calibration',
+  measurement_unit: 'percent'
+};
+
+const colorCalibrationParams = {
+  control_type: 'color_picker',
+  control_id: 'hull-accent',
+  measurement_unit: 'hex'
+};
+
+const networkToggleParams = {
+  surface: 'environment_monitor',
+  interaction_type: 'network_state'
+};
+
+const screenModeParams = {
+  surface: 'display_mode',
+  interaction_type: 'screen_state'
+};
+
+const orientationParams = {
+  surface: 'device_orientation',
+  interaction_type: 'orientation_lock'
+};
+
+const geolocationParams = {
+  surface: 'geolocation_request',
+  interaction_type: 'location_capture'
+};
+
+const pwaInstallParams = {
+  surface: 'pwa_installation',
+  interaction_type: 'install_prompt'
+};
+
+const pushConsentParams = {
+  surface: 'push_messaging',
+  interaction_type: 'permission_request'
+};
+
+const backgroundSyncParams = {
+  surface: 'background_sync',
+  interaction_type: 'sync_enqueue'
 };
 
 const modalDismissParams = {
@@ -210,7 +298,7 @@ const tutorialBaseParams = {
 };
 ---
 <Layout title="GA4 Sandbox">
-  <div class="container analytics-sandbox ga4-sandbox">
+  <div class="analytics-sandbox ga4-sandbox">
     <header class="sandbox-header hairline-bottom">
       <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>GA4 Sandbox</h1>
@@ -231,6 +319,26 @@ const tutorialBaseParams = {
       </dl>
     </header>
 
+    <nav class="sandbox-outline" aria-label="Interaction index">
+      <h2 class="sandbox-outline__title">Interaction index</h2>
+      <ol class="sandbox-outline__list">
+        <li><a href="#mission-actions">Mission-critical actions</a></li>
+        <li><a href="#navigation-discovery">Navigation &amp; discovery</a></li>
+        <li><a href="#media-docs">Media &amp; documents</a></li>
+        <li><a href="#commerce-conversions">Commerce &amp; conversions</a></li>
+        <li><a href="#feedback-support">Feedback, consent &amp; support</a></li>
+        <li><a href="#interface-overlays">Interface overlays &amp; detail panels</a></li>
+        <li><a href="#collaboration-sharing">Collaboration &amp; sharing</a></li>
+        <li><a href="#account-guidance">Account &amp; guidance flows</a></li>
+        <li><a href="#gestures-advanced">Gestures &amp; advanced inputs</a></li>
+        <li><a href="#data-tables">Data tables &amp; inline updates</a></li>
+        <li><a href="#analog-controls">Analog controls &amp; calibrations</a></li>
+        <li><a href="#environment-signals">Environment &amp; device sensors</a></li>
+        <li><a href="#progressive-features">Progressive web features</a></li>
+        <li><a href="#scroll-visibility">Scroll &amp; visibility</a></li>
+      </ol>
+    </nav>
+
     <div class="sandbox-grid">
       <section class="sandbox-panel" aria-labelledby="ga4-playground-heading">
         <h2 id="ga4-playground-heading">Tracked interface elements</h2>
@@ -240,7 +348,7 @@ const tutorialBaseParams = {
           <code>gtag('event')</code> calls and watch the Measurement Protocol payloads stream into the console.
         </p>
 
-        <div class="tracked-group">
+        <div class="tracked-group" id="mission-actions">
           <h3 class="tracked-group__title">Mission-critical actions</h3>
           <p class="tracked-group__intro">
             High-value engagements such as hero CTAs, promotions, and form submissions provide the foundation for
@@ -346,7 +454,7 @@ const tutorialBaseParams = {
           </div>
         </div>
 
-        <div class="tracked-group">
+        <div class="tracked-group" id="navigation-discovery">
           <h3 class="tracked-group__title">Navigation &amp; discovery</h3>
           <p class="tracked-group__intro">
             Wayfinding, search, and tab patterns help analysts understand how visitors explore dense knowledge bases.
@@ -491,7 +599,7 @@ const tutorialBaseParams = {
           </div>
         </div>
 
-        <div class="tracked-group">
+        <div class="tracked-group" id="media-docs">
           <h3 class="tracked-group__title">Media &amp; documents</h3>
           <p class="tracked-group__intro">
             Streaming events, downloads, and outbound clicks provide a feedback loop for long-form content strategy.
@@ -577,7 +685,7 @@ const tutorialBaseParams = {
           </div>
         </div>
 
-        <div class="tracked-group">
+        <div class="tracked-group" id="commerce-conversions">
           <h3 class="tracked-group__title">Commerce &amp; conversions</h3>
           <p class="tracked-group__intro">
             Ecommerce payloads maintain parity with GA4 retail schemas so merchandising teams can stitch together intent,
@@ -662,7 +770,7 @@ const tutorialBaseParams = {
           </div>
         </div>
 
-        <div class="tracked-group">
+        <div class="tracked-group" id="feedback-support">
           <h3 class="tracked-group__title">Feedback, consent &amp; support</h3>
           <p class="tracked-group__intro">
             Move beyond conversions to observe post-interaction signals such as satisfaction, consent choices, and service
@@ -755,7 +863,7 @@ const tutorialBaseParams = {
         </div>
       </div>
 
-      <div class="tracked-group">
+      <div class="tracked-group" id="interface-overlays">
         <h3 class="tracked-group__title">Interface overlays &amp; detail panels</h3>
         <p class="tracked-group__intro">
           Validate instrumentation for modals, accordions, and contextual tooltips. These UI flourishes often live outside
@@ -853,7 +961,7 @@ const tutorialBaseParams = {
         </div>
       </div>
 
-      <div class="tracked-group">
+      <div class="tracked-group" id="collaboration-sharing">
         <h3 class="tracked-group__title">Collaboration &amp; sharing</h3>
         <p class="tracked-group__intro">
           Track how operators distribute mission intelligence. Copy, share, and print flows emit <code>share</code> events with
@@ -926,7 +1034,7 @@ const tutorialBaseParams = {
         </div>
       </div>
 
-      <div class="tracked-group">
+      <div class="tracked-group" id="account-guidance">
         <h3 class="tracked-group__title">Account &amp; guidance flows</h3>
         <p class="tracked-group__intro">
           Authenticate operators, register new specialists, and walk teams through guided tours. These patterns provide a
@@ -1060,7 +1168,514 @@ const tutorialBaseParams = {
         </div>
       </div>
 
-        <div class="tracked-group">
+      <div class="tracked-group" id="gestures-advanced">
+        <h3 class="tracked-group__title">Gestures &amp; advanced inputs</h3>
+        <p class="tracked-group__intro">
+          Drag-and-drop, file uploads, keyboard shortcuts, and focus states round out instrumentation coverage.
+          These scenarios demonstrate how to capture intent signals beyond simple clicks.
+        </p>
+        <div class="tracked-grid">
+          <article class="sandbox-card tracked-card" data-event="drag_payload">
+            <header>
+              <p class="sandbox-card__tag mono">Event: drag_payload</p>
+              <h3>Drag &amp; drop manifest</h3>
+            </header>
+            <p>
+              Drag the manifest badge into the drop zone to log a custom drag event. GA4 records the payload source,
+              drop target, and pointer coordinates so analysts can validate complex workbench gestures.
+            </p>
+            <dl class="tracked-definition sandbox-card__meta">
+              <div>
+                <dt>Trigger</dt>
+                <dd>Drop</dd>
+              </div>
+              <div>
+                <dt>Parameters</dt>
+                <dd><code>{`{"interaction_type":"drag_drop","drop_zone":"Telemetry console"}`}</code></dd>
+              </div>
+            </dl>
+            <div class="tracked-drag">
+              <div
+                id="ga4-drag-manifest"
+                class="tracked-drag__source"
+                draggable="true"
+                data-ga4-drag-source="manifest"
+                data-ga4-drag-label="Mission manifest"
+              >
+                <span class="tracked-drag__title mono">Payload</span>
+                <strong>Mission manifest</strong>
+              </div>
+              <div
+                class="tracked-dropzone"
+                data-ga4-event="drag_payload"
+                data-ga4-trigger="drop"
+                data-ga4-dynamic="drag"
+                data-ga4-drop-zone="Telemetry console"
+                data-ga4-params={JSON.stringify(dragManifestParams)}
+                data-ga4-feedback="ga4-drag-status"
+              >
+                Drop manifest to hand off
+              </div>
+            </div>
+            <p id="ga4-drag-status" class="tracked-status">Idle — manifest undelivered.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="file_upload">
+            <header>
+              <p class="sandbox-card__tag mono">Event: file_upload</p>
+              <h3>Attach instrumentation log</h3>
+            </header>
+            <p>
+              File inputs push rich metadata including file names, extensions, and aggregate size. The sandbox intercepts
+              the selection so operators can verify uploads before piping them into GA4.
+            </p>
+            <label class="sandbox-form file-upload" data-ga4-upload>
+              <span class="mono">Choose log file</span>
+              <input
+                type="file"
+                accept=".csv,.json"
+                data-ga4-event="file_upload"
+                data-ga4-trigger="change"
+                data-ga4-dynamic="file"
+                data-ga4-upload-method="manual"
+                data-ga4-params={JSON.stringify(fileUploadParams)}
+                data-ga4-feedback="ga4-upload-status"
+              />
+            </label>
+            <p id="ga4-upload-status" class="tracked-status">Idle — awaiting file selection.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="command_palette">
+            <header>
+              <p class="sandbox-card__tag mono">Event: command_palette</p>
+              <h3>Keyboard shortcut</h3>
+            </header>
+            <p>
+              Capture keyboard shortcuts used to launch utilities like a command palette. GA4 can log the specific
+              combination to understand power-user behaviour.
+            </p>
+            <div
+              class="hotkey-instruction"
+              role="presentation"
+              data-ga4-hotkey="meta+k,ctrl+k"
+              data-ga4-hotkey-label="Command palette"
+              data-ga4-event="command_palette"
+              data-ga4-dynamic="hotkey"
+              data-ga4-params={JSON.stringify(commandPaletteParams)}
+              data-ga4-feedback="ga4-hotkey-status"
+            >
+              <span class="hotkey-badge mono">⌘ K</span>
+              <span class="hotkey-badge mono">Ctrl K</span>
+              <p class="hotkey-instruction__caption">Press to launch command palette</p>
+            </div>
+            <p id="ga4-hotkey-status" class="tracked-status">Idle — shortcut not used.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="form_start">
+            <header>
+              <p class="sandbox-card__tag mono">Event: form_start</p>
+              <h3>Focus instrumentation</h3>
+            </header>
+            <p>
+              Tracking focus states reveals where operators pause before committing. The field below logs a
+              <code>form_start</code> hit the moment it receives focus.
+            </p>
+            <label class="sandbox-form focus-capture">
+              <span class="mono">Call sign</span>
+              <input
+                type="text"
+                name="callSign"
+                placeholder="Vanguard-12"
+                data-ga4-event="form_start"
+                data-ga4-trigger="focus"
+                data-ga4-dynamic="focus"
+                data-ga4-params={JSON.stringify(formFocusParams)}
+                data-ga4-feedback="ga4-focus-status"
+              />
+            </label>
+            <p id="ga4-focus-status" class="tracked-status">Idle — focus not yet captured.</p>
+          </article>
+        </div>
+      </div>
+
+      <div class="tracked-group" id="data-tables">
+        <h3 class="tracked-group__title">Data tables &amp; inline updates</h3>
+        <p class="tracked-group__intro">
+          Mission control tables often power operational dashboards. The sandbox models sort, filter, and inline
+          edit workflows so you can observe how stateful UI changes translate into GA4 events.
+        </p>
+        <div class="tracked-grid">
+          <article class="sandbox-card tracked-card" data-event="table_sort">
+            <header>
+              <p class="sandbox-card__tag mono">Event: table_sort</p>
+              <h3>Roster sort action</h3>
+            </header>
+            <p>
+              Sort interactions communicate which column and direction the operator selected. Use the control to
+              reorder the roster by crew status and inspect the resulting <code>sort_field</code> metadata.
+            </p>
+            <div class="tracked-table-wrapper">
+              <table class="tracked-table" id="ga4-crew-table">
+                <caption class="visually-hidden">Mission crew roster</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Crew member</th>
+                    <th scope="col">Role</th>
+                    <th scope="col">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr data-status="ready" data-sort-order="1">
+                    <td>Lt. Vega</td>
+                    <td>Flight director</td>
+                    <td class="mono">Ready</td>
+                  </tr>
+                  <tr data-status="standby" data-sort-order="2">
+                    <td>Cmdr. Malik</td>
+                    <td>Navigation lead</td>
+                    <td class="mono">Standby</td>
+                  </tr>
+                  <tr data-status="maintenance" data-sort-order="3">
+                    <td>Spec. Ito</td>
+                    <td>Propulsion engineer</td>
+                    <td class="mono">Maintenance</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <button
+              type="button"
+              class="sandbox-action"
+              data-ga4-event="table_sort"
+              data-ga4-dynamic="sort"
+              data-ga4-sort-field="crew_status"
+              data-ga4-sort-direction="asc"
+              data-ga4-sort-table="ga4-crew-table"
+              data-ga4-feedback="ga4-sort-status"
+              data-ga4-params={JSON.stringify(tableSortParams)}
+            >
+              Toggle status sort
+            </button>
+            <p id="ga4-sort-status" class="tracked-status">Initial order &mdash; ready crew first.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="table_filter">
+            <header>
+              <p class="sandbox-card__tag mono">Event: table_filter</p>
+              <h3>Status filter selection</h3>
+            </header>
+            <p>
+              Filtering narrows the analysis surface. Choose a crew status from the select menu to see how the
+              event packages <code>filter_value</code> and <code>filter_state</code> along with the roster metadata.
+            </p>
+            <label class="sandbox-form">
+              <span class="mono">Filter crew roster</span>
+              <select
+                id="ga4-filter-select"
+                data-ga4-event="table_filter"
+                data-ga4-trigger="change"
+                data-ga4-dynamic="filter"
+                data-ga4-filter-id="crew_status"
+                data-ga4-filter-table="ga4-crew-table"
+                data-ga4-feedback="ga4-filter-status"
+                data-ga4-params={JSON.stringify(tableFilterParams)}
+              >
+                <option value="all">Show all crew</option>
+                <option value="ready">Ready only</option>
+                <option value="standby">Standby only</option>
+                <option value="maintenance">Maintenance only</option>
+              </select>
+            </label>
+            <p id="ga4-filter-status" class="tracked-status">No filter applied.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="inline_edit">
+            <header>
+              <p class="sandbox-card__tag mono">Event: inline_edit</p>
+              <h3>Inline roster update</h3>
+            </header>
+            <p>
+              Inline edits capture the exact field and value operators adjust. Submit a new call sign to watch the
+              sandbox broadcast <code>field_name</code>, <code>field_value</code>, and update status in the console.
+            </p>
+            <p class="tracked-inline-display">
+              Current call sign: <span id="ga4-inline-call-sign" class="mono">Voyager-1</span>
+            </p>
+            <form
+              class="tracked-inline-form"
+              data-ga4-event="inline_edit"
+              data-ga4-trigger="submit"
+              data-ga4-dynamic="inline"
+              data-ga4-inline-field="call_sign"
+              data-ga4-inline-target="ga4-inline-call-sign"
+              data-ga4-feedback="ga4-inline-status"
+              data-ga4-params={JSON.stringify(inlineEditParams)}
+            >
+              <label class="sandbox-form">
+                <span class="mono">New call sign</span>
+                <input type="text" name="callSign" placeholder="Aurora-3" required data-inline-value />
+              </label>
+              <button type="submit" class="sandbox-action">Commit update</button>
+            </form>
+            <p id="ga4-inline-status" class="tracked-status">Call sign unchanged.</p>
+          </article>
+        </div>
+      </div>
+
+      <div class="tracked-group" id="analog-controls">
+        <h3 class="tracked-group__title">Analog controls &amp; calibrations</h3>
+        <p class="tracked-group__intro">
+          Range sliders and color pickers translate physical console adjustments into digital events. These inputs
+          demonstrate how to capture the precise values operators dial in.
+        </p>
+        <div class="tracked-grid">
+          <article class="sandbox-card tracked-card" data-event="dial_calibration">
+            <header>
+              <p class="sandbox-card__tag mono">Event: dial_calibration</p>
+              <h3>Throttle calibration</h3>
+            </header>
+            <p>
+              The throttle slider emits both absolute and normalized percentages so analysts can trend how crews
+              prepare burn sequences. Adjust the range input to send an updated <code>control_percent</code> value.
+            </p>
+            <div class="tracked-gauge">
+              <label class="sandbox-form">
+                <span class="mono">Throttle output</span>
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value="42"
+                  step="1"
+                  data-ga4-event="dial_calibration"
+                  data-ga4-trigger="change"
+                  data-ga4-dynamic="range"
+                  data-ga4-range-target="ga4-range-output"
+                  data-ga4-feedback="ga4-range-status"
+                  data-ga4-params={JSON.stringify(rangeCalibrationParams)}
+                />
+              </label>
+              <output id="ga4-range-output" class="tracked-output mono">42%</output>
+            </div>
+            <p id="ga4-range-status" class="tracked-status">Throttle resting at 42%.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="color_adjust">
+            <header>
+              <p class="sandbox-card__tag mono">Event: color_adjust</p>
+              <h3>Hull accent tuning</h3>
+            </header>
+            <p>
+              Color pickers can log creative experimentation. Select a hue to update the live swatch and inspect the
+              <code>color_value</code> pushed into GA4.
+            </p>
+            <div class="tracked-color">
+              <div id="ga4-color-swatch" class="tracked-color__swatch" aria-hidden="true"></div>
+              <label class="sandbox-form color-picker">
+                <span class="mono">Accent color</span>
+                <input
+                  type="color"
+                  value="#7e2522"
+                  data-ga4-event="color_adjust"
+                  data-ga4-trigger="change"
+                  data-ga4-dynamic="color"
+                  data-ga4-color-target="ga4-color-swatch"
+                  data-ga4-feedback="ga4-color-status"
+                  data-ga4-params={JSON.stringify(colorCalibrationParams)}
+                />
+              </label>
+            </div>
+            <p id="ga4-color-status" class="tracked-status">Accent set to #7E2522.</p>
+          </article>
+        </div>
+      </div>
+
+      <div class="tracked-group" id="environment-signals">
+        <h3 class="tracked-group__title">Environment &amp; device sensors</h3>
+        <p class="tracked-group__intro">
+          Network shifts, viewport changes, and location lookups all influence user journeys. These controls model how
+          to broadcast environment context alongside primary engagement events.
+        </p>
+        <div class="tracked-grid">
+          <article class="sandbox-card tracked-card" data-event="network_state">
+            <header>
+              <p class="sandbox-card__tag mono">Event: network_state</p>
+              <h3>Network availability monitor</h3>
+            </header>
+            <p>
+              Toggling connectivity illustrates how GA4 can capture <code>network_state</code> and fallback logic when
+              visitors go offline. Use the control to simulate connectivity gains and losses.
+            </p>
+            <p class="tracked-readout">Current status: <span id="ga4-network-readout" class="mono">Online</span></p>
+            <button
+              type="button"
+              class="sandbox-action"
+              data-ga4-event="network_state"
+              data-ga4-dynamic="network"
+              data-ga4-network-state="online"
+              data-ga4-network-target="ga4-network-readout"
+              data-ga4-feedback="ga4-network-status"
+              data-ga4-params={JSON.stringify(networkToggleParams)}
+            >
+              Toggle connectivity
+            </button>
+            <p id="ga4-network-status" class="tracked-status">Network derived from browser API.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="orientation_lock">
+            <header>
+              <p class="sandbox-card__tag mono">Event: orientation_lock &amp; screen_mode</p>
+              <h3>Viewport instrumentation</h3>
+            </header>
+            <p>
+              Device orientation and fullscreen states influence layout analytics. The sandbox maintains an observation
+              viewport so you can flip orientation or trigger immersive mode.
+            </p>
+            <div id="ga4-screen-display" class="tracked-screen" data-orientation="landscape">
+              <span class="tracked-screen__label mono">Observation viewport</span>
+            </div>
+            <div class="tracked-screen__controls">
+              <button
+                type="button"
+                class="sandbox-action"
+                data-ga4-event="orientation_lock"
+                data-ga4-dynamic="orientation"
+                data-ga4-orientation-state="landscape"
+                data-ga4-orientation-target="ga4-screen-display"
+                data-ga4-feedback="ga4-orientation-status"
+                data-ga4-params={JSON.stringify(orientationParams)}
+              >
+                Toggle orientation lock
+              </button>
+              <button
+                type="button"
+                class="sandbox-action"
+                data-ga4-event="screen_mode"
+                data-ga4-dynamic="fullscreen"
+                data-ga4-screen-state="windowed"
+                data-ga4-screen-target="ga4-screen-display"
+                data-ga4-feedback="ga4-screen-status"
+                data-ga4-params={JSON.stringify(screenModeParams)}
+              >
+                Toggle immersive mode
+              </button>
+            </div>
+            <p id="ga4-orientation-status" class="tracked-status">Orientation locked to landscape.</p>
+            <p id="ga4-screen-status" class="tracked-status">Viewport currently windowed.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="geolocation_capture">
+            <header>
+              <p class="sandbox-card__tag mono">Event: geolocation_capture</p>
+              <h3>Geolocation sampling</h3>
+            </header>
+            <p>
+              Not every environment permits live geolocation, so this demo synthesizes coordinates while maintaining the
+              Measurement Protocol shape GA4 expects (<code>latitude</code>, <code>longitude</code>, and
+              <code>accuracy</code>).
+            </p>
+            <p class="tracked-readout">
+              Last coordinates: <span id="ga4-geo-readout" class="mono">None captured</span>
+            </p>
+            <button
+              type="button"
+              class="sandbox-action"
+              data-ga4-event="geolocation_capture"
+              data-ga4-dynamic="geo"
+              data-ga4-geo-target="ga4-geo-readout"
+              data-ga4-feedback="ga4-geo-status"
+              data-ga4-params={JSON.stringify(geolocationParams)}
+            >
+              Sample coordinates
+            </button>
+            <p id="ga4-geo-status" class="tracked-status">No geolocation sampled.</p>
+          </article>
+        </div>
+      </div>
+
+      <div class="tracked-group" id="progressive-features">
+        <h3 class="tracked-group__title">Progressive web features</h3>
+        <p class="tracked-group__intro">
+          Install prompts, push permissions, and background sync illustrate how to instrument app-like behaviors. Use
+          the controls to generate events that mirror real-world PWA flows.
+        </p>
+        <div class="tracked-grid">
+          <article class="sandbox-card tracked-card" data-event="pwa_install_prompt">
+            <header>
+              <p class="sandbox-card__tag mono">Event: pwa_install_prompt</p>
+              <h3>Install prompt outcome</h3>
+            </header>
+            <p>
+              Each activation alternates between acceptance and dismissal to demonstrate how GA4 can tally install
+              uptake. The payload includes <code>prompt_outcome</code> so analysts can monitor adoption health.
+            </p>
+            <button
+              type="button"
+              class="sandbox-action"
+              data-ga4-event="pwa_install_prompt"
+              data-ga4-dynamic="pwa"
+              data-ga4-pwa-state="dismissed"
+              data-ga4-feedback="ga4-pwa-status"
+              data-ga4-params={JSON.stringify(pwaInstallParams)}
+            >
+              Toggle install response
+            </button>
+            <p id="ga4-pwa-status" class="tracked-status">Prompt not yet accepted.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="push_opt_in">
+            <header>
+              <p class="sandbox-card__tag mono">Event: push_opt_in</p>
+              <h3>Push permission flow</h3>
+            </header>
+            <p>
+              Push prompts are notoriously sensitive. Alternate between granting and denying permission to understand how
+              GA4 can reflect consent changes in real time.
+            </p>
+            <button
+              type="button"
+              class="sandbox-action"
+              data-ga4-event="push_opt_in"
+              data-ga4-dynamic="permission"
+              data-ga4-permission-state="default"
+              data-ga4-feedback="ga4-push-status"
+              data-ga4-params={JSON.stringify(pushConsentParams)}
+            >
+              Toggle push permission
+            </button>
+            <p id="ga4-push-status" class="tracked-status">Permission state: default.</p>
+          </article>
+
+          <article class="sandbox-card tracked-card" data-event="background_sync">
+            <header>
+              <p class="sandbox-card__tag mono">Event: background_sync</p>
+              <h3>Background sync queue</h3>
+            </header>
+            <p>
+              Offline-friendly applications often queue jobs for Service Workers. Enqueue mock sync jobs to emit queue
+              depth and job identifiers in the Measurement Protocol payload.
+            </p>
+            <p class="tracked-readout">
+              Jobs queued: <span id="ga4-sync-readout" class="mono">0</span>
+            </p>
+            <button
+              type="button"
+              class="sandbox-action"
+              data-ga4-event="background_sync"
+              data-ga4-dynamic="sync"
+              data-ga4-sync-count="0"
+              data-ga4-sync-target="ga4-sync-readout"
+              data-ga4-feedback="ga4-sync-status"
+              data-ga4-params={JSON.stringify(backgroundSyncParams)}
+            >
+              Queue sync job
+            </button>
+            <p id="ga4-sync-status" class="tracked-status">No background jobs queued.</p>
+          </article>
+        </div>
+      </div>
+
+        <div class="tracked-group" id="scroll-visibility">
           <h3 class="tracked-group__title">Scroll &amp; visibility</h3>
           <p class="tracked-group__intro">
             Scroll depth milestones help confirm whether deep documentation is actually consumed. Reach the sentinel near the
@@ -1186,6 +1801,7 @@ const tutorialBaseParams = {
   window.dataLayer = window.dataLayer || [];
 
     let activeModal = null;
+    let activeDragPayload = null;
 
     function findModal(id) {
       if (!id) {
@@ -1248,6 +1864,54 @@ const tutorialBaseParams = {
         return;
       }
       feedbackNode.textContent = message;
+    }
+
+    function parseHotkeyCombo(combo) {
+      const blueprint = { key: '', ctrl: undefined, meta: undefined, alt: undefined, shift: undefined };
+      const parts = combo
+        .toLowerCase()
+        .split('+')
+        .map((part) => part.trim())
+        .filter(Boolean);
+
+      parts.forEach((part) => {
+        if (part === 'ctrl' || part === 'control') {
+          blueprint.ctrl = true;
+        } else if (part === 'meta' || part === 'cmd' || part === 'command') {
+          blueprint.meta = true;
+        } else if (part === 'shift') {
+          blueprint.shift = true;
+        } else if (part === 'alt' || part === 'option') {
+          blueprint.alt = true;
+        } else {
+          blueprint.key = part;
+        }
+      });
+
+      return blueprint;
+    }
+
+    function matchesHotkey(event, combo) {
+      if (!combo) {
+        return false;
+      }
+      const key = (event.key || '').toLowerCase();
+      if (combo.key && combo.key !== key) {
+        return false;
+      }
+      if (combo.ctrl !== undefined && combo.ctrl !== event.ctrlKey) {
+        return false;
+      }
+      if (combo.meta !== undefined && combo.meta !== event.metaKey) {
+        return false;
+      }
+      if (combo.shift !== undefined && combo.shift !== event.shiftKey) {
+        return false;
+      }
+      if (combo.alt !== undefined && combo.alt !== event.altKey) {
+        return false;
+      }
+      return true;
     }
 
     function createSandboxConsole({ limit = 12 } = {}) {
@@ -1560,6 +2224,272 @@ const tutorialBaseParams = {
         }
       }
 
+      if (dynamicType === 'drag') {
+        const dropZone = node.dataset.ga4DropZone || node.dataset.ga4DropLabel || node.textContent?.trim();
+        if (dropZone) {
+          nextParams.drop_zone = dropZone;
+        }
+        if (activeDragPayload) {
+          nextParams.drag_source_id = activeDragPayload.id;
+          nextParams.drag_source_label = activeDragPayload.label;
+        }
+        if (event && typeof event.clientX === 'number') {
+          nextParams.pointer_x = Math.round(event.clientX);
+          nextParams.pointer_y = Math.round(event.clientY);
+        }
+        if (!nextParams.interaction_type) {
+          nextParams.interaction_type = 'drag_drop';
+        }
+      }
+
+      if (dynamicType === 'file') {
+        const files = node.files ? Array.from(node.files) : [];
+        nextParams.file_count = files.length;
+        if (files.length > 0) {
+          nextParams.file_names = files.slice(0, 3).map((file) => file.name);
+          nextParams.file_types = files.slice(0, 3).map((file) => file.type || file.name.split('.').pop() || 'unknown');
+          const totalSize = files.reduce((total, file) => total + (file.size || 0), 0);
+          nextParams.file_bytes = totalSize;
+        }
+        if (node.dataset.ga4UploadMethod) {
+          nextParams.upload_method = node.dataset.ga4UploadMethod;
+        }
+      }
+
+      if (dynamicType === 'hotkey') {
+        const parts = [];
+        if (event?.metaKey) parts.push('Meta');
+        if (event?.ctrlKey) parts.push('Ctrl');
+        if (event?.shiftKey) parts.push('Shift');
+        if (event?.altKey) parts.push('Alt');
+        if (event?.key) {
+          const normalized = event.key.length === 1 ? event.key.toUpperCase() : event.key;
+          parts.push(normalized);
+        }
+        const combination = parts.join('+') || node.dataset.ga4HotkeyLabel || node.dataset.ga4Hotkey || 'Shortcut';
+        nextParams.hotkey_combination = combination;
+        if (node.dataset.ga4HotkeyLabel) {
+          nextParams.hotkey_label = node.dataset.ga4HotkeyLabel;
+        }
+        nextParams.trigger_source = 'keyboard';
+      }
+
+      if (dynamicType === 'focus') {
+        const fieldName = node.getAttribute('name') || node.id || node.getAttribute('aria-label') || 'field';
+        nextParams.focus_target = fieldName;
+        nextParams.focus_state = event?.type || 'focus';
+      }
+
+      if (dynamicType === 'sort') {
+        const field = node.dataset.ga4SortField || 'column';
+        const tableId = node.dataset.ga4SortTable;
+        const currentDirection = node.dataset.ga4SortDirection || 'asc';
+        const nextDirection = currentDirection === 'asc' ? 'desc' : 'asc';
+        nextParams.sort_field = field;
+        nextParams.sort_direction = nextDirection;
+        node.dataset.ga4SortDirection = nextDirection;
+
+        if (tableId) {
+          const table = document.getElementById(tableId);
+          if (table) {
+            const body = table.querySelector('tbody');
+            if (body) {
+              const rows = Array.from(body.querySelectorAll('tr'));
+              const sorted = rows.sort((a, b) => {
+                const aValue = Number(a.dataset.sortOrder || 0);
+                const bValue = Number(b.dataset.sortOrder || 0);
+                return nextDirection === 'asc' ? aValue - bValue : bValue - aValue;
+              });
+              sorted.forEach((row) => body.appendChild(row));
+            }
+          }
+        }
+      }
+
+      if (dynamicType === 'filter') {
+        const filterId = node.dataset.ga4FilterId || 'filter';
+        let value = '';
+        let state = 'applied';
+
+        if (node instanceof HTMLSelectElement) {
+          value = node.value || 'all';
+          state = value === 'all' ? 'cleared' : 'applied';
+        } else if (node instanceof HTMLInputElement) {
+          const checked = node.checked;
+          value = node.value || node.dataset.ga4FilterValue || 'selection';
+          state = checked ? 'applied' : 'cleared';
+        } else {
+          value = node.dataset.ga4FilterValue || 'selection';
+          const currentState = node.dataset.ga4FilterState === 'active';
+          const nextState = !currentState;
+          node.dataset.ga4FilterState = nextState ? 'active' : 'inactive';
+          state = nextState ? 'applied' : 'cleared';
+        }
+
+        nextParams.filter_id = filterId;
+        nextParams.filter_value = value;
+        nextParams.filter_state = state;
+
+        const tableId = node.dataset.ga4FilterTable;
+        if (tableId) {
+          const table = document.getElementById(tableId);
+          if (table) {
+            const rows = table.querySelectorAll('tbody tr');
+            rows.forEach((row) => {
+              const status = row.dataset.status || '';
+              const shouldShow = value === 'all' || status === value;
+              row.hidden = !shouldShow;
+            });
+          }
+        }
+      }
+
+      if (dynamicType === 'inline') {
+        const input = node.querySelector('[data-inline-value]') || node.querySelector('input, textarea');
+        const rawValue = input ? input.value.trim() : '';
+        const field = node.dataset.ga4InlineField || input?.getAttribute('name') || 'field';
+        nextParams.field_name = field;
+        nextParams.field_value = rawValue || 'empty';
+        nextParams.update_action = rawValue ? 'submitted' : 'cleared';
+
+        const targetId = node.dataset.ga4InlineTarget;
+        if (targetId) {
+          const target = document.getElementById(targetId);
+          if (target && rawValue) {
+            target.textContent = rawValue;
+          }
+        }
+      }
+
+      if (dynamicType === 'range') {
+        const value = Number(node.value || node.getAttribute('value') || 0);
+        const min = Number(node.min || 0);
+        const max = Number(node.max || 100);
+        const denominator = max - min || 1;
+        const percent = Math.round(((value - min) / denominator) * 100);
+        nextParams.control_value = value;
+        nextParams.control_percent = percent;
+
+        const targetId = node.dataset.ga4RangeTarget;
+        if (targetId) {
+          const target = document.getElementById(targetId);
+          if (target) {
+            target.textContent = `${value}%`;
+          }
+        }
+      }
+
+      if (dynamicType === 'color') {
+        const hex = (node.value || '#000000').toUpperCase();
+        nextParams.color_value = hex;
+
+        const targetId = node.dataset.ga4ColorTarget;
+        if (targetId) {
+          const target = document.getElementById(targetId);
+          if (target) {
+            target.style.setProperty('--swatch-color', hex);
+            target.style.backgroundColor = hex;
+          }
+        }
+      }
+
+      if (dynamicType === 'network') {
+        const current = node.dataset.ga4NetworkState || (navigator.onLine ? 'online' : 'offline');
+        const nextState = current === 'online' ? 'offline' : 'online';
+        node.dataset.ga4NetworkState = nextState;
+        nextParams.network_state = nextState;
+        nextParams.previous_state = current;
+
+        const targetId = node.dataset.ga4NetworkTarget;
+        if (targetId) {
+          const target = document.getElementById(targetId);
+          if (target) {
+            target.textContent = nextState.charAt(0).toUpperCase() + nextState.slice(1);
+          }
+        }
+      }
+
+      if (dynamicType === 'fullscreen') {
+        const currentState = node.dataset.ga4ScreenState || 'windowed';
+        const nextState = currentState === 'immersive' ? 'windowed' : 'immersive';
+        node.dataset.ga4ScreenState = nextState;
+        nextParams.screen_state = nextState;
+        nextParams.previous_state = currentState;
+
+        const targetId = node.dataset.ga4ScreenTarget;
+        if (targetId) {
+          const target = document.getElementById(targetId);
+          if (target) {
+            target.classList.toggle('tracked-screen--immersive', nextState === 'immersive');
+          }
+        }
+      }
+
+      if (dynamicType === 'orientation') {
+        const currentState = node.dataset.ga4OrientationState || 'landscape';
+        const nextState = currentState === 'landscape' ? 'portrait' : 'landscape';
+        node.dataset.ga4OrientationState = nextState;
+        nextParams.orientation_state = nextState;
+        nextParams.previous_state = currentState;
+
+        const targetId = node.dataset.ga4OrientationTarget;
+        if (targetId) {
+          const target = document.getElementById(targetId);
+          if (target) {
+            target.dataset.orientation = nextState;
+            target.classList.toggle('tracked-screen--portrait', nextState === 'portrait');
+          }
+        }
+      }
+
+      if (dynamicType === 'geo') {
+        const latitude = Number((Math.random() * 180 - 90).toFixed(4));
+        const longitude = Number((Math.random() * 360 - 180).toFixed(4));
+        const accuracy = Number((Math.random() * 50 + 5).toFixed(1));
+        nextParams.latitude = latitude;
+        nextParams.longitude = longitude;
+        nextParams.accuracy = accuracy;
+
+        const targetId = node.dataset.ga4GeoTarget;
+        if (targetId) {
+          const target = document.getElementById(targetId);
+          if (target) {
+            target.textContent = `${latitude.toFixed(4)}, ${longitude.toFixed(4)} (±${accuracy}km)`;
+          }
+        }
+      }
+
+      if (dynamicType === 'pwa') {
+        const currentState = node.dataset.ga4PwaState || 'dismissed';
+        const nextState = currentState === 'accepted' ? 'dismissed' : 'accepted';
+        node.dataset.ga4PwaState = nextState;
+        nextParams.prompt_outcome = nextState;
+      }
+
+      if (dynamicType === 'permission') {
+        const currentState = node.dataset.ga4PermissionState || 'default';
+        const nextState = currentState === 'granted' ? 'denied' : 'granted';
+        node.dataset.ga4PermissionState = nextState;
+        nextParams.permission_state = nextState;
+        nextParams.previous_state = currentState;
+      }
+
+      if (dynamicType === 'sync') {
+        const currentCount = Number(node.dataset.ga4SyncCount || 0);
+        const nextCount = currentCount + 1;
+        node.dataset.ga4SyncCount = String(nextCount);
+        nextParams.job_count = nextCount;
+        nextParams.job_id = `sync-${Date.now().toString().slice(-5)}`;
+
+        const targetId = node.dataset.ga4SyncTarget;
+        if (targetId) {
+          const target = document.getElementById(targetId);
+          if (target) {
+            target.textContent = String(nextCount);
+          }
+        }
+      }
+
       return nextParams;
     }
 
@@ -1630,10 +2560,107 @@ const tutorialBaseParams = {
           feedbackMessage = `${label} logged (step ${stepNumber}/${total}) at ${timestamp}.`;
         }
 
+        if (node.dataset.ga4Dynamic === 'drag') {
+          const source = params.drag_source_label || 'Payload';
+          feedbackMessage = `${source} delivered at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'file') {
+          const count = params.file_count || 0;
+          const summary = count === 1 ? '1 file' : `${count} files`;
+          feedbackMessage = count ? `${summary} staged at ${timestamp}.` : `No files selected at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'hotkey') {
+          const combo = params.hotkey_combination || 'Shortcut';
+          feedbackMessage = `${combo} logged at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'focus') {
+          const field = params.focus_target || 'Field';
+          feedbackMessage = `${field} focus captured at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'sort') {
+          const field = params.sort_field || 'Column';
+          const direction = (params.sort_direction || '').toString().toUpperCase();
+          feedbackMessage = `${field} sorted ${direction || 'ASC'} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'filter') {
+          const value = params.filter_value || 'all';
+          const state = params.filter_state || 'applied';
+          feedbackMessage = `Filter ${value} ${state} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'inline') {
+          const field = params.field_name || 'Field';
+          const value = params.field_value || 'empty';
+          feedbackMessage = `${field} updated to ${value} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'range') {
+          const value =
+            typeof params.control_value === 'number'
+              ? params.control_value
+              : typeof params.control_percent === 'number'
+              ? params.control_percent
+              : 0;
+          feedbackMessage = `Dial tuned to ${value}% at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'color') {
+          const color = params.color_value || '#000000';
+          feedbackMessage = `Accent set to ${color} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'network') {
+          const state = params.network_state || 'unknown';
+          feedbackMessage = `Network ${state} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'fullscreen') {
+          const state = params.screen_state || 'windowed';
+          feedbackMessage = `Screen mode ${state} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'orientation') {
+          const state = params.orientation_state || 'landscape';
+          feedbackMessage = `Orientation locked to ${state} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'geo') {
+          const lat = params.latitude;
+          const lng = params.longitude;
+          const hasCoords = typeof lat === 'number' && typeof lng === 'number';
+          feedbackMessage = hasCoords
+            ? `Coordinates ${lat.toFixed(4)}, ${lng.toFixed(4)} logged at ${timestamp}.`
+            : `Geolocation sampled at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'pwa') {
+          const outcome = params.prompt_outcome || 'dismissed';
+          feedbackMessage = `Install prompt ${outcome} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'permission') {
+          const state = params.permission_state || 'default';
+          feedbackMessage = `Push permission ${state} at ${timestamp}.`;
+        }
+
+        if (node.dataset.ga4Dynamic === 'sync') {
+          const count = params.job_count || 0;
+          feedbackMessage = `Sync queue length ${count} at ${timestamp}.`;
+        }
+
         updateFeedback(node, feedbackMessage);
 
         if (node instanceof HTMLFormElement && trigger === 'submit') {
           node.reset();
+        }
+
+        if (node instanceof HTMLInputElement && node.type === 'file' && trigger === 'change') {
+          node.value = '';
         }
       });
     }
@@ -1641,6 +2668,84 @@ const tutorialBaseParams = {
     document.querySelectorAll('[data-ga4-event]').forEach((node) => {
       registerTrackable(node);
     });
+
+    document.querySelectorAll('[data-ga4-drag-source]').forEach((source) => {
+      source.addEventListener('dragstart', (event) => {
+        activeDragPayload = {
+          id: source.dataset.ga4DragSource || source.id || 'drag-source',
+          label: source.dataset.ga4DragLabel || (source.textContent ? source.textContent.trim() : 'Payload'),
+        };
+        source.classList.add('tracked-drag__source--active');
+        if (event.dataTransfer) {
+          event.dataTransfer.setData('text/plain', activeDragPayload.label);
+          event.dataTransfer.effectAllowed = 'move';
+        }
+      });
+
+      source.addEventListener('dragend', () => {
+        source.classList.remove('tracked-drag__source--active');
+        activeDragPayload = null;
+      });
+    });
+
+    document.querySelectorAll('[data-ga4-dynamic="drag"]').forEach((zone) => {
+      zone.addEventListener('dragover', (event) => {
+        event.preventDefault();
+        zone.classList.add('tracked-dropzone--active');
+        if (event.dataTransfer) {
+          event.dataTransfer.dropEffect = 'move';
+        }
+      });
+
+      zone.addEventListener('dragleave', () => {
+        zone.classList.remove('tracked-dropzone--active');
+      });
+
+      zone.addEventListener('drop', (event) => {
+        event.preventDefault();
+        zone.classList.remove('tracked-dropzone--active');
+      });
+    });
+
+    const hotkeyNodes = Array.from(document.querySelectorAll('[data-ga4-hotkey]'));
+    if (hotkeyNodes.length) {
+      const hotkeyConfigs = hotkeyNodes.map((node) => ({
+        node,
+        combos: (node.dataset.ga4Hotkey || '')
+          .split(',')
+          .map((combo) => combo.trim())
+          .filter(Boolean)
+          .map((combo) => parseHotkeyCombo(combo)),
+      }));
+
+      document.addEventListener('keydown', (event) => {
+        if (event.repeat) {
+          return;
+        }
+        hotkeyConfigs.forEach(({ node, combos }) => {
+          if (!combos.length) {
+            return;
+          }
+          const match = combos.some((combo) => matchesHotkey(event, combo));
+          if (!match) {
+            return;
+          }
+
+          const eventName = node.dataset.ga4Event;
+          if (!eventName) {
+            return;
+          }
+
+          event.preventDefault();
+          let params = parseParams(node);
+          params = applyDynamicParams(node, params, event);
+          trackEvent(eventName, params);
+          const timestamp = formatTimestamp();
+          const combo = params.hotkey_combination || 'Shortcut';
+          updateFeedback(node, `${combo} logged at ${timestamp}.`);
+        });
+      });
+    }
 
     document.querySelectorAll('[data-modal]').forEach((modal) => {
       modal.addEventListener('click', (event) => {
@@ -1879,6 +2984,124 @@ const tutorialBaseParams = {
       flex-wrap: wrap;
       gap: var(--space-2);
     }
+
+    .ga4-sandbox .tracked-drag {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-2);
+      align-items: stretch;
+    }
+
+    .ga4-sandbox .tracked-drag__source {
+      flex: 1 1 160px;
+      border: 1px solid var(--color-rule);
+      border-radius: var(--radius-2);
+      padding: var(--space-2);
+      background: rgba(255, 255, 255, 0.85);
+      cursor: grab;
+      display: grid;
+      gap: var(--space-1);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .ga4-sandbox .tracked-drag__source--active {
+      transform: translateY(-2px);
+      box-shadow: 0 12px 28px rgba(24, 24, 24, 0.18);
+      cursor: grabbing;
+    }
+
+    .ga4-sandbox .tracked-drag__title {
+      font-size: var(--text-12);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+    }
+
+    .ga4-sandbox .tracked-dropzone {
+      flex: 1 1 200px;
+      border: 2px dashed color-mix(in srgb, var(--color-rule) 80%, transparent);
+      border-radius: var(--radius-2);
+      padding: var(--space-2);
+      font-family: var(--font-mono);
+      font-size: var(--text-12);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      background: rgba(0, 0, 0, 0.04);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      min-height: 104px;
+      transition: border-color 0.2s ease, background 0.2s ease;
+    }
+
+    .ga4-sandbox .tracked-dropzone--active {
+      border-style: solid;
+      border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
+      background: rgba(190, 133, 55, 0.15);
+    }
+
+    .ga4-sandbox .file-upload {
+      gap: var(--space-1);
+    }
+
+    .ga4-sandbox .file-upload span {
+      font-size: var(--text-12);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+    }
+
+    .ga4-sandbox .file-upload input[type='file'] {
+      padding: var(--space-1);
+      border: 1px dashed color-mix(in srgb, var(--color-rule) 70%, transparent);
+      border-radius: var(--radius-2);
+      background: rgba(0, 0, 0, 0.02);
+      cursor: pointer;
+    }
+
+    .ga4-sandbox .focus-capture input[type='text'] {
+      padding: var(--space-1);
+      border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
+      border-radius: var(--radius-2);
+      font-size: var(--text-16);
+      background: rgba(255, 255, 255, 0.85);
+      transition: border-color var(--transition-base), box-shadow var(--transition-base);
+    }
+
+    .ga4-sandbox .focus-capture input[type='text']:focus-visible {
+      border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
+      box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 12%, transparent);
+    }
+
+    .ga4-sandbox .hotkey-instruction {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2);
+      border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
+      border-radius: var(--radius-2);
+      padding: var(--space-2);
+      background: rgba(255, 255, 255, 0.75);
+    }
+
+    .ga4-sandbox .hotkey-badge {
+      padding: calc(var(--space-1) * 0.5) var(--space-1);
+      border: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
+      border-radius: var(--radius-1);
+      background: rgba(0, 0, 0, 0.04);
+      font-size: var(--text-12);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .ga4-sandbox .hotkey-instruction__caption {
+      margin: 0;
+      font-size: var(--text-12);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--color-muted);
+    }
+
 
     .ga4-sandbox .sandbox-modal {
       position: fixed;

--- a/src/pages/lab/analytics/gtm-sandbox.astro
+++ b/src/pages/lab/analytics/gtm-sandbox.astro
@@ -3,7 +3,7 @@ import Layout from '../../../layouts/Layout.astro';
 import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="GTM Sandbox">
-  <div class="container analytics-sandbox gtm-sandbox">
+  <div class="analytics-sandbox gtm-sandbox">
     <header class="sandbox-header hairline-bottom">
       <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>Google Tag Manager Sandbox</h1>

--- a/src/pages/lab/analytics/index.md
+++ b/src/pages/lab/analytics/index.md
@@ -2,9 +2,8 @@
 layout: ../../../layouts/Layout.astro
 title: "Analytics"
 ---
-<div class="container">
-  <h1>Analytics</h1>
-  <div class="grid">
+<h1>Analytics</h1>
+<div class="grid">
     <article class="card span-4">
       <div class="label mono">001</div>
       <div>
@@ -54,5 +53,4 @@ title: "Analytics"
         <p>Example data layer pattern with custom events.</p>
       </div>
     </article>
-  </div>
 </div>

--- a/src/pages/lab/analytics/linkedin-pixel.astro
+++ b/src/pages/lab/analytics/linkedin-pixel.astro
@@ -3,7 +3,7 @@ import Layout from '../../../layouts/Layout.astro';
 import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="LinkedIn Insight Tag Sandbox">
-  <div class="container analytics-sandbox linkedin-sandbox">
+  <div class="analytics-sandbox linkedin-sandbox">
     <header class="sandbox-header hairline-bottom">
       <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>LinkedIn Insight Tag Sandbox</h1>

--- a/src/pages/lab/analytics/meta-pixel.astro
+++ b/src/pages/lab/analytics/meta-pixel.astro
@@ -3,7 +3,7 @@ import Layout from '../../../layouts/Layout.astro';
 import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="Meta Pixel Sandbox">
-  <div class="container analytics-sandbox meta-sandbox">
+  <div class="analytics-sandbox meta-sandbox">
     <header class="sandbox-header hairline-bottom">
       <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>Meta Pixel Sandbox</h1>

--- a/src/pages/lab/analytics/unified-data-layer.astro
+++ b/src/pages/lab/analytics/unified-data-layer.astro
@@ -3,7 +3,7 @@ import Layout from '../../../layouts/Layout.astro';
 import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="Unified Data Layer">
-  <div class="container analytics-sandbox udl-sandbox">
+  <div class="analytics-sandbox udl-sandbox">
     <header class="sandbox-header hairline-bottom">
       <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>Unified Data Layer Sandbox</h1>

--- a/src/pages/lab/analytics/x-pixel.astro
+++ b/src/pages/lab/analytics/x-pixel.astro
@@ -3,7 +3,7 @@ import Layout from '../../../layouts/Layout.astro';
 import '../../../styles/analytics-sandbox.css';
 ---
 <Layout title="X Pixel Sandbox">
-  <div class="container analytics-sandbox x-sandbox">
+  <div class="analytics-sandbox x-sandbox">
     <header class="sandbox-header hairline-bottom">
       <p class="supertitle mono">Analytics Lab / Instrumentation</p>
       <h1>X Pixel Sandbox</h1>

--- a/src/pages/lab/art/index.md
+++ b/src/pages/lab/art/index.md
@@ -2,8 +2,6 @@
 layout: ../../../layouts/Layout.astro
 title: "Art"
 ---
-<div class="container">
-  <h1>Art</h1>
-  <div class="grid">
-  </div>
+<h1>Art</h1>
+<div class="grid">
 </div>

--- a/src/pages/lab/index.md
+++ b/src/pages/lab/index.md
@@ -2,9 +2,8 @@
 layout: ../../layouts/Layout.astro
 title: "Lab"
 ---
-<div class="container">
-  <h1>Lab</h1>
-  <div class="grid">
+<h1>Lab</h1>
+<div class="grid">
     <article class="card span-4">
       <div class="label mono">001</div>
       <div>
@@ -40,5 +39,4 @@ title: "Lab"
         <p>Generative art, design, and visual studies.</p>
       </div>
     </article>
-  </div>
 </div>

--- a/src/pages/lab/marketing/index.md
+++ b/src/pages/lab/marketing/index.md
@@ -2,8 +2,6 @@
 layout: ../../../layouts/Layout.astro
 title: "Marketing"
 ---
-<div class="container">
-  <h1>Marketing</h1>
-  <div class="grid">
-  </div>
+<h1>Marketing</h1>
+<div class="grid">
 </div>

--- a/src/styles/analytics-sandbox.css
+++ b/src/styles/analytics-sandbox.css
@@ -319,6 +319,161 @@
   overflow-x: auto;
 }
 
+.sandbox-outline {
+  margin: var(--space-3) 0 var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
+  border-radius: var(--radius-2);
+  padding: var(--space-3);
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.sandbox-outline__title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-14);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.sandbox-outline__list {
+  margin: 0;
+  padding-left: var(--space-3);
+  display: grid;
+  gap: calc(var(--space-1) * 0.75);
+  font-size: var(--text-14);
+  list-style: decimal-leading-zero;
+}
+
+.sandbox-outline__list a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted transparent;
+  transition: border-color var(--transition-base), color var(--transition-base);
+}
+
+.sandbox-outline__list a:hover,
+.sandbox-outline__list a:focus-visible {
+  border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
+  color: var(--color-text);
+}
+
+.tracked-table-wrapper {
+  margin-top: var(--space-2);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-2);
+  overflow-x: auto;
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.tracked-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-14);
+}
+
+.tracked-table th,
+.tracked-table td {
+  padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
+}
+
+.tracked-table th {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: var(--text-12);
+  color: var(--color-muted);
+}
+
+.tracked-inline-display {
+  margin: var(--space-2) 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-14);
+}
+
+.tracked-inline-form {
+  display: grid;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.tracked-inline-form input[type='text'] {
+  padding: var(--space-1);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 75%, transparent);
+  border-radius: var(--radius-2);
+  font-size: var(--text-16);
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.tracked-gauge {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
+.tracked-output {
+  font-size: var(--text-20);
+}
+
+.tracked-color {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+
+.tracked-color__swatch {
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-2);
+  border: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
+  background: var(--color-accent);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.tracked-readout {
+  font-family: var(--font-mono);
+  font-size: var(--text-14);
+  margin: var(--space-2) 0;
+}
+
+.tracked-screen {
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-2);
+  padding: var(--space-3);
+  background: rgba(0, 0, 0, 0.04);
+  display: grid;
+  place-items: center;
+  min-height: 160px;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.tracked-screen--immersive {
+  background: #181818;
+  color: #f3eddf;
+  transform: scale(1.02);
+}
+
+.tracked-screen--portrait {
+  min-height: 220px;
+}
+
+.tracked-screen__label {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: var(--text-12);
+}
+
+.tracked-screen__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.tracked-screen__controls .sandbox-action {
+  flex: 1 1 160px;
+}
+
 .sandbox-list {
   margin: 0;
   padding-left: var(--space-3);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -73,6 +73,7 @@ html {
   line-height: 1.33;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
+  scroll-behavior: smooth;
 }
 
 *, *::before, *::after {
@@ -629,5 +630,134 @@ footer .container {
 
   .card .label {
     order: -1;
+  }
+}
+
+/* Heading tracker */
+.heading-tracker {
+  display: grid;
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.heading-tracker__main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.heading-tracker__top {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-bottom: var(--space-2);
+}
+
+.heading-tracker__top[hidden],
+.heading-tracker__rail[hidden] {
+  display: none !important;
+}
+
+.heading-tracker__top-label,
+.heading-tracker__rail-label {
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: var(--text-12);
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.heading-tracker__list {
+  margin: 0;
+  padding-left: var(--space-3);
+  display: grid;
+  gap: calc(var(--space-1) * 0.75);
+}
+
+.heading-tracker__list--nested {
+  margin-top: calc(var(--space-1) * 0.5);
+}
+
+.heading-tracker__item {
+  list-style: none;
+}
+
+.heading-tracker__link {
+  text-decoration: none;
+  color: var(--color-muted);
+  font-size: var(--text-14);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5ch;
+  position: relative;
+  padding-left: calc(var(--space-1) * 0.5);
+  transition: color var(--transition-base);
+}
+
+.heading-tracker__link::before {
+  content: '○';
+  font-family: var(--font-mono);
+  font-size: 0.75em;
+  color: color-mix(in srgb, var(--color-muted) 80%, transparent);
+}
+
+.heading-tracker__link[aria-current='true'] {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.heading-tracker__link[aria-current='true']::before {
+  content: '●';
+  color: var(--color-accent);
+}
+
+.heading-tracker__link:hover,
+.heading-tracker__link:focus-visible {
+  color: var(--color-text);
+}
+
+.heading-tracker__rail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border-left: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
+  padding-left: var(--space-2);
+  position: sticky;
+  top: clamp(2rem, 6vw, 4rem);
+}
+
+.heading-tracker__content h2,
+.heading-tracker__content h3,
+.heading-tracker__content h4 {
+  scroll-margin-top: clamp(6rem, 12vw, 8rem);
+}
+
+.heading-tracker__content > :first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 1024px) {
+  .heading-tracker {
+    grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 1023px) {
+  .heading-tracker {
+    grid-template-columns: 1fr;
+  }
+
+  .heading-tracker__rail {
+    display: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .heading-tracker__rail {
+    border-left-color: color-mix(in srgb, var(--color-rule) 70%, transparent);
+  }
+
+  .heading-tracker__link::before {
+    color: color-mix(in srgb, var(--color-muted) 60%, transparent);
   }
 }


### PR DESCRIPTION
## Summary
- add an interaction index to the GA4 sandbox and introduce sections for data tables, analog controls, environment signals, and PWA scenarios with live instrumentation
- extend the GA4 sandbox scripting to support new dynamic event types, UI feedback, and measurement payloads for the added demos
- share navigation outline and table styling across sandboxes and surface the index on the Adobe Analytics lab page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e343a82f0c83238ef9d72060eebb4e