### PR TITLE
feat: add cryptography lab playground

### DIFF
--- a/src/pages/lab/cryptography/index.astro
+++ b/src/pages/lab/cryptography/index.astro
@@ -1,0 +1,444 @@
+import Layout from '../../../layouts/Layout.astro';
+
+const cryptoScript = Astro.resolve('../../../scripts/cryptography.js');
+---
+<Layout title="Cryptography">
+  <section id="tracked-content" class="container lab-cryptography">
+    <header class="lab-header">
+      <p class="label mono">Module CRY</p>
+      <h1>Cryptography Lab</h1>
+      <p class="intro mono">
+        Paste a signal, tune the parameters, and watch the lab sweep through common ciphers. We run every encoder and decoder in
+        parallel and surface heuristics so you can zero in on promising leads fast.
+      </p>
+    </header>
+
+    <h2>Operations Playground</h2>
+    <div class="playground-grid">
+      <section class="panel input-panel">
+        <h3>Input signal</h3>
+        <p class="mono muted">Type or paste any text, ciphertext, or encoded payload.</p>
+        <textarea
+          id="crypto-input"
+          rows="8"
+          placeholder="VGhpcyBpcyBhIHBsYWludGV4dCBzYW1wbGUuIFRyeSBydW5uaW5nIGEgZmV3IGFsZ29yaXRobXMgdG8gZmluZCBhIGh1bWFuLXJlYWRhYmxlIGRlY29kZS4="
+        ></textarea>
+        <div class="controls mono">
+          <label class="toggle">
+            <input type="checkbox" id="auto-heuristics" checked />
+            <span>Enable heuristics sweep across all decoders</span>
+          </label>
+          <div class="actions">
+            <button type="button" class="btn" data-action="clear">Clear</button>
+            <button type="button" class="btn" data-action="sample">Load sample ciphertext</button>
+          </div>
+        </div>
+        <p class="mono footnote">
+          The heuristics pass scores each decoder for language likelihood, entropy, and alphabet fit. Disable it for raw transform
+          output only.
+        </p>
+      </section>
+      <section class="panel heuristics-panel" aria-live="polite">
+        <h3>Heuristic sweep</h3>
+        <p class="mono muted">
+          We attempt every decoder and rank the most plausible outputs. Scores combine alphabet conformity, printable ratios, and
+          vowel balance checks.
+        </p>
+        <ol id="heuristics-summary" class="heuristics-summary mono"></ol>
+      </section>
+    </div>
+
+    <h2>Transform Library</h2>
+    <p class="mono muted">Each module emits both encode and decode results automatically as you type.</p>
+    <div class="grid crypto-grid">
+      <article class="card span-6 crypto-card" data-algorithm="caesar" data-algorithm-label="CRY-001" data-algorithm-title="Caesar Shift">
+        <div class="label mono">CRY-001</div>
+        <div>
+          <h3>Caesar Shift</h3>
+          <p>Classic rotational substitution that shifts alphabetic characters through a fixed offset.</p>
+          <div class="control-group">
+            <label class="control mono" for="caesar-shift">
+              <span>Shift</span>
+              <div class="control-input">
+                <input id="caesar-shift" type="range" min="1" max="25" step="1" value="3" data-option-input data-option="shift" />
+                <span class="control-value" data-option-display="shift">3</span>
+              </div>
+            </label>
+          </div>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="rot13" data-algorithm-label="CRY-002" data-algorithm-title="ROT13">
+        <div class="label mono">CRY-002</div>
+        <div>
+          <h3>ROT13</h3>
+          <p>Fixed 13-character Caesar shift used frequently in forums and classic puzzle books.</p>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="atbash" data-algorithm-label="CRY-003" data-algorithm-title="Atbash">
+        <div class="label mono">CRY-003</div>
+        <div>
+          <h3>Atbash</h3>
+          <p>Biblical-era monoalphabetic cipher mirroring the alphabet so A ↔ Z, B ↔ Y, etc.</p>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="vigenere" data-algorithm-label="CRY-004" data-algorithm-title="Vigenère">
+        <div class="label mono">CRY-004</div>
+        <div>
+          <h3>Vigenère</h3>
+          <p>Polyalphabetic substitution using a repeating key phrase across the alphabet grid.</p>
+          <div class="control-group">
+            <label class="control mono" for="vigenere-key">
+              <span>Key</span>
+              <input
+                id="vigenere-key"
+                type="text"
+                value="cipher"
+                placeholder="Keyword (letters only)"
+                data-option-input
+                data-option="key"
+              />
+            </label>
+          </div>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="base64" data-algorithm-label="CRY-005" data-algorithm-title="Base64">
+        <div class="label mono">CRY-005</div>
+        <div>
+          <h3>Base64</h3>
+          <p>Binary-to-text encoding using the RFC 4648 alphabet for transport across ASCII-only channels.</p>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="hex" data-algorithm-label="CRY-006" data-algorithm-title="Hex">
+        <div class="label mono">CRY-006</div>
+        <div>
+          <h3>Hexadecimal</h3>
+          <p>Two-character per byte representation aligned with packet captures, firmware dumps, and memory scans.</p>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="binary" data-algorithm-label="CRY-007" data-algorithm-title="Binary">
+        <div class="label mono">CRY-007</div>
+        <div>
+          <h3>Binary</h3>
+          <p>Eight-bit binary groupings for quick inspection of raw byte patterns and ASCII toggling.</p>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="morse" data-algorithm-label="CRY-008" data-algorithm-title="Morse">
+        <div class="label mono">CRY-008</div>
+        <div>
+          <h3>Morse Code</h3>
+          <p>Dits and dahs for radio era transmissions with support for letters, numerals, and punctuation.</p>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="url" data-algorithm-label="CRY-009" data-algorithm-title="URL">
+        <div class="label mono">CRY-009</div>
+        <div>
+          <h3>URL Encoding</h3>
+          <p>Percent-encoding for safely embedding binary data inside query strings and HTTP headers.</p>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+
+      <article class="card span-6 crypto-card" data-algorithm="railfence" data-algorithm-label="CRY-010" data-algorithm-title="Rail Fence">
+        <div class="label mono">CRY-010</div>
+        <div>
+          <h3>Rail Fence</h3>
+          <p>Zig-zag transposition cipher that writes characters across multiple rails before reading row-wise.</p>
+          <div class="control-group">
+            <label class="control mono" for="railfence-rails">
+              <span>Rails</span>
+              <div class="control-input">
+                <input
+                  id="railfence-rails"
+                  type="number"
+                  min="2"
+                  max="10"
+                  step="1"
+                  value="3"
+                  data-option-input
+                  data-option="rails"
+                />
+              </div>
+            </label>
+          </div>
+          <div class="heuristic mono" data-heuristic></div>
+          <div class="result">
+            <h4>Encode</h4>
+            <pre class="mono" data-encode></pre>
+          </div>
+          <div class="result">
+            <h4>Decode</h4>
+            <pre class="mono" data-decode></pre>
+          </div>
+        </div>
+      </article>
+    </div>
+  </section>
+</Layout>
+
+  <style>
+    .lab-cryptography {
+      display: grid;
+      gap: var(--space-5);
+      padding-bottom: var(--space-6);
+    }
+
+    .lab-header {
+      display: grid;
+      gap: var(--space-2);
+      padding-top: var(--space-2);
+    }
+
+    .lab-header .label {
+      font-size: var(--text-12);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .lab-header h1 {
+      margin-bottom: 0;
+    }
+
+    .lab-header .intro {
+      max-width: 70ch;
+    }
+
+    .playground-grid {
+      display: grid;
+      gap: var(--space-3);
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    }
+
+    .panel {
+      background: var(--surface-panel);
+    }
+
+    .panel h3 {
+      margin-bottom: var(--space-1);
+    }
+
+    .muted {
+      color: var(--color-muted);
+    }
+
+    textarea {
+      width: 100%;
+      min-height: 160px;
+      resize: vertical;
+    }
+
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      margin-top: var(--space-2);
+    }
+
+    .toggle {
+      display: flex;
+      align-items: center;
+      gap: var(--space-1);
+    }
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-2);
+    }
+
+    .btn {
+      border: 1px solid var(--color-rule);
+      background: transparent;
+      color: inherit;
+      padding: var(--space-1) var(--space-2);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      cursor: pointer;
+      transition: background-color var(--transition-base), color var(--transition-base);
+    }
+
+    .btn:hover,
+    .btn:focus-visible {
+      background: var(--color-accent);
+      color: var(--color-bg);
+    }
+
+    .footnote {
+      font-size: var(--text-12);
+      margin-top: var(--space-2);
+    }
+
+    .heuristics-summary {
+      margin: 0;
+      padding-left: var(--space-3);
+      display: grid;
+      gap: var(--space-1);
+    }
+
+    .heuristics-summary li {
+      line-height: 1.4;
+    }
+
+    .heuristics-summary .score {
+      display: inline-block;
+      min-width: 3ch;
+      font-weight: 700;
+      margin-right: var(--space-1);
+    }
+
+    .crypto-grid {
+      align-items: stretch;
+    }
+
+    .crypto-card {
+      position: relative;
+    }
+
+    .crypto-card h3 {
+      margin-top: 0;
+    }
+
+    .control-group {
+      display: grid;
+      gap: var(--space-2);
+      margin-bottom: var(--space-2);
+    }
+
+    .control {
+      display: grid;
+      gap: var(--space-1);
+    }
+
+    .control-input {
+      display: flex;
+      align-items: center;
+      gap: var(--space-2);
+    }
+
+    .control-value {
+      min-width: 2ch;
+    }
+
+    .result {
+      margin-top: var(--space-2);
+    }
+
+    .result pre {
+      padding: var(--space-2);
+      background: var(--surface-tint);
+      border-radius: var(--radius-1);
+      min-height: 56px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .heuristic {
+      font-size: var(--text-12);
+      color: var(--color-muted);
+      margin-bottom: var(--space-1);
+    }
+
+    .heuristic[data-level='high'] {
+      color: var(--color-accent);
+    }
+
+    .heuristic[data-level='medium'] {
+      color: color-mix(in srgb, var(--color-accent) 45%, var(--color-text));
+    }
+
+    @media (max-width: 720px) {
+      .crypto-card {
+        grid-column: span 12;
+      }
+    }
+  </style>
+
+  <script type="module" src={cryptoScript}></script>
+</Layout>

--- a/src/pages/lab/index.md
+++ b/src/pages/lab/index.md
@@ -39,4 +39,11 @@ title: "Lab"
         <p>Generative art, design, and visual studies.</p>
       </div>
     </article>
-</div>
+    <article class="card span-4">
+      <div class="label mono">006</div>
+      <div>
+        <h2><a href="/lab/cryptography/">Cryptography</a></h2>
+        <p>Classical ciphers, encoders, and signal analysis playground.</p>
+      </div>
+    </article>
+  </div>

--- a/src/scripts/cryptography.js
+++ b/src/scripts/cryptography.js
@@ -1,0 +1,564 @@
+const textInput = document.querySelector('#crypto-input');
+const heuristicsSummary = document.querySelector('#heuristics-summary');
+const heuristicsToggle = document.querySelector('#auto-heuristics');
+const cards = Array.from(document.querySelectorAll('.crypto-card'));
+
+const MORSE_TABLE = {
+  A: '.-',
+  B: '-...',
+  C: '-.-.',
+  D: '-..',
+  E: '.',
+  F: '..-.',
+  G: '--.',
+  H: '....',
+  I: '..',
+  J: '.---',
+  K: '-.-',
+  L: '.-..',
+  M: '--',
+  N: '-.',
+  O: '---',
+  P: '.--.',
+  Q: '--.-',
+  R: '.-.',
+  S: '...',
+  T: '-',
+  U: '..-',
+  V: '...-',
+  W: '.--',
+  X: '-..-',
+  Y: '-.--',
+  Z: '--..',
+  0: '-----',
+  1: '.----',
+  2: '..---',
+  3: '...--',
+  4: '....-',
+  5: '.....',
+  6: '-....',
+  7: '--...',
+  8: '---..',
+  9: '----.',
+  '.': '.-.-.-',
+  ',': '--..--',
+  '?': '..--..',
+  '!': '-.-.--',
+  '-': '-....-',
+  '/': '-..-.',
+  '@': '.--.-.',
+  '(': '-.--.',
+  ')': '-.--.-',
+  '&': '.-...',
+  ':': '---...',
+  ';': '-.-.-.',
+  '=': '-...-',
+  '+': '.-.-.',
+  '"': '.-..-.',
+  "'": '.----.',
+  '_': '..--.-',
+  '$': '...-..-',
+  '¿': '..-.-',
+  '¡': '--...-'
+};
+
+const MORSE_REVERSE = Object.fromEntries(Object.entries(MORSE_TABLE).map(([key, value]) => [value, key]));
+
+const algorithms = {
+  caesar: {
+    encode: (input, options) => rotateCipher(input, Number(options.shift ?? 3)),
+    decode: (input, options) => rotateCipher(input, 26 - (Number(options.shift ?? 3) % 26)),
+    heuristics: (input, options) =>
+      heuristicsFromDecode(rotateCipher(input, 26 - (Number(options.shift ?? 3) % 26)), 'shifted alphabetic characters').withSignal(
+        input
+      )
+  },
+  rot13: {
+    encode: (input) => rotateCipher(input, 13),
+    decode: (input) => rotateCipher(input, 13),
+    heuristics: (input) => heuristicsFromDecode(rotateCipher(input, 13), 'ROT13 decode test').withSignal(input)
+  },
+  atbash: {
+    encode: (input) => atbashTransform(input),
+    decode: (input) => atbashTransform(input),
+    heuristics: (input) => heuristicsFromDecode(atbashTransform(input), 'Atbash decode test').withSignal(input)
+  },
+  vigenere: {
+    encode: (input, options) => vigenereTransform(input, (options.key || 'cipher').toString(), false),
+    decode: (input, options) => vigenereTransform(input, (options.key || 'cipher').toString(), true),
+    heuristics: (input, options) =>
+      heuristicsFromDecode(
+        vigenereTransform(input, (options.key || 'cipher').toString(), true),
+        'Vigenère decode test'
+      ).withSignal(input, (options.key || '').toString())
+  },
+  base64: {
+    encode: (input) => base64Encode(input),
+    decode: (input) => base64Decode(input),
+    heuristics: (input) => base64Heuristics(input)
+  },
+  hex: {
+    encode: (input) => hexEncode(input),
+    decode: (input) => hexDecode(input),
+    heuristics: (input) => hexHeuristics(input)
+  },
+  binary: {
+    encode: (input) => binaryEncode(input),
+    decode: (input) => binaryDecode(input),
+    heuristics: (input) => binaryHeuristics(input)
+  },
+  morse: {
+    encode: (input) => morseEncode(input),
+    decode: (input) => morseDecode(input),
+    heuristics: (input) => morseHeuristics(input)
+  },
+  url: {
+    encode: (input) => urlEncode(input),
+    decode: (input) => urlDecode(input),
+    heuristics: (input) => urlHeuristics(input)
+  },
+  railfence: {
+    encode: (input, options) => railFenceEncode(input, Number(options.rails ?? 3)),
+    decode: (input, options) => railFenceDecode(input, Number(options.rails ?? 3)),
+    heuristics: (input, options) =>
+      heuristicsFromDecode(railFenceDecode(input, Number(options.rails ?? 3)), 'rail fence decode test').withSignal(input)
+  }
+};
+
+function rotateCipher(input, shift) {
+  if (!input) return '';
+  const normalized = ((shift % 26) + 26) % 26;
+  return Array.from(input)
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      if (code >= 65 && code <= 90) {
+        return String.fromCharCode(((code - 65 + normalized) % 26) + 65);
+      }
+      if (code >= 97 && code <= 122) {
+        return String.fromCharCode(((code - 97 + normalized) % 26) + 97);
+      }
+      return char;
+    })
+    .join('');
+}
+
+function atbashTransform(input) {
+  if (!input) return '';
+  return Array.from(input)
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      if (code >= 65 && code <= 90) {
+        return String.fromCharCode(90 - (code - 65));
+      }
+      if (code >= 97 && code <= 122) {
+        return String.fromCharCode(122 - (code - 97));
+      }
+      return char;
+    })
+    .join('');
+}
+
+function normalizeKey(key) {
+  return key.replace(/[^A-Za-z]/g, '').toUpperCase();
+}
+
+function vigenereTransform(input, rawKey, decode = false) {
+  if (!input) return '';
+  const key = normalizeKey(rawKey || 'cipher');
+  if (!key) return input;
+  let keyIndex = 0;
+  return Array.from(input)
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      const isUpper = code >= 65 && code <= 90;
+      const isLower = code >= 97 && code <= 122;
+      if (!isUpper && !isLower) {
+        return char;
+      }
+      const base = isUpper ? 65 : 97;
+      const keyShift = key.charCodeAt(keyIndex % key.length) - 65;
+      keyIndex += 1;
+      const offset = decode ? 26 - keyShift : keyShift;
+      return String.fromCharCode(((code - base + offset) % 26) + base);
+    })
+    .join('');
+}
+
+function base64Encode(input) {
+  if (input === undefined || input === null) return '';
+  const bytes = new TextEncoder().encode(input);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
+function base64Decode(input) {
+  if (!input) return '';
+  try {
+    const sanitized = input.replace(/\s+/g, '');
+    const binary = atob(sanitized);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch (error) {
+    return '';
+  }
+}
+
+function base64Heuristics(input) {
+  const cleaned = (input || '').replace(/\s+/g, '');
+  if (!cleaned) {
+    return { score: 0, reason: 'Awaiting input for base64 analysis.' };
+  }
+  const base64Regex = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+  if (cleaned.length % 4 === 0 && base64Regex.test(cleaned)) {
+    return { score: 0.92, reason: 'Valid base64 alphabet and padding alignment detected.' };
+  }
+  if (/^[A-Za-z0-9+/=]+$/.test(cleaned)) {
+    return { score: 0.42, reason: 'Mostly base64-safe characters but length is not aligned to 4.' };
+  }
+  return { score: 0.08, reason: 'Characters fall outside the base64 alphabet.' };
+}
+
+function hexEncode(input) {
+  if (input === undefined || input === null) return '';
+  return Array.from(new TextEncoder().encode(input))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join(' ')
+    .toUpperCase();
+}
+
+function hexDecode(input) {
+  if (!input) return '';
+  const cleaned = input.replace(/[^0-9A-Fa-f]/g, '');
+  if (cleaned.length % 2 !== 0) return '';
+  const bytes = cleaned.match(/.{1,2}/g) || [];
+  try {
+    return new TextDecoder().decode(Uint8Array.from(bytes.map((byte) => parseInt(byte, 16))));
+  } catch (error) {
+    return '';
+  }
+}
+
+function hexHeuristics(input) {
+  const cleaned = (input || '').replace(/\s+/g, '');
+  if (!cleaned) {
+    return { score: 0, reason: 'Awaiting input for hexadecimal detection.' };
+  }
+  if (/^[0-9A-Fa-f]+$/.test(cleaned) && cleaned.length % 2 === 0) {
+    return { score: 0.88, reason: 'Even-length hexadecimal byte pattern detected.' };
+  }
+  if (/^[0-9A-Fa-f\s]+$/.test(input)) {
+    return { score: 0.36, reason: 'Hexadecimal alphabet detected but byte alignment is irregular.' };
+  }
+  return { score: 0.1, reason: 'Contains characters outside hexadecimal ranges.' };
+}
+
+function binaryEncode(input) {
+  if (input === undefined || input === null) return '';
+  return Array.from(new TextEncoder().encode(input))
+    .map((byte) => byte.toString(2).padStart(8, '0'))
+    .join(' ');
+}
+
+function binaryDecode(input) {
+  if (!input) return '';
+  const bits = input.trim().split(/\s+/);
+  if (bits.some((segment) => !/^[01]{1,8}$/.test(segment))) {
+    return '';
+  }
+  const bytes = bits.map((segment) => parseInt(segment, 2));
+  try {
+    return new TextDecoder().decode(Uint8Array.from(bytes));
+  } catch (error) {
+    return '';
+  }
+}
+
+function binaryHeuristics(input) {
+  const cleaned = (input || '').trim();
+  if (!cleaned) {
+    return { score: 0, reason: 'Awaiting input for binary detection.' };
+  }
+  const segments = cleaned.split(/\s+/);
+  const isBinary = segments.every((segment) => /^[01]+$/.test(segment));
+  if (!isBinary) {
+    return { score: 0.12, reason: 'Non-binary characters present.' };
+  }
+  const validLength = segments.every((segment) => segment.length === 8);
+  if (validLength) {
+    return { score: 0.9, reason: 'All segments are 8-bit binary groups.' };
+  }
+  return { score: 0.44, reason: 'Binary digits detected but byte lengths vary.' };
+}
+
+function morseEncode(input) {
+  if (!input) return '';
+  return input
+    .toUpperCase()
+    .split('')
+    .map((char) => MORSE_TABLE[char] || '')
+    .filter(Boolean)
+    .join(' ');
+}
+
+function morseDecode(input) {
+  if (!input) return '';
+  return input
+    .trim()
+    .split(/\s*\/\s*|\s{3,}/)
+    .map((word) =>
+      word
+        .trim()
+        .split(/\s+/)
+        .map((symbol) => MORSE_REVERSE[symbol] || '')
+        .join('')
+    )
+    .join(' ')
+    .trim();
+}
+
+function morseHeuristics(input) {
+  const cleaned = (input || '').trim();
+  if (!cleaned) {
+    return { score: 0, reason: 'Awaiting input for Morse code analysis.' };
+  }
+  if (/^[.\-\s\/]+$/.test(cleaned)) {
+    return { score: 0.85, reason: 'Only dots, dashes, slashes, and spaces detected — Morse likely.' };
+  }
+  return { score: 0.1, reason: 'Contains symbols outside Morse alphabet.' };
+}
+
+function urlEncode(input) {
+  if (input === undefined || input === null) return '';
+  return encodeURIComponent(input);
+}
+
+function urlDecode(input) {
+  if (!input) return '';
+  try {
+    return decodeURIComponent(input.replace(/\+/g, ' '));
+  } catch (error) {
+    return '';
+  }
+}
+
+function urlHeuristics(input) {
+  if (!input) {
+    return { score: 0, reason: 'Awaiting input for URL encoding analysis.' };
+  }
+  if (/%[0-9A-Fa-f]{2}/.test(input)) {
+    return { score: 0.78, reason: 'Percent-encoded octets detected.' };
+  }
+  if (/^[A-Za-z0-9\-_.~%]+$/.test(input)) {
+    return { score: 0.4, reason: 'Safe URL character set detected without encoded bytes.' };
+  }
+  return { score: 0.12, reason: 'Contains characters that are usually not percent-encoded.' };
+}
+
+function railFenceEncode(input, rails) {
+  if (!input) return '';
+  const sanitizedRails = Math.max(2, Math.min(Number.isFinite(rails) ? rails : 3, 10));
+  const rows = Array.from({ length: sanitizedRails }, () => []);
+  let rail = 0;
+  let direction = 1;
+  for (const char of input) {
+    rows[rail].push(char);
+    rail += direction;
+    if (rail === sanitizedRails - 1 || rail === 0) {
+      direction *= -1;
+    }
+  }
+  return rows.flat().join('');
+}
+
+function railFenceDecode(input, rails) {
+  if (!input) return '';
+  const sanitizedRails = Math.max(2, Math.min(Number.isFinite(rails) ? rails : 3, 10));
+  const pattern = new Array(input.length);
+  let rail = 0;
+  let direction = 1;
+  for (let i = 0; i < input.length; i += 1) {
+    pattern[i] = rail;
+    rail += direction;
+    if (rail === sanitizedRails - 1 || rail === 0) {
+      direction *= -1;
+    }
+  }
+  const counts = Array.from({ length: sanitizedRails }, () => 0);
+  pattern.forEach((r) => {
+    counts[r] += 1;
+  });
+  const railsContent = counts.map(() => []);
+  let pointer = 0;
+  for (let r = 0; r < sanitizedRails; r += 1) {
+    railsContent[r] = input.slice(pointer, pointer + counts[r]).split('');
+    pointer += counts[r];
+  }
+  return pattern.map((r) => railsContent[r].shift()).join('');
+}
+
+function heuristicsFromDecode(decoded, description) {
+  return {
+    withSignal(input, key) {
+      const trimmed = (input || '').replace(/\s+/g, '');
+      if (!trimmed) {
+        return { score: 0, reason: `Awaiting input before running ${description}.` };
+      }
+      if (!decoded) {
+        return { score: 0.05, reason: 'Decoder did not produce printable text.' };
+      }
+      const printableCharacters = decoded.match(/[\x20-\x7E]/g) || [];
+      const printableRatio = printableCharacters.length / decoded.length;
+      const alphaCount = (decoded.match(/[A-Za-z]/g) || []).length;
+      const total = decoded.length;
+      const alphaRatio = total ? alphaCount / total : 0;
+      const vowelCount = (decoded.match(/[AEIOUaeiou]/g) || []).length;
+      const vowelRatio = alphaCount ? vowelCount / alphaCount : 0;
+      const coherence = Math.min(1, alphaRatio * 0.5 + printableRatio * 0.3 + Math.min(vowelRatio * 1.2, 0.4));
+      const keyNote = key && !normalizeKey(key) ? ' Key is empty or lacks alphabetic characters.' : '';
+      const baseReason = coherence > 0.55 ? 'Decoded output resembles natural language.' : 'Decoded output is noisy.';
+      return {
+        score: coherence,
+        reason: `${baseReason}${keyNote}`
+      };
+    }
+  };
+}
+
+function updateCard(card) {
+  const id = card.dataset.algorithm;
+  const algorithm = algorithms[id];
+  if (!algorithm) return null;
+  const options = {};
+  card.querySelectorAll('[data-option-input]').forEach((input) => {
+    const key = input.dataset.option;
+    if (!key) return;
+    if (input.type === 'number' || input.type === 'range') {
+      options[key] = Number(input.value);
+    } else {
+      options[key] = input.value;
+    }
+    const display = card.querySelector(`[data-option-display="${key}"]`);
+    if (display) {
+      display.textContent = input.value;
+    }
+  });
+
+  const inputValue = textInput ? textInput.value : '';
+  let encodeResult = '';
+  let decodeResult = '';
+  try {
+    encodeResult = algorithm.encode(inputValue, options) || '';
+  } catch (error) {
+    encodeResult = '';
+  }
+  try {
+    decodeResult = algorithm.decode(inputValue, options) || '';
+  } catch (error) {
+    decodeResult = '';
+  }
+
+  const encodeTarget = card.querySelector('[data-encode]');
+  const decodeTarget = card.querySelector('[data-decode]');
+  if (encodeTarget) {
+    encodeTarget.textContent = encodeResult || '—';
+  }
+  if (decodeTarget) {
+    decodeTarget.textContent = decodeResult || '—';
+  }
+
+  const heuristicTarget = card.querySelector('[data-heuristic]');
+  if (!heuristicTarget) {
+    return null;
+  }
+
+  const heuristicsResult = algorithm.heuristics
+    ? algorithm.heuristics(inputValue, options)
+    : { score: 0, reason: 'No heuristics available.' };
+
+  if (!heuristicsToggle || !heuristicsToggle.checked) {
+    heuristicTarget.textContent = 'Heuristics disabled.';
+    heuristicTarget.dataset.level = '';
+    return { id, score: 0, label: card.dataset.algorithmLabel, title: card.dataset.algorithmTitle, reason: '' };
+  }
+
+  heuristicTarget.textContent = heuristicsResult.reason;
+  heuristicTarget.dataset.level = heuristicsResult.score > 0.66 ? 'high' : heuristicsResult.score > 0.33 ? 'medium' : 'low';
+  return {
+    id,
+    score: heuristicsResult.score || 0,
+    label: card.dataset.algorithmLabel,
+    title: card.dataset.algorithmTitle,
+    reason: heuristicsResult.reason
+  };
+}
+
+function updateHeuristicsSummary(results) {
+  if (!heuristicsSummary) return;
+  heuristicsSummary.innerHTML = '';
+  if (!heuristicsToggle || !heuristicsToggle.checked) {
+    const li = document.createElement('li');
+    li.textContent = 'Enable heuristics to see ranked decoder suggestions.';
+    heuristicsSummary.append(li);
+    return;
+  }
+
+  const filtered = results
+    .filter(Boolean)
+    .filter((item) => item.score && item.score > 0.05)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+
+  if (!filtered.length) {
+    const li = document.createElement('li');
+    li.textContent = 'No strong heuristic matches yet — try adjusting options or a different sample.';
+    heuristicsSummary.append(li);
+    return;
+  }
+
+  filtered.forEach((item) => {
+    const li = document.createElement('li');
+    const score = Math.round((item.score || 0) * 100);
+    li.innerHTML = `<span class="score">${score.toString().padStart(2, '0')}%</span> ${item.title}: ${item.reason}`;
+    heuristicsSummary.append(li);
+  });
+}
+
+function updateAll() {
+  const results = cards.map((card) => updateCard(card));
+  updateHeuristicsSummary(results);
+}
+
+cards.forEach((card) => {
+  card.querySelectorAll('[data-option-input]').forEach((input) => {
+    input.addEventListener('input', updateAll);
+    input.addEventListener('change', updateAll);
+  });
+});
+
+if (textInput) {
+  textInput.addEventListener('input', updateAll);
+}
+
+if (heuristicsToggle) {
+  heuristicsToggle.addEventListener('change', updateAll);
+}
+
+document.querySelectorAll('.btn[data-action]').forEach((button) => {
+  button.addEventListener('click', () => {
+    const action = button.dataset.action;
+    if (!textInput) return;
+    if (action === 'clear') {
+      textInput.value = '';
+      updateAll();
+    }
+    if (action === 'sample') {
+      textInput.value = 'Gur synt vf va gur qrpevcgvba.';
+      updateAll();
+    }
+  });
+});
+
+updateAll();


### PR DESCRIPTION
## Summary
- add a new /lab/cryptography playground with copy, controls, and cipher result cards
- implement client-side transformations and heuristics in a dedicated cryptography.js module
- surface the new lab section from the main lab index

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build
- npm run preview

------
https://chatgpt.com/codex/tasks/task_e_68e450a067c083239cae737f1c7a7082