### PR TITLE
Add lab ads platform manuals

### DIFF
--- a/src/pages/lab/ads/amazon-ads.md
+++ b/src/pages/lab/ads/amazon-ads.md
@@ -1,0 +1,68 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "Amazon Ads Deployment Brief"
+description: "Operating procedure for Sponsored Ads, DSP, and retail readiness on Amazon."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>Amazon Ads Deployment Brief</h1>
+  <p class="intro">Amazon Ads thrives when retail operations and media work in lockstep. This brief ensures the product detail page, inventory, and DSP activations stay synchronized.</p>
+
+  <section>
+    <h2>Retail readiness</h2>
+    <ul>
+      <li>Confirm Buy Box ownership above 95% for promoted ASINs.</li>
+      <li>Product detail pages must include 6+ images, enhanced A+ content, and at least 25 reviews (4+ star average).</li>
+      <li>Inventory minimum: 30 days cover for each ASIN; coordinate with supply chain to avoid stock-outs.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Sponsored Ads structure</h2>
+    <ul>
+      <li>Separate campaigns for Sponsored Products (automatic vs manual), Sponsored Brands, and Sponsored Display.</li>
+      <li>Manual campaigns: use keyword match type pods (Exact, Phrase, Broad) with shared negative keyword lists.</li>
+      <li>Sponsored Brands: build landing pages in Stores and utilize video placements where available.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>DSP architecture</h2>
+    <ul>
+      <li>Construct separate orders for Prospecting, Remarketing, and Loyalty with unique frequency caps.</li>
+      <li>Leverage Amazon Marketing Cloud (AMC) audiences for high-value segments.</li>
+      <li>Deploy third-party measurement pixels via Sizmek container when using external verification.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Measurement and reporting</h2>
+    <ul>
+      <li>Use Amazon Attribution tags for off-Amazon media driving to Amazon store pages.</li>
+      <li>Pull search term reports and DSP delivery reports weekly; surface insights to merchandising teams.</li>
+      <li>Feed AMC queries into BI dashboards for path-to-purchase and halo analysis.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization cadence</h2>
+    <ul>
+      <li><strong>Daily:</strong> Monitor retail health (inventory, Buy Box, pricing) and pause ads if stock dips below threshold.</li>
+      <li><strong>Weekly:</strong> Adjust bids by placement type (Top of Search, Product Pages) and update negative keywords.</li>
+      <li><strong>Monthly:</strong> Evaluate DSP reach/frequency, update AMC segments, and refresh creative assets.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pre-launch checklist</h2>
+    <ul>
+      <li>Sponsored Ads tracking templates tested; budgets allocated per ASIN priority.</li>
+      <li>DSP creatives approved and trafficking complete via Amazon Ad Console.</li>
+      <li>Inventory, pricing, and promotions aligned with campaign calendar.</li>
+      <li>Attribution and AMC reporting dashboards configured for stakeholders.</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/google-ads.md
+++ b/src/pages/lab/ads/google-ads.md
@@ -1,0 +1,74 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "Google Ads Mission Plan"
+description: "Activation checklist and optimization rituals for Google Ads Search, Performance Max, and Display."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>Google Ads Mission Plan</h1>
+  <p class="intro">This playbook keeps Google Ads launches aligned with NASA-grade rigor. It covers account structure, conversion telemetry, and optimization loops for Search, Performance Max, and Display inventory.</p>
+
+  <section>
+    <h2>Mission profile</h2>
+    <p>Establish a modular campaign architecture so each conversion signal is traceable and budget shifts can happen without downtime.</p>
+    <ul>
+      <li>Separate Search, Performance Max, and Display into mission groupings with shared budgets and naming syntax: <span class="mono">[LOB]-[Geo]-[Objective]-[Stage]</span>.</li>
+      <li>Use campaign experiments for incremental testing; reserve 10% of budget for variant flights.</li>
+      <li>Pin hero assets in responsive formats only when compliance demands; otherwise allow ML to rotate freely.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Audience and keyword architecture</h2>
+    <p>Blend automation and manual controls so search intent and audience signals reinforce each other.</p>
+    <ul>
+      <li>Adopt match-type pods: <strong>Exact</strong> pods for high-value queries, <strong>Phrase</strong> pods for discovery, and <strong>Broad</strong> pods with smart bidding for scale.</li>
+      <li>Layer first-party audiences and Customer Match lists into every campaign as observation segments.</li>
+      <li>Supply Performance Max with high-quality audience signals (remarketing lists, custom segments, product feeds) to cut ramp-up time.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creative payload</h2>
+    <p>Ensure each campaign has enough assets for Google’s combinatorial systems while retaining brand consistency.</p>
+    <ul>
+      <li>Responsive Search Ads: 12 headlines, 4 descriptions, include keyword variants, proof points, and compliance copy.</li>
+      <li>Performance Max: provide at least 5 images, 5 logos, 5 headlines, 4 descriptions, and 1 short-form video or auto-generated video approval.</li>
+      <li>Display: adopt 1x1, 4x5, and 16x9 aspect ratios plus HTML5 creative when rich interactions are required.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Telemetry and measurement</h2>
+    <p>Keep bid automation anchored to high-fidelity conversions.</p>
+    <ul>
+      <li>Route conversions through Google Tag Manager or the gtag interface with <strong>enhanced conversions</strong> enabled when policy allows.</li>
+      <li>Define primary vs secondary actions in the conversion manager so Smart Bidding optimizes toward the correct objective.</li>
+      <li>Deploy offline conversion imports (OCI) for sales stages beyond the site. Automate the upload via Google Ads API or Zapier.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization rituals</h2>
+    <p>Schedule recurring reviews so campaign telemetry stays within mission tolerances.</p>
+    <ul>
+      <li><strong>Daily:</strong> Guardrails on spend, policy issues, and sudden CPC spikes.</li>
+      <li><strong>Weekly:</strong> Search term analysis with negative keyword sync across match-type pods.</li>
+      <li><strong>Bi-weekly:</strong> Asset performance rating review, rotating in new creatives for “Low” rated elements.</li>
+      <li><strong>Monthly:</strong> Performance Max placement and listing group audits. Adjust budgets across mission groupings based on MER (marketing efficiency ratio).</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Go / no-go checklist</h2>
+    <ul>
+      <li>All conversions verified in Google Tag Assistant and testing environment.</li>
+      <li>Audiences synced: Customer Match, remarketing pools, and data segments refreshed within last 30 days.</li>
+      <li>Negative keyword lists, brand safety exclusions, and placement lists applied.</li>
+      <li>Budget pacing dashboards wired into Looker Studio or preferred BI tool.</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/index.md
+++ b/src/pages/lab/ads/index.md
@@ -4,4 +4,74 @@ title: "Ads"
 ---
 <h1>Ads</h1>
 <div class="grid">
+    <article class="card span-4">
+      <div class="label mono">001</div>
+      <div>
+        <h2><a href="/lab/ads/google-ads/">Google Ads</a></h2>
+        <p>Search, Performance Max, and Display activation guidelines.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">002</div>
+      <div>
+        <h2><a href="/lab/ads/meta-ads/">Meta Ads</a></h2>
+        <p>Meta Advantage campaign architecture and conversion tracking.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">003</div>
+      <div>
+        <h2><a href="/lab/ads/linkedin-ads/">LinkedIn Ads</a></h2>
+        <p>ABM targeting, lead gen forms, and conversion lift instrumentation.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">004</div>
+      <div>
+        <h2><a href="/lab/ads/x-ads/">X Ads</a></h2>
+        <p>Timeline reach, conversational ads, and site visit optimization.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">005</div>
+      <div>
+        <h2><a href="/lab/ads/tiktok-ads/">TikTok Ads</a></h2>
+        <p>Spark Ads, creator integrations, and event API readiness.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">006</div>
+      <div>
+        <h2><a href="/lab/ads/snapchat-ads/">Snapchat Ads</a></h2>
+        <p>AR Lens deployment, pixel QA, and full-funnel optimization.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">007</div>
+      <div>
+        <h2><a href="/lab/ads/reddit-ads/">Reddit Ads</a></h2>
+        <p>Community-first placements, comment strategy, and safety controls.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">008</div>
+      <div>
+        <h2><a href="/lab/ads/pinterest-ads/">Pinterest Ads</a></h2>
+        <p>Idea Pin storytelling, retail data feeds, and conversion insights.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">009</div>
+      <div>
+        <h2><a href="/lab/ads/microsoft-advertising/">Microsoft Advertising</a></h2>
+        <p>Search, audience network, and cross-engine automation.</p>
+      </div>
+    </article>
+    <article class="card span-4">
+      <div class="label mono">010</div>
+      <div>
+        <h2><a href="/lab/ads/amazon-ads/">Amazon Ads</a></h2>
+        <p>Retail readiness, DSP architecture, and attribution modeling.</p>
+      </div>
+    </article>
 </div>

--- a/src/pages/lab/ads/linkedin-ads.md
+++ b/src/pages/lab/ads/linkedin-ads.md
@@ -1,0 +1,69 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "LinkedIn Ads Deployment Guide"
+description: "Runbook for B2B demand generation, ABM, and pipeline acceleration on LinkedIn."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>LinkedIn Ads Deployment Guide</h1>
+  <p class="intro">LinkedIn’s professional graph is ideal for account-based marketing and pipeline acceleration. This guide documents campaign structure, targeting controls, and lead management.</p>
+
+  <section>
+    <h2>Campaign architecture</h2>
+    <ul>
+      <li>Build separate campaign groups for Awareness, Consideration, and Conversion with shared objectives.</li>
+      <li>Use single objective per campaign: Brand Awareness, Website Conversions, or Lead Generation depending on funnel stage.</li>
+      <li>Adopt consistent taxonomy: <span class="mono">[Program]-[Segment]-[Offer]-[Quarter]</span>.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Audience design</h2>
+    <ul>
+      <li>Create matched audiences from CRM lists (CSV or API) segmented by buying committee roles.</li>
+      <li>Layer firmographic filters: industry, company size, seniority, and job function with audience expansion disabled for ABM programs.</li>
+      <li>Retarget site visitors with Insight Tag and video viewers at 25%, 50%, and 75% completion thresholds.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creative payloads</h2>
+    <p>Deliver value-forward creative that respects professional context.</p>
+    <ul>
+      <li>Sponsor Document Ads for deep content (whitepapers, research) with ungated preview pages.</li>
+      <li>Use Conversation Ads for multi-path nurture; craft decision trees that map to buyer readiness.</li>
+      <li>When using Lead Gen Forms, prefill custom questions for qualification. Sync responses to CRM within 15 minutes.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Measurement and integrations</h2>
+    <ul>
+      <li>Validate Insight Tag firing on key pages; map events to conversions within Campaign Manager.</li>
+      <li>Enable Conversion API for server-side events when form fills are captured offsite.</li>
+      <li>Pipe data into marketing automation via native connectors or tools like Zapier/Segment. Ensure UTM parameters align with reporting standards.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization cadence</h2>
+    <ul>
+      <li><strong>Weekly:</strong> Review frequency, CTR, and cost per qualified visit. Shift budget between campaign groups accordingly.</li>
+      <li><strong>Bi-weekly:</strong> Evaluate creative fatigue; rotate new conversation paths or document assets.</li>
+      <li><strong>Quarterly:</strong> Refresh firmographic filters based on sales feedback and opportunity quality.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pre-flight checklist</h2>
+    <ul>
+      <li>Insight Tag validated and matched audiences above minimum threshold (300 members).</li>
+      <li>Lead Gen Form connectors tested for CRM/marketing automation sync.</li>
+      <li>All creatives pass brand and legal review with accessible contrast and subtitles on video.</li>
+      <li>Budget pacing dashboard configured (Looker Studio, Tableau, or Power BI).</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/meta-ads.md
+++ b/src/pages/lab/ads/meta-ads.md
@@ -1,0 +1,70 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "Meta Ads Launch Manual"
+description: "Blueprint for Meta Advantage campaigns spanning Facebook, Instagram, and Audience Network."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>Meta Ads Launch Manual</h1>
+  <p class="intro">Meta’s ecosystem rewards signal density and creative variety. This manual captures the operating procedure for Meta Advantage+ shopping, lead generation, and consideration campaigns.</p>
+
+  <section>
+    <h2>Account flight plan</h2>
+    <ul>
+      <li>Unify pixel, Conversions API, and offline events inside Events Manager with deduplication keys configured.</li>
+      <li>Use Advantage campaign budget (CBO) for scaled programs; reserve ABO for tight guardrails or incrementality tests.</li>
+      <li>Apply naming taxonomy: <span class="mono">[LOB]-[Geo]-[Funnel]-[Offer]-[Experiment]</span> at the ad set level for quick log reviews.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Audience playbooks</h2>
+    <ul>
+      <li>Seed lookalikes with high-quality first-party conversions (value-based when available). Maintain 1%, 2-3%, and 5% tiers.</li>
+      <li>Maintain stacked interest-based ad sets only if they outperform broad + Advantage audience benchmarks after 2 flight cycles.</li>
+      <li>Refresh remarketing windows: 1-day, 7-day, 30-day site visitors plus product catalog retargeting when feeds are present.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creative systems</h2>
+    <p>Meta favors a healthy mix of lo-fi native content and polished assets.</p>
+    <ul>
+      <li>Develop modular asset kits: square, vertical, and landscape plus 15s and 30s video edits. Provide raw footage for Advantage+ creative remixes.</li>
+      <li>Use branded templates for Stories/Reels to maintain compliance while enabling text swaps.</li>
+      <li>Document best-performing hooks and CTAs in a shared creative telemetry log.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Signal integrity</h2>
+    <p>Bid automation relies on clean conversion data.</p>
+    <ul>
+      <li>Leverage Conversions API Gateway or direct server-side integration to reduce signal loss from privacy controls.</li>
+      <li>Map each conversion event to an onsite/CRM status, and deprecate redundant events in Events Manager.</li>
+      <li>Enable Aggregated Event Measurement configuration with prioritized events for ATT-restricted traffic.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization cadences</h2>
+    <ul>
+      <li><strong>Twice weekly:</strong> Review learning phase progress, break out ad sets that cap budget too early.</li>
+      <li><strong>Weekly:</strong> Rotate creatives based on thumb-stop rate, hold-out brand lift tests for validation.</li>
+      <li><strong>Monthly:</strong> Inspect Incrementality experiments or geo-holdouts to calibrate MMM or MER targets.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pre-launch checklist</h2>
+    <ul>
+      <li>Pixel, CAPI, and offline events deduplicated and validated with the Test Events tool.</li>
+      <li>Commerce catalogs synced (if applicable) with proper domain verification.</li>
+      <li>All ads reviewed in Creative Hub mockups for compliance and accessibility (captions, safe zones).</li>
+      <li>Alerting configured in Ads Manager or third-party monitor for spend anomalies.</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/microsoft-advertising.md
+++ b/src/pages/lab/ads/microsoft-advertising.md
@@ -1,0 +1,68 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "Microsoft Advertising Deployment Manual"
+description: "Checklist for Microsoft Search, Audience Network, and import automation."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>Microsoft Advertising Deployment Manual</h1>
+  <p class="intro">Microsoft Advertising complements Google coverage with search scale, audience network placements, and unique LinkedIn profile targeting. Use this manual to align launches with enterprise rigor.</p>
+
+  <section>
+    <h2>Campaign structure</h2>
+    <ul>
+      <li>Mirror Google Ads naming and campaign segmentation for parity, but tailor budgets to Microsoft market share.</li>
+      <li>Create separate campaigns for Search, Audience Network, and Shopping. Avoid importing Display-only structures.</li>
+      <li>Adopt naming: <span class="mono">[LOB]-[Geo]-[Objective]-[Engine]</span>.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Import and sync operations</h2>
+    <ul>
+      <li>Schedule Google Import with post-import checks (bid strategy compatibility, negative keyword lists, URL parameters).</li>
+      <li>Audit automated rules to ensure budgets, bids, and ad schedules align with Microsoft auction patterns.</li>
+      <li>Use Multi-platform campaigns only when creative parity is required; otherwise manage Microsoft-native optimizations.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Audience enhancements</h2>
+    <ul>
+      <li>Apply LinkedIn Profile Targeting (company, industry, job function) as bid modifiers on search campaigns.</li>
+      <li>Leverage In-market Audiences and remarketing lists imported via UET.</li>
+      <li>Use dynamic remarketing for Shopping campaigns with product audiences.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Telemetry and measurement</h2>
+    <ul>
+      <li>Ensure Universal Event Tracking (UET) tag is firing on all key pages; configure conversion goals accordingly.</li>
+      <li>Integrate offline conversions using the Microsoft Advertising API or automated CSV uploads.</li>
+      <li>Map last-touch, assist, and cross-channel contributions in BI dashboards to understand Microsoft’s incrementality.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization cadence</h2>
+    <ul>
+      <li><strong>Weekly:</strong> Review search query reports, adjust negatives, and align ad copy to Microsoft-specific queries.</li>
+      <li><strong>Bi-weekly:</strong> Evaluate Audience Network placements; exclude low-quality inventory.</li>
+      <li><strong>Monthly:</strong> Compare cost per acquisition vs. Google. Rebalance budgets based on MER.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pre-launch checklist</h2>
+    <ul>
+      <li>UET tag validated with Microsoft UET Tag Helper.</li>
+      <li>Conversion goals mapped and imported from Google if applicable.</li>
+      <li>LinkedIn Profile targeting rules approved by stakeholders.</li>
+      <li>Budget pacing reports available to finance and marketing stakeholders.</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/pinterest-ads.md
+++ b/src/pages/lab/ads/pinterest-ads.md
@@ -1,0 +1,68 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "Pinterest Ads Flight Plan"
+description: "Guide for discovery commerce campaigns, Idea Pins, and conversion tracking on Pinterest."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>Pinterest Ads Flight Plan</h1>
+  <p class="intro">Pinterest is a visual discovery engine. This flight plan keeps creative storytelling, product feed hygiene, and conversion tracking synchronized.</p>
+
+  <section>
+    <h2>Campaign architecture</h2>
+    <ul>
+      <li>Build separate campaigns for Awareness, Consideration, and Conversions with the appropriate bidding strategy (CPM, CPC, CPA).</li>
+      <li>Adopt ad group naming: <span class="mono">[Objective]-[Audience]-[Creative]-[Season]</span>.</li>
+      <li>Use Shopping campaigns for catalog-driven programs; keep Dynamic Retargeting in its own budget lane.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creative system</h2>
+    <ul>
+      <li>Produce Idea Pins with 5-7 pages telling a cohesive story. Include instructional steps, product highlights, and clear CTA.</li>
+      <li>Vertical video specs: 9:16 ratio, 6-30 seconds, high-resolution imagery, captions for accessibility.</li>
+      <li>Ensure all creatives include tasteful branding and text within safe zones to avoid cropping.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Catalog and feed health</h2>
+    <ul>
+      <li>Sync product feed daily; audit for availability, price accuracy, and taxonomy mapping.</li>
+      <li>Utilize supplemental feeds to localize currency or seasonal assortments.</li>
+      <li>Leverage product groupings by category, price tier, and best sellers for granular reporting.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Measurement and signals</h2>
+    <ul>
+      <li>Deploy Pinterest tag events: page_visit, add_to_cart, signup, lead, checkout.</li>
+      <li>Enable the Conversion API (CAPI) for improved signal resilience.</li>
+      <li>Set attribution windows: 1/30 (view/click) default; tighten to 1/7 for upper funnel experiments.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization cadence</h2>
+    <ul>
+      <li><strong>Weekly:</strong> Review top search queries and adjust keyword targeting or negatives.</li>
+      <li><strong>Bi-weekly:</strong> Refresh Idea Pins and video assets to maintain engagement.</li>
+      <li><strong>Monthly:</strong> Evaluate assisted conversions and halo impact across discovery channels.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pre-launch checklist</h2>
+    <ul>
+      <li>Product feeds validated with no critical errors.</li>
+      <li>Pinterest tag and CAPI events tested in Events Manager.</li>
+      <li>Creative suite uploaded with cover images and text overlays QA’d.</li>
+      <li>Dashboard tracking marketing efficiency ratio (MER) across discovery channels ready.</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/reddit-ads.md
+++ b/src/pages/lab/ads/reddit-ads.md
@@ -1,0 +1,68 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "Reddit Ads Mission Manual"
+description: "Playbook for community-driven reach and conversion programs on Reddit."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>Reddit Ads Mission Manual</h1>
+  <p class="intro">Reddit demands authenticity and community alignment. This manual ensures campaigns respect subreddit culture while meeting acquisition targets.</p>
+
+  <section>
+    <h2>Campaign structure</h2>
+    <ul>
+      <li>Split campaigns by objective: Brand Awareness, Traffic, Conversions, App Installs, or Video Views.</li>
+      <li>Use ad group naming: <span class="mono">[Objective]-[Subreddit/Interest]-[Creative]-[Iteration]</span>.</li>
+      <li>Separate prospecting vs retargeting ad groups for clean reporting.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Community targeting</h2>
+    <ul>
+      <li>Hand-select subreddits with active moderation and relevant discussions; avoid broad interest targeting for sensitive products.</li>
+      <li>Engage moderators early if planning AMA or sponsored posts. Provide value-first content.</li>
+      <li>Monitor comments multiple times per day; respond with transparent, human voice.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creative guidance</h2>
+    <ul>
+      <li>Use conversational headlines and direct benefit statements. Include UTM tracking in destination URLs.</li>
+      <li>For video, keep under 15 seconds with text overlays since sound is often muted.</li>
+      <li>Test text posts vs. image posts; some subreddits prefer minimal imagery.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Measurement and safety</h2>
+    <ul>
+      <li>Install Reddit Pixel events via GTM (PageVisit, ViewContent, AddToCart, Purchase, Lead).</li>
+      <li>Enable the Conversion API for server events when dealing with high-value conversions.</li>
+      <li>Set brand safety filters to exclude sensitive inventory; review placements weekly.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization rituals</h2>
+    <ul>
+      <li><strong>Daily:</strong> Check comment sentiment and escalate issues to community or PR teams.</li>
+      <li><strong>Weekly:</strong> Adjust bids based on cost per qualified visit and conversion rate; rotate creative variants.</li>
+      <li><strong>Monthly:</strong> Host AMA or community engagement events to support awareness flight.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pre-launch checklist</h2>
+    <ul>
+      <li>Pixel validated across funnel events.</li>
+      <li>Community guidelines reviewed for each target subreddit.</li>
+      <li>Comment moderation workflow and escalation chart approved.</li>
+      <li>Budget pacing and anomaly alerts configured.</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/snapchat-ads.md
+++ b/src/pages/lab/ads/snapchat-ads.md
@@ -1,0 +1,68 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "Snapchat Ads Mission Checklist"
+description: "Framework for Snap Ads, AR Lens campaigns, and pixel instrumentation."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>Snapchat Ads Mission Checklist</h1>
+  <p class="intro">Snapchat delivers high-impact storytelling through vertical video and augmented reality. This checklist keeps creative, pixel data, and pacing aligned.</p>
+
+  <section>
+    <h2>Campaign structure</h2>
+    <ul>
+      <li>Organize campaigns by objective: Awareness, Engagement, Traffic, App Installs, or Conversions.</li>
+      <li>Use ad set naming: <span class="mono">[Objective]-[Audience]-[Placement]-[Flight]</span>.</li>
+      <li>Run AR Lens or Filter campaigns separately from Snap Ads to isolate delivery.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creative requirements</h2>
+    <ul>
+      <li>Video: 1080x1920, 9:16 ratio, 3-180 seconds, with burned-in captions and brand within first 2 seconds.</li>
+      <li>Collection Ads: provide at least 4 product tiles with unique URLs.</li>
+      <li>AR Lenses: deliver lens files, preview video, and icon assets per Snap specs; test lens performance on target devices.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Audience strategy</h2>
+    <ul>
+      <li>Mix Lifestyle Categories, lookalike audiences, and first-party match lists.</li>
+      <li>Deploy Pixel Custom Audiences for retargeting (site visitors, cart abandoners). Refresh within 7 days.</li>
+      <li>Use placement exclusions for Discover publishers if brand safety requires.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pixel and measurement</h2>
+    <ul>
+      <li>Implement Snap Pixel events: PAGE_VIEW, VIEW_CONTENT, ADD_CART, START_CHECKOUT, PURCHASE, SIGN_UP.</li>
+      <li>Enable Advanced Conversions (CAPI) for stronger attribution.</li>
+      <li>Configure conversion windows: 1/7 for upper funnel, 1/28 for conversion programs.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization and QA</h2>
+    <ul>
+      <li><strong>Daily:</strong> Monitor swipe-up rate, cost per pixel event, and Lens interaction rate.</li>
+      <li><strong>Weekly:</strong> Rotate creative sets; test Lens variations or new filter overlays.</li>
+      <li><strong>Monthly:</strong> Review Mixpanel/GA4 downstream performance for incrementality and cross-channel impact.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pre-launch checklist</h2>
+    <ul>
+      <li>Pixel events validated with Snap Pixel Helper.</li>
+      <li>AR Lens QA completed (tracking, occlusion, end card functionality).</li>
+      <li>Brand safety lists (publisher and category) applied.</li>
+      <li>Flight calendar shared with community/support teams.</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/tiktok-ads.md
+++ b/src/pages/lab/ads/tiktok-ads.md
@@ -1,0 +1,68 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "TikTok Ads Launch Kit"
+description: "Procedures for Spark Ads, creator collaborations, and TikTok pixel instrumentation."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>TikTok Ads Launch Kit</h1>
+  <p class="intro">TikTok’s algorithm thrives on creative velocity and strong conversion signals. This kit covers how to prepare assets, partner with creators, and ensure measurement fidelity.</p>
+
+  <section>
+    <h2>Flight plan</h2>
+    <ul>
+      <li>Segment campaigns by objective: Reach, Traffic, Lead, App Install, or Conversion. Avoid mixing optimization events within one campaign.</li>
+      <li>Adopt ad group naming: <span class="mono">[Objective]-[Audience]-[Offer]-[Iteration]</span>.</li>
+      <li>Enable automated creative optimization for discovery flights; use manual placements for retargeting.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creative operating system</h2>
+    <ul>
+      <li>Maintain a creative sprint cadence: drop 3-5 new assets each week. Use the “3-second hook, 15-second story, 3-second CTA” framework.</li>
+      <li>Leverage Spark Ads to whitelist top-performing organic posts or creator collaborations.</li>
+      <li>Generate scripts and storyboards with clear product demos, native captions, and trending audio guidance.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creator and community strategy</h2>
+    <ul>
+      <li>Source creators through TikTok Creator Marketplace or vetted agencies; capture usage rights durations in contracts.</li>
+      <li>Provide creative briefs with mission goals, messaging pillars, and compliance guardrails.</li>
+      <li>Monitor comments for product questions and respond within 1 hour during launch windows.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pixel, events, and API</h2>
+    <ul>
+      <li>Install TikTok Pixel via GTM and map standard events (ViewContent, AddToCart, CompletePayment, SubmitForm).</li>
+      <li>Enable Advanced Matching and Conversions API (Events API) for deduplication and improved attribution.</li>
+      <li>Test events using the TikTok Events Manager diagnostics prior to go-live.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Optimization and reporting</h2>
+    <ul>
+      <li><strong>Daily:</strong> Monitor learning phase and CPA fluctuations; pause underperforming creatives with low view-through rate.</li>
+      <li><strong>Weekly:</strong> Review creative insights (hook rate, 6s view rate) and refresh assets accordingly.</li>
+      <li><strong>Monthly:</strong> Evaluate conversion lift or brand lift studies to benchmark incremental impact.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pre-launch checklist</h2>
+    <ul>
+      <li>Pixel and Events API verified with deduplication IDs.</li>
+      <li>Creative backlog prepared for at least 3 weeks of rotations.</li>
+      <li>Creator usage rights documented, Spark Ad codes collected.</li>
+      <li>Spend alerts configured and dashboards ready for real-time pacing.</li>
+    </ul>
+  </section>
+</div>

--- a/src/pages/lab/ads/x-ads.md
+++ b/src/pages/lab/ads/x-ads.md
@@ -1,0 +1,68 @@
+---
+layout: ../../../layouts/Layout.astro
+title: "X Ads Operations Brief"
+description: "Guidance for awareness and performance programs on X (Twitter)."
+headingTracker:
+  enabled: true
+  contentId: tracked-content
+---
+<div class="container" id="tracked-content">
+  <p class="supertitle mono">Lab / Ads Platform Manual</p>
+  <h1>X Ads Operations Brief</h1>
+  <p class="intro">X Ads (formerly Twitter) excel when conversation and reach tactics are orchestrated together. This brief outlines how to structure campaigns, fuel the pixel, and manage brand safety.</p>
+
+  <section>
+    <h2>Campaign structure</h2>
+    <ul>
+      <li>Create separate campaigns for Reach, Website Traffic, Conversions, and App objectives. Avoid mixing objectives within one flight.</li>
+      <li>Use ad group naming: <span class="mono">[Objective]-[Audience]-[Creative]-[Flight]</span>.</li>
+      <li>Enable Frequency Cap for Reach campaigns (1 per user per day unless testing high frequency launches).</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Audience systems</h2>
+    <ul>
+      <li>Combine keyword targeting (15-25 terms) with follower look-alikes of influential accounts.</li>
+      <li>Deploy tailored audiences from site visitors, customer lists, and app users; refresh lists every 7 days for active programs.</li>
+      <li>Use conversation targeting or event targeting for cultural moments; align creative approvals ahead of time.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Creative payload</h2>
+    <ul>
+      <li>Leverage Website Cards and Conversation Cards for performance programs, Video Ads for awareness.</li>
+      <li>Draft copy variations with clear CTAs; limit to 2 hashtags to avoid siphoning traffic.</li>
+      <li>Plan replies for conversation ads. Ensure community managers have macros for follow-up responses.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pixel and measurement</h2>
+    <ul>
+      <li>Install X Pixel via GTM; verify Page View and conversion events with the Pixel Helper.</li>
+      <li>Implement the Conversions API (CAPI) for server-side events when dealing with gated conversions or app installs.</li>
+      <li>Set up conversion attribution windows per campaign: 1/7 day (view/click) for awareness, 1/30 for performance programs.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Brand safety</h2>
+    <ul>
+      <li>Apply adjacency controls: block lists, allow lists, and keyword exclusion lists updated weekly.</li>
+      <li>Activate third-party verification (DoubleVerify, IAS) when budgets justify.</li>
+      <li>Monitor conversation threads for sentiment; escalate outliers to comms within 2 hours.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Go / no-go checklist</h2>
+    <ul>
+      <li>Pixel and CAPI events validated across purchase funnel.</li>
+      <li>Conversation reply macros reviewed by legal/PR.</li>
+      <li>Brand safety lists uploaded and associated with campaigns.</li>
+      <li>Budget pacing alerts configured in Ads Manager or third-party stack.</li>
+    </ul>
+  </section>
+</div>


### PR DESCRIPTION
## Summary
- expand the lab ads index with navigation cards for ten major ad platforms
- add platform manuals outlining structure, targeting, measurement, and go-live checklists for Google, Meta, LinkedIn, X, TikTok, Snapchat, Reddit, Pinterest, Microsoft Advertising, and Amazon

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e45491378c83238f742a64d863c3b5