### PR TITLE
feat: scaffold marketing lab tactic index

### DIFF
--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/anchoring.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/anchoring.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Anchoring"
+description: "Scaffold notes for the Anchoring tactic."
+headingTracker: false
+---
+# Anchoring
+
+_This page is a scaffold for future research on the **Anchoring** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/authority.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/authority.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Authority"
+description: "Scaffold notes for the Authority tactic."
+headingTracker: false
+---
+# Authority
+
+_This page is a scaffold for future research on the **Authority** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/choice-reduction.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/choice-reduction.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Choice reduction"
+description: "Scaffold notes for the Choice reduction tactic."
+headingTracker: false
+---
+# Choice reduction
+
+_This page is a scaffold for future research on the **Choice reduction** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/consistency.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/consistency.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Consistency"
+description: "Scaffold notes for the Consistency tactic."
+headingTracker: false
+---
+# Consistency
+
+_This page is a scaffold for future research on the **Consistency** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/decoy-effect.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/decoy-effect.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Decoy effect"
+description: "Scaffold notes for the Decoy effect tactic."
+headingTracker: false
+---
+# Decoy effect
+
+_This page is a scaffold for future research on the **Decoy effect** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/endowment.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/endowment.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Endowment"
+description: "Scaffold notes for the Endowment tactic."
+headingTracker: false
+---
+# Endowment
+
+_This page is a scaffold for future research on the **Endowment** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/framing.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/framing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Framing"
+description: "Scaffold notes for the Framing tactic."
+headingTracker: false
+---
+# Framing
+
+_This page is a scaffold for future research on the **Framing** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/goal-gradient.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/goal-gradient.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Goal gradient"
+description: "Scaffold notes for the Goal gradient tactic."
+headingTracker: false
+---
+# Goal gradient
+
+_This page is a scaffold for future research on the **Goal gradient** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/hyperbolic-discounting.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/hyperbolic-discounting.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Hyperbolic discounting"
+description: "Scaffold notes for the Hyperbolic discounting tactic."
+headingTracker: false
+---
+# Hyperbolic discounting
+
+_This page is a scaffold for future research on the **Hyperbolic discounting** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/liking.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/liking.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Liking"
+description: "Scaffold notes for the Liking tactic."
+headingTracker: false
+---
+# Liking
+
+_This page is a scaffold for future research on the **Liking** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/loss-aversion.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/loss-aversion.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Loss aversion"
+description: "Scaffold notes for the Loss aversion tactic."
+headingTracker: false
+---
+# Loss aversion
+
+_This page is a scaffold for future research on the **Loss aversion** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/metaphor-led-copy.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/metaphor-led-copy.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Metaphor-led copy"
+description: "Scaffold notes for the Metaphor-led copy tactic."
+headingTracker: false
+---
+# Metaphor-led copy
+
+_This page is a scaffold for future research on the **Metaphor-led copy** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/narrative-hero-framing.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/narrative-hero-framing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Narrative/hero framing"
+description: "Scaffold notes for the Narrative/hero framing tactic."
+headingTracker: false
+---
+# Narrative/hero framing
+
+_This page is a scaffold for future research on the **Narrative/hero framing** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/peak-end-rule.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/peak-end-rule.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Peak–end rule"
+description: "Scaffold notes for the Peak–end rule tactic."
+headingTracker: false
+---
+# Peak–end rule
+
+_This page is a scaffold for future research on the **Peak–end rule** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/reciprocity.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/reciprocity.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Reciprocity"
+description: "Scaffold notes for the Reciprocity tactic."
+headingTracker: false
+---
+# Reciprocity
+
+_This page is a scaffold for future research on the **Reciprocity** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/scarcity.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/scarcity.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Scarcity"
+description: "Scaffold notes for the Scarcity tactic."
+headingTracker: false
+---
+# Scarcity
+
+_This page is a scaffold for future research on the **Scarcity** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/social-proof.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/social-proof.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Social proof"
+description: "Scaffold notes for the Social proof tactic."
+headingTracker: false
+---
+# Social proof
+
+_This page is a scaffold for future research on the **Social proof** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/temporal-reframing.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/temporal-reframing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Temporal reframing"
+description: "Scaffold notes for the Temporal reframing tactic."
+headingTracker: false
+---
+# Temporal reframing
+
+_This page is a scaffold for future research on the **Temporal reframing** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/unity-identity.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/unity-identity.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Unity/identity"
+description: "Scaffold notes for the Unity/identity tactic."
+headingTracker: false
+---
+# Unity/identity
+
+_This page is a scaffold for future research on the **Unity/identity** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/behavioral-psychology-and-messaging/zeigarnik.md
+++ b/src/pages/lab/marketing/behavioral-psychology-and-messaging/zeigarnik.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Zeigarnik"
+description: "Scaffold notes for the Zeigarnik tactic."
+headingTracker: false
+---
+# Zeigarnik
+
+_This page is a scaffold for future research on the **Zeigarnik** tactic within the Behavioral Psychology & Messaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/above-fold-clarity.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/above-fold-clarity.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Above-fold clarity"
+description: "Scaffold notes for the Above-fold clarity tactic."
+headingTracker: false
+---
+# Above-fold clarity
+
+_This page is a scaffold for future research on the **Above-fold clarity** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/accessibility-fixes.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/accessibility-fixes.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Accessibility fixes"
+description: "Scaffold notes for the Accessibility fixes tactic."
+headingTracker: false
+---
+# Accessibility fixes
+
+_This page is a scaffold for future research on the **Accessibility fixes** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/advertorial-pre-sells.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/advertorial-pre-sells.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Advertorial pre-sells"
+description: "Scaffold notes for the Advertorial pre-sells tactic."
+headingTracker: false
+---
+# Advertorial pre-sells
+
+_This page is a scaffold for future research on the **Advertorial pre-sells** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/checkout-cross-upsells.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/checkout-cross-upsells.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Checkout cross-/upsells"
+description: "Scaffold notes for the Checkout cross-/upsells tactic."
+headingTracker: false
+---
+# Checkout cross-/upsells
+
+_This page is a scaffold for future research on the **Checkout cross-/upsells** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/exit-intent-offers.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/exit-intent-offers.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Exit-intent offers"
+description: "Scaffold notes for the Exit-intent offers tactic."
+headingTracker: false
+---
+# Exit-intent offers
+
+_This page is a scaffold for future research on the **Exit-intent offers** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/honest-urgency-stock.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/honest-urgency-stock.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Honest urgency/stock"
+description: "Scaffold notes for the Honest urgency/stock tactic."
+headingTracker: false
+---
+# Honest urgency/stock
+
+_This page is a scaffold for future research on the **Honest urgency/stock** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/message-market-match.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/message-market-match.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Message–market match"
+description: "Scaffold notes for the Message–market match tactic."
+headingTracker: false
+---
+# Message–market match
+
+_This page is a scaffold for future research on the **Message–market match** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/multi-step-forms.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/multi-step-forms.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Multi-step forms"
+description: "Scaffold notes for the Multi-step forms tactic."
+headingTracker: false
+---
+# Multi-step forms
+
+_This page is a scaffold for future research on the **Multi-step forms** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/one-tap-autofill.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/one-tap-autofill.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "One-tap/autofill"
+description: "Scaffold notes for the One-tap/autofill tactic."
+headingTracker: false
+---
+# One-tap/autofill
+
+_This page is a scaffold for future research on the **One-tap/autofill** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/onsite-personalization.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/onsite-personalization.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Onsite personalization"
+description: "Scaffold notes for the Onsite personalization tactic."
+headingTracker: false
+---
+# Onsite personalization
+
+_This page is a scaffold for future research on the **Onsite personalization** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/post-purchase-upsells.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/post-purchase-upsells.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Post-purchase upsells"
+description: "Scaffold notes for the Post-purchase upsells tactic."
+headingTracker: false
+---
+# Post-purchase upsells
+
+_This page is a scaffold for future research on the **Post-purchase upsells** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/quiz-funnels.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/quiz-funnels.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Quiz funnels"
+description: "Scaffold notes for the Quiz funnels tactic."
+headingTracker: false
+---
+# Quiz funnels
+
+_This page is a scaffold for future research on the **Quiz funnels** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/speed-core-web-vitals.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/speed-core-web-vitals.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Speed/Core Web Vitals"
+description: "Scaffold notes for the Speed/Core Web Vitals tactic."
+headingTracker: false
+---
+# Speed/Core Web Vitals
+
+_This page is a scaffold for future research on the **Speed/Core Web Vitals** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/sticky-ctas-bars.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/sticky-ctas-bars.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Sticky CTAs/bars"
+description: "Scaffold notes for the Sticky CTAs/bars tactic."
+headingTracker: false
+---
+# Sticky CTAs/bars
+
+_This page is a scaffold for future research on the **Sticky CTAs/bars** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/trust-badges-density.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/trust-badges-density.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Trust badges density"
+description: "Scaffold notes for the Trust badges density tactic."
+headingTracker: false
+---
+# Trust badges density
+
+_This page is a scaffold for future research on the **Trust badges density** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/conversion-and-ux-cro/ugc-review-widgets.md
+++ b/src/pages/lab/marketing/conversion-and-ux-cro/ugc-review-widgets.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "UGC/review widgets"
+description: "Scaffold notes for the UGC/review widgets tactic."
+headingTracker: false
+---
+# UGC/review widgets
+
+_This page is a scaffold for future research on the **UGC/review widgets** tactic within the Conversion & UX/CRO module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/cohort-rfm-tracking.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/cohort-rfm-tracking.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Cohort/RFM tracking"
+description: "Scaffold notes for the Cohort/RFM tracking tactic."
+headingTracker: false
+---
+# Cohort/RFM tracking
+
+_This page is a scaffold for future research on the **Cohort/RFM tracking** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/creative-taxonomy.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/creative-taxonomy.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Creative taxonomy"
+description: "Scaffold notes for the Creative taxonomy tactic."
+headingTracker: false
+---
+# Creative taxonomy
+
+_This page is a scaffold for future research on the **Creative taxonomy** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/diff-in-diff-analysis.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/diff-in-diff-analysis.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Diff-in-diff analysis"
+description: "Scaffold notes for the Diff-in-diff analysis tactic."
+headingTracker: false
+---
+# Diff-in-diff analysis
+
+_This page is a scaffold for future research on the **Diff-in-diff analysis** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/geo-holdouts.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/geo-holdouts.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Geo holdouts"
+description: "Scaffold notes for the Geo holdouts tactic."
+headingTracker: false
+---
+# Geo holdouts
+
+_This page is a scaffold for future research on the **Geo holdouts** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/mmm-vs-mta-triangulation.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/mmm-vs-mta-triangulation.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "MMM vs MTA triangulation"
+description: "Scaffold notes for the MMM vs MTA triangulation tactic."
+headingTracker: false
+---
+# MMM vs MTA triangulation
+
+_This page is a scaffold for future research on the **MMM vs MTA triangulation** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/north-star-dashboard.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/north-star-dashboard.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "North-star dashboard"
+description: "Scaffold notes for the North-star dashboard tactic."
+headingTracker: false
+---
+# North-star dashboard
+
+_This page is a scaffold for future research on the **North-star dashboard** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/platform-lift-studies.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/platform-lift-studies.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Platform lift studies"
+description: "Scaffold notes for the Platform lift studies tactic."
+headingTracker: false
+---
+# Platform lift studies
+
+_This page is a scaffold for future research on the **Platform lift studies** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/server-side-conversions.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/server-side-conversions.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Server-side conversions"
+description: "Scaffold notes for the Server-side conversions tactic."
+headingTracker: false
+---
+# Server-side conversions
+
+_This page is a scaffold for future research on the **Server-side conversions** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/survey-based-lift.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/survey-based-lift.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Survey-based lift"
+description: "Scaffold notes for the Survey-based lift tactic."
+headingTracker: false
+---
+# Survey-based lift
+
+_This page is a scaffold for future research on the **Survey-based lift** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/data-experimentation-and-analytics/synthetic-controls.md
+++ b/src/pages/lab/marketing/data-experimentation-and-analytics/synthetic-controls.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Synthetic controls"
+description: "Scaffold notes for the Synthetic controls tactic."
+headingTracker: false
+---
+# Synthetic controls
+
+_This page is a scaffold for future research on the **Synthetic controls** tactic within the Data, Experimentation & Analytics module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/build-your-own-bundles.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/build-your-own-bundles.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Build-your-own bundles"
+description: "Scaffold notes for the Build-your-own bundles tactic."
+headingTracker: false
+---
+# Build-your-own bundles
+
+_This page is a scaffold for future research on the **Build-your-own bundles** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/buy-the-set-collections.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/buy-the-set-collections.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Buy-the-set collections"
+description: "Scaffold notes for the Buy-the-set collections tactic."
+headingTracker: false
+---
+# Buy-the-set collections
+
+_This page is a scaffold for future research on the **Buy-the-set collections** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/free-returns-exchanges.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/free-returns-exchanges.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Free returns/exchanges"
+description: "Scaffold notes for the Free returns/exchanges tactic."
+headingTracker: false
+---
+# Free returns/exchanges
+
+_This page is a scaffold for future research on the **Free returns/exchanges** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/gift-with-purchase-tiers.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/gift-with-purchase-tiers.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Gift-with-purchase tiers"
+description: "Scaffold notes for the Gift-with-purchase tiers tactic."
+headingTracker: false
+---
+# Gift-with-purchase tiers
+
+_This page is a scaffold for future research on the **Gift-with-purchase tiers** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/one-click-checkout.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/one-click-checkout.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "One-click checkout"
+description: "Scaffold notes for the One-click checkout tactic."
+headingTracker: false
+---
+# One-click checkout
+
+_This page is a scaffold for future research on the **One-click checkout** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/pre-order-back-in-stock.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/pre-order-back-in-stock.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Pre-order/back-in-stock"
+description: "Scaffold notes for the Pre-order/back-in-stock tactic."
+headingTracker: false
+---
+# Pre-order/back-in-stock
+
+_This page is a scaffold for future research on the **Pre-order/back-in-stock** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/shop-the-look-modules.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/shop-the-look-modules.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Shop-the-look modules"
+description: "Scaffold notes for the Shop-the-look modules tactic."
+headingTracker: false
+---
+# Shop-the-look modules
+
+_This page is a scaffold for future research on the **Shop-the-look modules** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/size-fit-calculators.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/size-fit-calculators.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Size/fit calculators"
+description: "Scaffold notes for the Size/fit calculators tactic."
+headingTracker: false
+---
+# Size/fit calculators
+
+_This page is a scaffold for future research on the **Size/fit calculators** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/skip-pause-subscriptions.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/skip-pause-subscriptions.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Skip/pause subscriptions"
+description: "Scaffold notes for the Skip/pause subscriptions tactic."
+headingTracker: false
+---
+# Skip/pause subscriptions
+
+_This page is a scaffold for future research on the **Skip/pause subscriptions** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/ecommerce-and-checkout/tracking-page-upsells.md
+++ b/src/pages/lab/marketing/ecommerce-and-checkout/tracking-page-upsells.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Tracking-page upsells"
+description: "Scaffold notes for the Tracking-page upsells tactic."
+headingTracker: false
+---
+# Tracking-page upsells
+
+_This page is a scaffold for future research on the **Tracking-page upsells** tactic within the Ecommerce & Checkout module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/events-pr-and-offline/booth-theater.md
+++ b/src/pages/lab/marketing/events-pr-and-offline/booth-theater.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Booth theater"
+description: "Scaffold notes for the Booth theater tactic."
+headingTracker: false
+---
+# Booth theater
+
+_This page is a scaffold for future research on the **Booth theater** tactic within the Events, PR & Offline module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/events-pr-and-offline/experiential-pop-ups.md
+++ b/src/pages/lab/marketing/events-pr-and-offline/experiential-pop-ups.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Experiential pop-ups"
+description: "Scaffold notes for the Experiential pop-ups tactic."
+headingTracker: false
+---
+# Experiential pop-ups
+
+_This page is a scaffold for future research on the **Experiential pop-ups** tactic within the Events, PR & Offline module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/events-pr-and-offline/guerrilla-activations.md
+++ b/src/pages/lab/marketing/events-pr-and-offline/guerrilla-activations.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Guerrilla activations"
+description: "Scaffold notes for the Guerrilla activations tactic."
+headingTracker: false
+---
+# Guerrilla activations
+
+_This page is a scaffold for future research on the **Guerrilla activations** tactic within the Events, PR & Offline module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/events-pr-and-offline/pitch-angles-calendar.md
+++ b/src/pages/lab/marketing/events-pr-and-offline/pitch-angles-calendar.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Pitch angles calendar"
+description: "Scaffold notes for the Pitch angles calendar tactic."
+headingTracker: false
+---
+# Pitch angles calendar
+
+_This page is a scaffold for future research on the **Pitch angles calendar** tactic within the Events, PR & Offline module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/events-pr-and-offline/prable-data-reports.md
+++ b/src/pages/lab/marketing/events-pr-and-offline/prable-data-reports.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "PRable data reports"
+description: "Scaffold notes for the PRable data reports tactic."
+headingTracker: false
+---
+# PRable data reports
+
+_This page is a scaffold for future research on the **PRable data reports** tactic within the Events, PR & Offline module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/events-pr-and-offline/rapid-newsjacking.md
+++ b/src/pages/lab/marketing/events-pr-and-offline/rapid-newsjacking.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Rapid newsjacking"
+description: "Scaffold notes for the Rapid newsjacking tactic."
+headingTracker: false
+---
+# Rapid newsjacking
+
+_This page is a scaffold for future research on the **Rapid newsjacking** tactic within the Events, PR & Offline module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/events-pr-and-offline/speaking-slots.md
+++ b/src/pages/lab/marketing/events-pr-and-offline/speaking-slots.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Speaking slots"
+description: "Scaffold notes for the Speaking slots tactic."
+headingTracker: false
+---
+# Speaking slots
+
+_This page is a scaffold for future research on the **Speaking slots** tactic within the Events, PR & Offline module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/events-pr-and-offline/sponsorship-plus-stage.md
+++ b/src/pages/lab/marketing/events-pr-and-offline/sponsorship-plus-stage.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Sponsorship + stage"
+description: "Scaffold notes for the Sponsorship + stage tactic."
+headingTracker: false
+---
+# Sponsorship + stage
+
+_This page is a scaffold for future research on the **Sponsorship + stage** tactic within the Events, PR & Offline module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/index.md
+++ b/src/pages/lab/marketing/index.md
@@ -1,7 +1,271 @@
 ---
 layout: ../../../layouts/Layout.astro
-title: "Marketing"
+title: "Marketing Lab Index"
+description: "Index of 200 marketing tactics organized by module."
+headingTracker:
+  enabled: true
+  headingsSelector: 'h2'
 ---
-<h1>Marketing</h1>
-<div class="grid">
-</div>
+# Marketing Lab Modules
+
+This index organizes two hundred marketing tactics into modules. Each module links to a dedicated scaffold where experiments, frameworks, and future research notes can be collected.
+
+## Strategy & Objectives
+
+- [North Star metric](./strategy-and-objectives/north-star-metric/)
+- [Jobs-to-be-Done map](./strategy-and-objectives/jobs-to-be-done-map/)
+- [Category design/reframe](./strategy-and-objectives/category-design-reframe/)
+- [Strategic narrative](./strategy-and-objectives/strategic-narrative/)
+- [Moat/defensibility story](./strategy-and-objectives/moat-defensibility-story/)
+- [RICE/ICE prioritization](./strategy-and-objectives/rice-ice-prioritization/)
+
+## Market Research & Segmentation
+
+- [Qual interviews (5 Whys)](./market-research-and-segmentation/qual-interviews-5-whys/)
+- [Conjoint/feature trade-offs](./market-research-and-segmentation/conjoint-feature-trade-offs/)
+- [RFM behavioral segments](./market-research-and-segmentation/rfm-behavioral-segments/)
+- [Intent mining (search/forums)](./market-research-and-segmentation/intent-mining-search-forums/)
+- [TAM/SAM/SOM sizing](./market-research-and-segmentation/tam-sam-som-sizing/)
+- [Journey stage mapping](./market-research-and-segmentation/journey-stage-mapping/)
+
+## Positioning & Brand
+
+- [Positioning A/B tests](./positioning-and-brand/positioning-a-b-tests/)
+- [Value prop hierarchy](./positioning-and-brand/value-prop-hierarchy/)
+- [Category entry points](./positioning-and-brand/category-entry-points/)
+- [Brand archetypes](./positioning-and-brand/brand-archetypes/)
+- [Distinctive brand assets](./positioning-and-brand/distinctive-brand-assets/)
+- [Naming/tagline tests](./positioning-and-brand/naming-tagline-tests/)
+- [Visual identity guardrails](./positioning-and-brand/visual-identity-guardrails/)
+- [Brand mascot/character](./positioning-and-brand/brand-mascot-character/)
+
+## Product & Packaging
+
+- [Freemium tiering](./product-and-packaging/freemium-tiering/)
+- [Bundle/unbundle](./product-and-packaging/bundle-unbundle/)
+- [Feature gating](./product-and-packaging/feature-gating/)
+- [Limited drops/editions](./product-and-packaging/limited-drops-editions/)
+- [Starter kits/samples](./product-and-packaging/starter-kits-samples/)
+- [Packaging as media (QR)](./product-and-packaging/packaging-as-media-qr/)
+
+## Pricing & Offers
+
+- [Anchoring/decoy price](./pricing-and-offers/anchoring-decoy-price/)
+- [Charm pricing (.99/.97)](./pricing-and-offers/charm-pricing-99-97/)
+- [Good–Better–Best tiers](./pricing-and-offers/good-better-best-tiers/)
+- [Dynamic demand pricing](./pricing-and-offers/dynamic-demand-pricing/)
+- [Geo pricing](./pricing-and-offers/geo-pricing/)
+- [Bundled discounts](./pricing-and-offers/bundled-discounts/)
+- [Subscribe & save](./pricing-and-offers/subscribe-and-save/)
+- [Free shipping threshold](./pricing-and-offers/free-shipping-threshold/)
+- [Risk reversal guarantee](./pricing-and-offers/risk-reversal-guarantee/)
+- [Buy Now Pay Later](./pricing-and-offers/buy-now-pay-later/)
+
+## Paid Media
+
+- [TOFU/MOFU/BOFU structure](./paid-media/tofu-mofu-bofu-structure/)
+- [Creative matrix testing](./paid-media/creative-matrix-testing/)
+- [Broad + algo bidding](./paid-media/broad-plus-algo-bidding/)
+- [Lookalikes](./paid-media/lookalikes/)
+- [Sequential remarketing](./paid-media/sequential-remarketing/)
+- [Whitelisted UGC ads](./paid-media/whitelisted-ugc-ads/)
+- [Lead magnet → tripwire](./paid-media/lead-magnet-to-tripwire/)
+- [Seasonal/event hijacks](./paid-media/seasonal-event-hijacks/)
+- [Geo bid mods](./paid-media/geo-bid-mods/)
+- [Dayparting](./paid-media/dayparting/)
+- [Holdout incrementality](./paid-media/holdout-incrementality/)
+- [Cross-channel sequencing](./paid-media/cross-channel-sequencing/)
+- [Native lead forms](./paid-media/native-lead-forms/)
+- [Programmatic native](./paid-media/programmatic-native/)
+
+## SEO & Content
+
+- [Topic clusters/pillars](./seo-and-content/topic-clusters-pillars/)
+- [Programmatic SEO](./seo-and-content/programmatic-seo/)
+- [Internal linking (entity)](./seo-and-content/internal-linking-entity/)
+- [Schema/rich results](./seo-and-content/schema-rich-results/)
+- [Content refresh cycles](./seo-and-content/content-refresh-cycles/)
+- [Pain–Claim–Gain posts](./seo-and-content/pain-claim-gain-posts/)
+- [POV thought leadership](./seo-and-content/pov-thought-leadership/)
+- [Data studies for links](./seo-and-content/data-studies-for-links/)
+- [Glossary/academy builds](./seo-and-content/glossary-academy-builds/)
+- [UGC/Q&A harvesting](./seo-and-content/ugc-q-and-a-harvesting/)
+- [E-E-A-T signals](./seo-and-content/e-e-a-t-signals/)
+- [Video SEO (chapters)](./seo-and-content/video-seo-chapters/)
+
+## Social & Community
+
+- [Repurposing flywheel](./social-and-community/repurposing-flywheel/)
+- [Trend-jacking rules](./social-and-community/trend-jacking-rules/)
+- [Duets/remixes](./social-and-community/duets-remixes/)
+- [Localized memes](./social-and-community/localized-memes/)
+- [Challenge formats](./social-and-community/challenge-formats/)
+- [Live + timed offers](./social-and-community/live-plus-timed-offers/)
+- [Proof carousels](./social-and-community/proof-carousels/)
+- [Employee advocacy](./social-and-community/employee-advocacy/)
+- [AMAs](./social-and-community/amas/)
+- [Reddit/Discord presence](./social-and-community/reddit-discord-presence/)
+- [Social listening loops](./social-and-community/social-listening-loops/)
+- [DM funnel scripts](./social-and-community/dm-funnel-scripts/)
+
+## Influencer & Partnerships
+
+- [Product seeding](./influencer-and-partnerships/product-seeding/)
+- [Affiliate codes/UTMs](./influencer-and-partnerships/affiliate-codes-utms/)
+- [Whitelisting/licensing](./influencer-and-partnerships/whitelisting-licensing/)
+- [Co-branded drops](./influencer-and-partnerships/co-branded-drops/)
+- [Expert/KOL endorsements](./influencer-and-partnerships/expert-kol-endorsements/)
+- [Marketplace bundles](./influencer-and-partnerships/marketplace-bundles/)
+- [Joint webinars/lives](./influencer-and-partnerships/joint-webinars-lives/)
+- [Brand swaps](./influencer-and-partnerships/brand-swaps/)
+
+## Virality & Referrals
+
+- [Double-sided rewards](./virality-and-referrals/double-sided-rewards/)
+- [Milestone waitlists](./virality-and-referrals/milestone-waitlists/)
+- [Feature-unlock invites](./virality-and-referrals/feature-unlock-invites/)
+- [Social unlock walls](./virality-and-referrals/social-unlock-walls/)
+- [Leaderboards/streaks](./virality-and-referrals/leaderboards-streaks/)
+- [Gifting features](./virality-and-referrals/gifting-features/)
+- [Shareable templates](./virality-and-referrals/shareable-templates/)
+- [“Powered by” watermark](./virality-and-referrals/powered-by-watermark/)
+
+## Conversion & UX/CRO
+
+- [Message–market match](./conversion-and-ux-cro/message-market-match/)
+- [Above-fold clarity](./conversion-and-ux-cro/above-fold-clarity/)
+- [One-tap/autofill](./conversion-and-ux-cro/one-tap-autofill/)
+- [Honest urgency/stock](./conversion-and-ux-cro/honest-urgency-stock/)
+- [Trust badges density](./conversion-and-ux-cro/trust-badges-density/)
+- [Exit-intent offers](./conversion-and-ux-cro/exit-intent-offers/)
+- [Multi-step forms](./conversion-and-ux-cro/multi-step-forms/)
+- [Quiz funnels](./conversion-and-ux-cro/quiz-funnels/)
+- [Advertorial pre-sells](./conversion-and-ux-cro/advertorial-pre-sells/)
+- [Checkout cross-/upsells](./conversion-and-ux-cro/checkout-cross-upsells/)
+- [Post-purchase upsells](./conversion-and-ux-cro/post-purchase-upsells/)
+- [Onsite personalization](./conversion-and-ux-cro/onsite-personalization/)
+- [UGC/review widgets](./conversion-and-ux-cro/ugc-review-widgets/)
+- [Sticky CTAs/bars](./conversion-and-ux-cro/sticky-ctas-bars/)
+- [Speed/Core Web Vitals](./conversion-and-ux-cro/speed-core-web-vitals/)
+- [Accessibility fixes](./conversion-and-ux-cro/accessibility-fixes/)
+
+## Lifecycle & Retention (Email/SMS/App)
+
+- [Welcome series](./lifecycle-and-retention-email-sms-app/welcome-series/)
+- [Cart/browse abandonment](./lifecycle-and-retention-email-sms-app/cart-browse-abandonment/)
+- [Post-purchase education](./lifecycle-and-retention-email-sms-app/post-purchase-education/)
+- [Replenishment reminders](./lifecycle-and-retention-email-sms-app/replenishment-reminders/)
+- [Churn-reason win-backs](./lifecycle-and-retention-email-sms-app/churn-reason-win-backs/)
+- [Pillar newsletter](./lifecycle-and-retention-email-sms-app/pillar-newsletter/)
+- [VIP/loyalty tiers](./lifecycle-and-retention-email-sms-app/vip-loyalty-tiers/)
+- [Preference center](./lifecycle-and-retention-email-sms-app/preference-center/)
+- [Usage-milestone nudges](./lifecycle-and-retention-email-sms-app/usage-milestone-nudges/)
+- [In-app messaging](./lifecycle-and-retention-email-sms-app/in-app-messaging/)
+- [Re-activation offers](./lifecycle-and-retention-email-sms-app/re-activation-offers/)
+- [NPS-timed referral asks](./lifecycle-and-retention-email-sms-app/nps-timed-referral-asks/)
+- [Review/UGC requests](./lifecycle-and-retention-email-sms-app/review-ugc-requests/)
+- [Renewal/dunning ops](./lifecycle-and-retention-email-sms-app/renewal-dunning-ops/)
+
+## Sales-Led & B2B ABM
+
+- [ICP scoring model](./sales-led-and-b2b-abm/icp-scoring-model/)
+- [Tiered account lists](./sales-led-and-b2b-abm/tiered-account-lists/)
+- [Intent-triggered outreach](./sales-led-and-b2b-abm/intent-triggered-outreach/)
+- [Multithreading sequences](./sales-led-and-b2b-abm/multithreading-sequences/)
+- [ABM landing pages](./sales-led-and-b2b-abm/abm-landing-pages/)
+- [Executive gifting mailers](./sales-led-and-b2b-abm/executive-gifting-mailers/)
+- [C-suite roundtables](./sales-led-and-b2b-abm/c-suite-roundtables/)
+- [Verticalized case studies](./sales-led-and-b2b-abm/verticalized-case-studies/)
+
+## Events, PR & Offline
+
+- [Pitch angles calendar](./events-pr-and-offline/pitch-angles-calendar/)
+- [Speaking slots](./events-pr-and-offline/speaking-slots/)
+- [Guerrilla activations](./events-pr-and-offline/guerrilla-activations/)
+- [Booth theater](./events-pr-and-offline/booth-theater/)
+- [Experiential pop-ups](./events-pr-and-offline/experiential-pop-ups/)
+- [Sponsorship + stage](./events-pr-and-offline/sponsorship-plus-stage/)
+- [Rapid newsjacking](./events-pr-and-offline/rapid-newsjacking/)
+- [PRable data reports](./events-pr-and-offline/prable-data-reports/)
+
+## Local & Field Marketing
+
+- [Google Biz Profile ops](./local-and-field-marketing/google-biz-profile-ops/)
+- [Local citations/reviews](./local-and-field-marketing/local-citations-reviews/)
+- [Flyers/door hangers + QR](./local-and-field-marketing/flyers-door-hangers-plus-qr/)
+- [Community sponsorships](./local-and-field-marketing/community-sponsorships/)
+- [Street teams/sampling](./local-and-field-marketing/street-teams-sampling/)
+- [Nextdoor ads](./local-and-field-marketing/nextdoor-ads/)
+
+## Ecommerce & Checkout
+
+- [One-click checkout](./ecommerce-and-checkout/one-click-checkout/)
+- [Free returns/exchanges](./ecommerce-and-checkout/free-returns-exchanges/)
+- [Size/fit calculators](./ecommerce-and-checkout/size-fit-calculators/)
+- [Build-your-own bundles](./ecommerce-and-checkout/build-your-own-bundles/)
+- [Skip/pause subscriptions](./ecommerce-and-checkout/skip-pause-subscriptions/)
+- [Pre-order/back-in-stock](./ecommerce-and-checkout/pre-order-back-in-stock/)
+- [Gift-with-purchase tiers](./ecommerce-and-checkout/gift-with-purchase-tiers/)
+- [Shop-the-look modules](./ecommerce-and-checkout/shop-the-look-modules/)
+- [Buy-the-set collections](./ecommerce-and-checkout/buy-the-set-collections/)
+- [Tracking-page upsells](./ecommerce-and-checkout/tracking-page-upsells/)
+
+## Mobile/App Growth
+
+- [ASO metadata/tests](./mobile-app-growth/aso-metadata-tests/)
+- [Aha-moment onboarding](./mobile-app-growth/aha-moment-onboarding/)
+- [Push cadences](./mobile-app-growth/push-cadences/)
+- [Feature-flag experiments](./mobile-app-growth/feature-flag-experiments/)
+- [Rating prompts post-win](./mobile-app-growth/rating-prompts-post-win/)
+- [Deep linking](./mobile-app-growth/deep-linking/)
+
+## Data, Experimentation & Analytics
+
+- [North-star dashboard](./data-experimentation-and-analytics/north-star-dashboard/)
+- [MMM vs MTA triangulation](./data-experimentation-and-analytics/mmm-vs-mta-triangulation/)
+- [Geo holdouts](./data-experimentation-and-analytics/geo-holdouts/)
+- [Synthetic controls](./data-experimentation-and-analytics/synthetic-controls/)
+- [Cohort/RFM tracking](./data-experimentation-and-analytics/cohort-rfm-tracking/)
+- [Platform lift studies](./data-experimentation-and-analytics/platform-lift-studies/)
+- [Creative taxonomy](./data-experimentation-and-analytics/creative-taxonomy/)
+- [Survey-based lift](./data-experimentation-and-analytics/survey-based-lift/)
+- [Diff-in-diff analysis](./data-experimentation-and-analytics/diff-in-diff-analysis/)
+- [Server-side conversions](./data-experimentation-and-analytics/server-side-conversions/)
+
+## Behavioral Psychology & Messaging
+
+- [Reciprocity](./behavioral-psychology-and-messaging/reciprocity/)
+- [Social proof](./behavioral-psychology-and-messaging/social-proof/)
+- [Scarcity](./behavioral-psychology-and-messaging/scarcity/)
+- [Authority](./behavioral-psychology-and-messaging/authority/)
+- [Consistency](./behavioral-psychology-and-messaging/consistency/)
+- [Liking](./behavioral-psychology-and-messaging/liking/)
+- [Unity/identity](./behavioral-psychology-and-messaging/unity-identity/)
+- [Loss aversion](./behavioral-psychology-and-messaging/loss-aversion/)
+- [Anchoring](./behavioral-psychology-and-messaging/anchoring/)
+- [Framing](./behavioral-psychology-and-messaging/framing/)
+- [Decoy effect](./behavioral-psychology-and-messaging/decoy-effect/)
+- [Endowment](./behavioral-psychology-and-messaging/endowment/)
+- [Zeigarnik](./behavioral-psychology-and-messaging/zeigarnik/)
+- [Goal gradient](./behavioral-psychology-and-messaging/goal-gradient/)
+- [Peak–end rule](./behavioral-psychology-and-messaging/peak-end-rule/)
+- [Hyperbolic discounting](./behavioral-psychology-and-messaging/hyperbolic-discounting/)
+- [Choice reduction](./behavioral-psychology-and-messaging/choice-reduction/)
+- [Temporal reframing](./behavioral-psychology-and-messaging/temporal-reframing/)
+- [Narrative/hero framing](./behavioral-psychology-and-messaging/narrative-hero-framing/)
+- [Metaphor-led copy](./behavioral-psychology-and-messaging/metaphor-led-copy/)
+
+## Platform-Specific Micro-plays
+
+- [Meta: Advantage+ Shopping](./platform-specific-micro-plays/meta-advantage-plus-shopping/)
+- [Meta: Conversions API](./platform-specific-micro-plays/meta-conversions-api/)
+- [Meta: Thumb-stop testing](./platform-specific-micro-plays/meta-thumb-stop-testing/)
+- [Google: Performance Max](./platform-specific-micro-plays/google-performance-max/)
+- [Google: DSA coverage](./platform-specific-micro-plays/google-dsa-coverage/)
+- [Google: Shopping feed ops](./platform-specific-micro-plays/google-shopping-feed-ops/)
+- [TikTok: Spark Ads](./platform-specific-micro-plays/tiktok-spark-ads/)
+- [TikTok: Sound-on hooks](./platform-specific-micro-plays/tiktok-sound-on-hooks/)
+- [LinkedIn: Conversation Ads](./platform-specific-micro-plays/linkedin-conversation-ads/)
+- [YouTube: 6-sec bumpers](./platform-specific-micro-plays/youtube-6-sec-bumpers/)
+- [Amazon: Subscribe & Save](./platform-specific-micro-plays/amazon-subscribe-and-save/)
+- [Product Hunt: launch orchestration](./platform-specific-micro-plays/product-hunt-launch-orchestration/)

--- a/src/pages/lab/marketing/influencer-and-partnerships/affiliate-codes-utms.md
+++ b/src/pages/lab/marketing/influencer-and-partnerships/affiliate-codes-utms.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Affiliate codes/UTMs"
+description: "Scaffold notes for the Affiliate codes/UTMs tactic."
+headingTracker: false
+---
+# Affiliate codes/UTMs
+
+_This page is a scaffold for future research on the **Affiliate codes/UTMs** tactic within the Influencer & Partnerships module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/influencer-and-partnerships/brand-swaps.md
+++ b/src/pages/lab/marketing/influencer-and-partnerships/brand-swaps.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Brand swaps"
+description: "Scaffold notes for the Brand swaps tactic."
+headingTracker: false
+---
+# Brand swaps
+
+_This page is a scaffold for future research on the **Brand swaps** tactic within the Influencer & Partnerships module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/influencer-and-partnerships/co-branded-drops.md
+++ b/src/pages/lab/marketing/influencer-and-partnerships/co-branded-drops.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Co-branded drops"
+description: "Scaffold notes for the Co-branded drops tactic."
+headingTracker: false
+---
+# Co-branded drops
+
+_This page is a scaffold for future research on the **Co-branded drops** tactic within the Influencer & Partnerships module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/influencer-and-partnerships/expert-kol-endorsements.md
+++ b/src/pages/lab/marketing/influencer-and-partnerships/expert-kol-endorsements.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Expert/KOL endorsements"
+description: "Scaffold notes for the Expert/KOL endorsements tactic."
+headingTracker: false
+---
+# Expert/KOL endorsements
+
+_This page is a scaffold for future research on the **Expert/KOL endorsements** tactic within the Influencer & Partnerships module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/influencer-and-partnerships/joint-webinars-lives.md
+++ b/src/pages/lab/marketing/influencer-and-partnerships/joint-webinars-lives.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Joint webinars/lives"
+description: "Scaffold notes for the Joint webinars/lives tactic."
+headingTracker: false
+---
+# Joint webinars/lives
+
+_This page is a scaffold for future research on the **Joint webinars/lives** tactic within the Influencer & Partnerships module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/influencer-and-partnerships/marketplace-bundles.md
+++ b/src/pages/lab/marketing/influencer-and-partnerships/marketplace-bundles.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Marketplace bundles"
+description: "Scaffold notes for the Marketplace bundles tactic."
+headingTracker: false
+---
+# Marketplace bundles
+
+_This page is a scaffold for future research on the **Marketplace bundles** tactic within the Influencer & Partnerships module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/influencer-and-partnerships/product-seeding.md
+++ b/src/pages/lab/marketing/influencer-and-partnerships/product-seeding.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Product seeding"
+description: "Scaffold notes for the Product seeding tactic."
+headingTracker: false
+---
+# Product seeding
+
+_This page is a scaffold for future research on the **Product seeding** tactic within the Influencer & Partnerships module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/influencer-and-partnerships/whitelisting-licensing.md
+++ b/src/pages/lab/marketing/influencer-and-partnerships/whitelisting-licensing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Whitelisting/licensing"
+description: "Scaffold notes for the Whitelisting/licensing tactic."
+headingTracker: false
+---
+# Whitelisting/licensing
+
+_This page is a scaffold for future research on the **Whitelisting/licensing** tactic within the Influencer & Partnerships module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/cart-browse-abandonment.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/cart-browse-abandonment.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Cart/browse abandonment"
+description: "Scaffold notes for the Cart/browse abandonment tactic."
+headingTracker: false
+---
+# Cart/browse abandonment
+
+_This page is a scaffold for future research on the **Cart/browse abandonment** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/churn-reason-win-backs.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/churn-reason-win-backs.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Churn-reason win-backs"
+description: "Scaffold notes for the Churn-reason win-backs tactic."
+headingTracker: false
+---
+# Churn-reason win-backs
+
+_This page is a scaffold for future research on the **Churn-reason win-backs** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/in-app-messaging.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/in-app-messaging.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "In-app messaging"
+description: "Scaffold notes for the In-app messaging tactic."
+headingTracker: false
+---
+# In-app messaging
+
+_This page is a scaffold for future research on the **In-app messaging** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/nps-timed-referral-asks.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/nps-timed-referral-asks.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "NPS-timed referral asks"
+description: "Scaffold notes for the NPS-timed referral asks tactic."
+headingTracker: false
+---
+# NPS-timed referral asks
+
+_This page is a scaffold for future research on the **NPS-timed referral asks** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/pillar-newsletter.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/pillar-newsletter.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Pillar newsletter"
+description: "Scaffold notes for the Pillar newsletter tactic."
+headingTracker: false
+---
+# Pillar newsletter
+
+_This page is a scaffold for future research on the **Pillar newsletter** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/post-purchase-education.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/post-purchase-education.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Post-purchase education"
+description: "Scaffold notes for the Post-purchase education tactic."
+headingTracker: false
+---
+# Post-purchase education
+
+_This page is a scaffold for future research on the **Post-purchase education** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/preference-center.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/preference-center.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Preference center"
+description: "Scaffold notes for the Preference center tactic."
+headingTracker: false
+---
+# Preference center
+
+_This page is a scaffold for future research on the **Preference center** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/re-activation-offers.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/re-activation-offers.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Re-activation offers"
+description: "Scaffold notes for the Re-activation offers tactic."
+headingTracker: false
+---
+# Re-activation offers
+
+_This page is a scaffold for future research on the **Re-activation offers** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/renewal-dunning-ops.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/renewal-dunning-ops.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Renewal/dunning ops"
+description: "Scaffold notes for the Renewal/dunning ops tactic."
+headingTracker: false
+---
+# Renewal/dunning ops
+
+_This page is a scaffold for future research on the **Renewal/dunning ops** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/replenishment-reminders.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/replenishment-reminders.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Replenishment reminders"
+description: "Scaffold notes for the Replenishment reminders tactic."
+headingTracker: false
+---
+# Replenishment reminders
+
+_This page is a scaffold for future research on the **Replenishment reminders** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/review-ugc-requests.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/review-ugc-requests.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Review/UGC requests"
+description: "Scaffold notes for the Review/UGC requests tactic."
+headingTracker: false
+---
+# Review/UGC requests
+
+_This page is a scaffold for future research on the **Review/UGC requests** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/usage-milestone-nudges.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/usage-milestone-nudges.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Usage-milestone nudges"
+description: "Scaffold notes for the Usage-milestone nudges tactic."
+headingTracker: false
+---
+# Usage-milestone nudges
+
+_This page is a scaffold for future research on the **Usage-milestone nudges** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/vip-loyalty-tiers.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/vip-loyalty-tiers.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "VIP/loyalty tiers"
+description: "Scaffold notes for the VIP/loyalty tiers tactic."
+headingTracker: false
+---
+# VIP/loyalty tiers
+
+_This page is a scaffold for future research on the **VIP/loyalty tiers** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/welcome-series.md
+++ b/src/pages/lab/marketing/lifecycle-and-retention-email-sms-app/welcome-series.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Welcome series"
+description: "Scaffold notes for the Welcome series tactic."
+headingTracker: false
+---
+# Welcome series
+
+_This page is a scaffold for future research on the **Welcome series** tactic within the Lifecycle & Retention (Email/SMS/App) module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/local-and-field-marketing/community-sponsorships.md
+++ b/src/pages/lab/marketing/local-and-field-marketing/community-sponsorships.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Community sponsorships"
+description: "Scaffold notes for the Community sponsorships tactic."
+headingTracker: false
+---
+# Community sponsorships
+
+_This page is a scaffold for future research on the **Community sponsorships** tactic within the Local & Field Marketing module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/local-and-field-marketing/flyers-door-hangers-plus-qr.md
+++ b/src/pages/lab/marketing/local-and-field-marketing/flyers-door-hangers-plus-qr.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Flyers/door hangers + QR"
+description: "Scaffold notes for the Flyers/door hangers + QR tactic."
+headingTracker: false
+---
+# Flyers/door hangers + QR
+
+_This page is a scaffold for future research on the **Flyers/door hangers + QR** tactic within the Local & Field Marketing module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/local-and-field-marketing/google-biz-profile-ops.md
+++ b/src/pages/lab/marketing/local-and-field-marketing/google-biz-profile-ops.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Google Biz Profile ops"
+description: "Scaffold notes for the Google Biz Profile ops tactic."
+headingTracker: false
+---
+# Google Biz Profile ops
+
+_This page is a scaffold for future research on the **Google Biz Profile ops** tactic within the Local & Field Marketing module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/local-and-field-marketing/local-citations-reviews.md
+++ b/src/pages/lab/marketing/local-and-field-marketing/local-citations-reviews.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Local citations/reviews"
+description: "Scaffold notes for the Local citations/reviews tactic."
+headingTracker: false
+---
+# Local citations/reviews
+
+_This page is a scaffold for future research on the **Local citations/reviews** tactic within the Local & Field Marketing module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/local-and-field-marketing/nextdoor-ads.md
+++ b/src/pages/lab/marketing/local-and-field-marketing/nextdoor-ads.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Nextdoor ads"
+description: "Scaffold notes for the Nextdoor ads tactic."
+headingTracker: false
+---
+# Nextdoor ads
+
+_This page is a scaffold for future research on the **Nextdoor ads** tactic within the Local & Field Marketing module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/local-and-field-marketing/street-teams-sampling.md
+++ b/src/pages/lab/marketing/local-and-field-marketing/street-teams-sampling.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Street teams/sampling"
+description: "Scaffold notes for the Street teams/sampling tactic."
+headingTracker: false
+---
+# Street teams/sampling
+
+_This page is a scaffold for future research on the **Street teams/sampling** tactic within the Local & Field Marketing module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/market-research-and-segmentation/conjoint-feature-trade-offs.md
+++ b/src/pages/lab/marketing/market-research-and-segmentation/conjoint-feature-trade-offs.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Conjoint/feature trade-offs"
+description: "Scaffold notes for the Conjoint/feature trade-offs tactic."
+headingTracker: false
+---
+# Conjoint/feature trade-offs
+
+_This page is a scaffold for future research on the **Conjoint/feature trade-offs** tactic within the Market Research & Segmentation module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/market-research-and-segmentation/intent-mining-search-forums.md
+++ b/src/pages/lab/marketing/market-research-and-segmentation/intent-mining-search-forums.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Intent mining (search/forums)"
+description: "Scaffold notes for the Intent mining (search/forums) tactic."
+headingTracker: false
+---
+# Intent mining (search/forums)
+
+_This page is a scaffold for future research on the **Intent mining (search/forums)** tactic within the Market Research & Segmentation module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/market-research-and-segmentation/journey-stage-mapping.md
+++ b/src/pages/lab/marketing/market-research-and-segmentation/journey-stage-mapping.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Journey stage mapping"
+description: "Scaffold notes for the Journey stage mapping tactic."
+headingTracker: false
+---
+# Journey stage mapping
+
+_This page is a scaffold for future research on the **Journey stage mapping** tactic within the Market Research & Segmentation module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/market-research-and-segmentation/qual-interviews-5-whys.md
+++ b/src/pages/lab/marketing/market-research-and-segmentation/qual-interviews-5-whys.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Qual interviews (5 Whys)"
+description: "Scaffold notes for the Qual interviews (5 Whys) tactic."
+headingTracker: false
+---
+# Qual interviews (5 Whys)
+
+_This page is a scaffold for future research on the **Qual interviews (5 Whys)** tactic within the Market Research & Segmentation module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/market-research-and-segmentation/rfm-behavioral-segments.md
+++ b/src/pages/lab/marketing/market-research-and-segmentation/rfm-behavioral-segments.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "RFM behavioral segments"
+description: "Scaffold notes for the RFM behavioral segments tactic."
+headingTracker: false
+---
+# RFM behavioral segments
+
+_This page is a scaffold for future research on the **RFM behavioral segments** tactic within the Market Research & Segmentation module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/market-research-and-segmentation/tam-sam-som-sizing.md
+++ b/src/pages/lab/marketing/market-research-and-segmentation/tam-sam-som-sizing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "TAM/SAM/SOM sizing"
+description: "Scaffold notes for the TAM/SAM/SOM sizing tactic."
+headingTracker: false
+---
+# TAM/SAM/SOM sizing
+
+_This page is a scaffold for future research on the **TAM/SAM/SOM sizing** tactic within the Market Research & Segmentation module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/mobile-app-growth/aha-moment-onboarding.md
+++ b/src/pages/lab/marketing/mobile-app-growth/aha-moment-onboarding.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Aha-moment onboarding"
+description: "Scaffold notes for the Aha-moment onboarding tactic."
+headingTracker: false
+---
+# Aha-moment onboarding
+
+_This page is a scaffold for future research on the **Aha-moment onboarding** tactic within the Mobile/App Growth module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/mobile-app-growth/aso-metadata-tests.md
+++ b/src/pages/lab/marketing/mobile-app-growth/aso-metadata-tests.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "ASO metadata/tests"
+description: "Scaffold notes for the ASO metadata/tests tactic."
+headingTracker: false
+---
+# ASO metadata/tests
+
+_This page is a scaffold for future research on the **ASO metadata/tests** tactic within the Mobile/App Growth module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/mobile-app-growth/deep-linking.md
+++ b/src/pages/lab/marketing/mobile-app-growth/deep-linking.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Deep linking"
+description: "Scaffold notes for the Deep linking tactic."
+headingTracker: false
+---
+# Deep linking
+
+_This page is a scaffold for future research on the **Deep linking** tactic within the Mobile/App Growth module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/mobile-app-growth/feature-flag-experiments.md
+++ b/src/pages/lab/marketing/mobile-app-growth/feature-flag-experiments.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Feature-flag experiments"
+description: "Scaffold notes for the Feature-flag experiments tactic."
+headingTracker: false
+---
+# Feature-flag experiments
+
+_This page is a scaffold for future research on the **Feature-flag experiments** tactic within the Mobile/App Growth module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/mobile-app-growth/push-cadences.md
+++ b/src/pages/lab/marketing/mobile-app-growth/push-cadences.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Push cadences"
+description: "Scaffold notes for the Push cadences tactic."
+headingTracker: false
+---
+# Push cadences
+
+_This page is a scaffold for future research on the **Push cadences** tactic within the Mobile/App Growth module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/mobile-app-growth/rating-prompts-post-win.md
+++ b/src/pages/lab/marketing/mobile-app-growth/rating-prompts-post-win.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Rating prompts post-win"
+description: "Scaffold notes for the Rating prompts post-win tactic."
+headingTracker: false
+---
+# Rating prompts post-win
+
+_This page is a scaffold for future research on the **Rating prompts post-win** tactic within the Mobile/App Growth module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/broad-plus-algo-bidding.md
+++ b/src/pages/lab/marketing/paid-media/broad-plus-algo-bidding.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Broad + algo bidding"
+description: "Scaffold notes for the Broad + algo bidding tactic."
+headingTracker: false
+---
+# Broad + algo bidding
+
+_This page is a scaffold for future research on the **Broad + algo bidding** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/creative-matrix-testing.md
+++ b/src/pages/lab/marketing/paid-media/creative-matrix-testing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Creative matrix testing"
+description: "Scaffold notes for the Creative matrix testing tactic."
+headingTracker: false
+---
+# Creative matrix testing
+
+_This page is a scaffold for future research on the **Creative matrix testing** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/cross-channel-sequencing.md
+++ b/src/pages/lab/marketing/paid-media/cross-channel-sequencing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Cross-channel sequencing"
+description: "Scaffold notes for the Cross-channel sequencing tactic."
+headingTracker: false
+---
+# Cross-channel sequencing
+
+_This page is a scaffold for future research on the **Cross-channel sequencing** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/dayparting.md
+++ b/src/pages/lab/marketing/paid-media/dayparting.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Dayparting"
+description: "Scaffold notes for the Dayparting tactic."
+headingTracker: false
+---
+# Dayparting
+
+_This page is a scaffold for future research on the **Dayparting** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/geo-bid-mods.md
+++ b/src/pages/lab/marketing/paid-media/geo-bid-mods.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Geo bid mods"
+description: "Scaffold notes for the Geo bid mods tactic."
+headingTracker: false
+---
+# Geo bid mods
+
+_This page is a scaffold for future research on the **Geo bid mods** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/holdout-incrementality.md
+++ b/src/pages/lab/marketing/paid-media/holdout-incrementality.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Holdout incrementality"
+description: "Scaffold notes for the Holdout incrementality tactic."
+headingTracker: false
+---
+# Holdout incrementality
+
+_This page is a scaffold for future research on the **Holdout incrementality** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/lead-magnet-to-tripwire.md
+++ b/src/pages/lab/marketing/paid-media/lead-magnet-to-tripwire.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Lead magnet → tripwire"
+description: "Scaffold notes for the Lead magnet → tripwire tactic."
+headingTracker: false
+---
+# Lead magnet → tripwire
+
+_This page is a scaffold for future research on the **Lead magnet → tripwire** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/lookalikes.md
+++ b/src/pages/lab/marketing/paid-media/lookalikes.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Lookalikes"
+description: "Scaffold notes for the Lookalikes tactic."
+headingTracker: false
+---
+# Lookalikes
+
+_This page is a scaffold for future research on the **Lookalikes** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/native-lead-forms.md
+++ b/src/pages/lab/marketing/paid-media/native-lead-forms.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Native lead forms"
+description: "Scaffold notes for the Native lead forms tactic."
+headingTracker: false
+---
+# Native lead forms
+
+_This page is a scaffold for future research on the **Native lead forms** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/programmatic-native.md
+++ b/src/pages/lab/marketing/paid-media/programmatic-native.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Programmatic native"
+description: "Scaffold notes for the Programmatic native tactic."
+headingTracker: false
+---
+# Programmatic native
+
+_This page is a scaffold for future research on the **Programmatic native** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/seasonal-event-hijacks.md
+++ b/src/pages/lab/marketing/paid-media/seasonal-event-hijacks.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Seasonal/event hijacks"
+description: "Scaffold notes for the Seasonal/event hijacks tactic."
+headingTracker: false
+---
+# Seasonal/event hijacks
+
+_This page is a scaffold for future research on the **Seasonal/event hijacks** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/sequential-remarketing.md
+++ b/src/pages/lab/marketing/paid-media/sequential-remarketing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Sequential remarketing"
+description: "Scaffold notes for the Sequential remarketing tactic."
+headingTracker: false
+---
+# Sequential remarketing
+
+_This page is a scaffold for future research on the **Sequential remarketing** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/tofu-mofu-bofu-structure.md
+++ b/src/pages/lab/marketing/paid-media/tofu-mofu-bofu-structure.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "TOFU/MOFU/BOFU structure"
+description: "Scaffold notes for the TOFU/MOFU/BOFU structure tactic."
+headingTracker: false
+---
+# TOFU/MOFU/BOFU structure
+
+_This page is a scaffold for future research on the **TOFU/MOFU/BOFU structure** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/paid-media/whitelisted-ugc-ads.md
+++ b/src/pages/lab/marketing/paid-media/whitelisted-ugc-ads.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Whitelisted UGC ads"
+description: "Scaffold notes for the Whitelisted UGC ads tactic."
+headingTracker: false
+---
+# Whitelisted UGC ads
+
+_This page is a scaffold for future research on the **Whitelisted UGC ads** tactic within the Paid Media module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/amazon-subscribe-and-save.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/amazon-subscribe-and-save.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Amazon: Subscribe & Save"
+description: "Scaffold notes for the Amazon: Subscribe & Save tactic."
+headingTracker: false
+---
+# Amazon: Subscribe & Save
+
+_This page is a scaffold for future research on the **Amazon: Subscribe & Save** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/google-dsa-coverage.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/google-dsa-coverage.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Google: DSA coverage"
+description: "Scaffold notes for the Google: DSA coverage tactic."
+headingTracker: false
+---
+# Google: DSA coverage
+
+_This page is a scaffold for future research on the **Google: DSA coverage** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/google-performance-max.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/google-performance-max.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Google: Performance Max"
+description: "Scaffold notes for the Google: Performance Max tactic."
+headingTracker: false
+---
+# Google: Performance Max
+
+_This page is a scaffold for future research on the **Google: Performance Max** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/google-shopping-feed-ops.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/google-shopping-feed-ops.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Google: Shopping feed ops"
+description: "Scaffold notes for the Google: Shopping feed ops tactic."
+headingTracker: false
+---
+# Google: Shopping feed ops
+
+_This page is a scaffold for future research on the **Google: Shopping feed ops** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/linkedin-conversation-ads.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/linkedin-conversation-ads.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "LinkedIn: Conversation Ads"
+description: "Scaffold notes for the LinkedIn: Conversation Ads tactic."
+headingTracker: false
+---
+# LinkedIn: Conversation Ads
+
+_This page is a scaffold for future research on the **LinkedIn: Conversation Ads** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/meta-advantage-plus-shopping.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/meta-advantage-plus-shopping.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Meta: Advantage+ Shopping"
+description: "Scaffold notes for the Meta: Advantage+ Shopping tactic."
+headingTracker: false
+---
+# Meta: Advantage+ Shopping
+
+_This page is a scaffold for future research on the **Meta: Advantage+ Shopping** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/meta-conversions-api.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/meta-conversions-api.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Meta: Conversions API"
+description: "Scaffold notes for the Meta: Conversions API tactic."
+headingTracker: false
+---
+# Meta: Conversions API
+
+_This page is a scaffold for future research on the **Meta: Conversions API** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/meta-thumb-stop-testing.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/meta-thumb-stop-testing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Meta: Thumb-stop testing"
+description: "Scaffold notes for the Meta: Thumb-stop testing tactic."
+headingTracker: false
+---
+# Meta: Thumb-stop testing
+
+_This page is a scaffold for future research on the **Meta: Thumb-stop testing** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/product-hunt-launch-orchestration.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/product-hunt-launch-orchestration.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Product Hunt: launch orchestration"
+description: "Scaffold notes for the Product Hunt: launch orchestration tactic."
+headingTracker: false
+---
+# Product Hunt: launch orchestration
+
+_This page is a scaffold for future research on the **Product Hunt: launch orchestration** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/tiktok-sound-on-hooks.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/tiktok-sound-on-hooks.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "TikTok: Sound-on hooks"
+description: "Scaffold notes for the TikTok: Sound-on hooks tactic."
+headingTracker: false
+---
+# TikTok: Sound-on hooks
+
+_This page is a scaffold for future research on the **TikTok: Sound-on hooks** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/tiktok-spark-ads.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/tiktok-spark-ads.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "TikTok: Spark Ads"
+description: "Scaffold notes for the TikTok: Spark Ads tactic."
+headingTracker: false
+---
+# TikTok: Spark Ads
+
+_This page is a scaffold for future research on the **TikTok: Spark Ads** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/platform-specific-micro-plays/youtube-6-sec-bumpers.md
+++ b/src/pages/lab/marketing/platform-specific-micro-plays/youtube-6-sec-bumpers.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "YouTube: 6-sec bumpers"
+description: "Scaffold notes for the YouTube: 6-sec bumpers tactic."
+headingTracker: false
+---
+# YouTube: 6-sec bumpers
+
+_This page is a scaffold for future research on the **YouTube: 6-sec bumpers** tactic within the Platform-Specific Micro-plays module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/positioning-and-brand/brand-archetypes.md
+++ b/src/pages/lab/marketing/positioning-and-brand/brand-archetypes.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Brand archetypes"
+description: "Scaffold notes for the Brand archetypes tactic."
+headingTracker: false
+---
+# Brand archetypes
+
+_This page is a scaffold for future research on the **Brand archetypes** tactic within the Positioning & Brand module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/positioning-and-brand/brand-mascot-character.md
+++ b/src/pages/lab/marketing/positioning-and-brand/brand-mascot-character.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Brand mascot/character"
+description: "Scaffold notes for the Brand mascot/character tactic."
+headingTracker: false
+---
+# Brand mascot/character
+
+_This page is a scaffold for future research on the **Brand mascot/character** tactic within the Positioning & Brand module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/positioning-and-brand/category-entry-points.md
+++ b/src/pages/lab/marketing/positioning-and-brand/category-entry-points.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Category entry points"
+description: "Scaffold notes for the Category entry points tactic."
+headingTracker: false
+---
+# Category entry points
+
+_This page is a scaffold for future research on the **Category entry points** tactic within the Positioning & Brand module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/positioning-and-brand/distinctive-brand-assets.md
+++ b/src/pages/lab/marketing/positioning-and-brand/distinctive-brand-assets.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Distinctive brand assets"
+description: "Scaffold notes for the Distinctive brand assets tactic."
+headingTracker: false
+---
+# Distinctive brand assets
+
+_This page is a scaffold for future research on the **Distinctive brand assets** tactic within the Positioning & Brand module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/positioning-and-brand/naming-tagline-tests.md
+++ b/src/pages/lab/marketing/positioning-and-brand/naming-tagline-tests.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Naming/tagline tests"
+description: "Scaffold notes for the Naming/tagline tests tactic."
+headingTracker: false
+---
+# Naming/tagline tests
+
+_This page is a scaffold for future research on the **Naming/tagline tests** tactic within the Positioning & Brand module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/positioning-and-brand/positioning-a-b-tests.md
+++ b/src/pages/lab/marketing/positioning-and-brand/positioning-a-b-tests.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Positioning A/B tests"
+description: "Scaffold notes for the Positioning A/B tests tactic."
+headingTracker: false
+---
+# Positioning A/B tests
+
+_This page is a scaffold for future research on the **Positioning A/B tests** tactic within the Positioning & Brand module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/positioning-and-brand/value-prop-hierarchy.md
+++ b/src/pages/lab/marketing/positioning-and-brand/value-prop-hierarchy.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Value prop hierarchy"
+description: "Scaffold notes for the Value prop hierarchy tactic."
+headingTracker: false
+---
+# Value prop hierarchy
+
+_This page is a scaffold for future research on the **Value prop hierarchy** tactic within the Positioning & Brand module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/positioning-and-brand/visual-identity-guardrails.md
+++ b/src/pages/lab/marketing/positioning-and-brand/visual-identity-guardrails.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Visual identity guardrails"
+description: "Scaffold notes for the Visual identity guardrails tactic."
+headingTracker: false
+---
+# Visual identity guardrails
+
+_This page is a scaffold for future research on the **Visual identity guardrails** tactic within the Positioning & Brand module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/anchoring-decoy-price.md
+++ b/src/pages/lab/marketing/pricing-and-offers/anchoring-decoy-price.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Anchoring/decoy price"
+description: "Scaffold notes for the Anchoring/decoy price tactic."
+headingTracker: false
+---
+# Anchoring/decoy price
+
+_This page is a scaffold for future research on the **Anchoring/decoy price** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/bundled-discounts.md
+++ b/src/pages/lab/marketing/pricing-and-offers/bundled-discounts.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Bundled discounts"
+description: "Scaffold notes for the Bundled discounts tactic."
+headingTracker: false
+---
+# Bundled discounts
+
+_This page is a scaffold for future research on the **Bundled discounts** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/buy-now-pay-later.md
+++ b/src/pages/lab/marketing/pricing-and-offers/buy-now-pay-later.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Buy Now Pay Later"
+description: "Scaffold notes for the Buy Now Pay Later tactic."
+headingTracker: false
+---
+# Buy Now Pay Later
+
+_This page is a scaffold for future research on the **Buy Now Pay Later** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/charm-pricing-99-97.md
+++ b/src/pages/lab/marketing/pricing-and-offers/charm-pricing-99-97.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Charm pricing (.99/.97)"
+description: "Scaffold notes for the Charm pricing (.99/.97) tactic."
+headingTracker: false
+---
+# Charm pricing (.99/.97)
+
+_This page is a scaffold for future research on the **Charm pricing (.99/.97)** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/dynamic-demand-pricing.md
+++ b/src/pages/lab/marketing/pricing-and-offers/dynamic-demand-pricing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Dynamic demand pricing"
+description: "Scaffold notes for the Dynamic demand pricing tactic."
+headingTracker: false
+---
+# Dynamic demand pricing
+
+_This page is a scaffold for future research on the **Dynamic demand pricing** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/free-shipping-threshold.md
+++ b/src/pages/lab/marketing/pricing-and-offers/free-shipping-threshold.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Free shipping threshold"
+description: "Scaffold notes for the Free shipping threshold tactic."
+headingTracker: false
+---
+# Free shipping threshold
+
+_This page is a scaffold for future research on the **Free shipping threshold** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/geo-pricing.md
+++ b/src/pages/lab/marketing/pricing-and-offers/geo-pricing.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Geo pricing"
+description: "Scaffold notes for the Geo pricing tactic."
+headingTracker: false
+---
+# Geo pricing
+
+_This page is a scaffold for future research on the **Geo pricing** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/good-better-best-tiers.md
+++ b/src/pages/lab/marketing/pricing-and-offers/good-better-best-tiers.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Good–Better–Best tiers"
+description: "Scaffold notes for the Good–Better–Best tiers tactic."
+headingTracker: false
+---
+# Good–Better–Best tiers
+
+_This page is a scaffold for future research on the **Good–Better–Best tiers** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/risk-reversal-guarantee.md
+++ b/src/pages/lab/marketing/pricing-and-offers/risk-reversal-guarantee.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Risk reversal guarantee"
+description: "Scaffold notes for the Risk reversal guarantee tactic."
+headingTracker: false
+---
+# Risk reversal guarantee
+
+_This page is a scaffold for future research on the **Risk reversal guarantee** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/pricing-and-offers/subscribe-and-save.md
+++ b/src/pages/lab/marketing/pricing-and-offers/subscribe-and-save.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Subscribe & save"
+description: "Scaffold notes for the Subscribe & save tactic."
+headingTracker: false
+---
+# Subscribe & save
+
+_This page is a scaffold for future research on the **Subscribe & save** tactic within the Pricing & Offers module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/product-and-packaging/bundle-unbundle.md
+++ b/src/pages/lab/marketing/product-and-packaging/bundle-unbundle.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Bundle/unbundle"
+description: "Scaffold notes for the Bundle/unbundle tactic."
+headingTracker: false
+---
+# Bundle/unbundle
+
+_This page is a scaffold for future research on the **Bundle/unbundle** tactic within the Product & Packaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/product-and-packaging/feature-gating.md
+++ b/src/pages/lab/marketing/product-and-packaging/feature-gating.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Feature gating"
+description: "Scaffold notes for the Feature gating tactic."
+headingTracker: false
+---
+# Feature gating
+
+_This page is a scaffold for future research on the **Feature gating** tactic within the Product & Packaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/product-and-packaging/freemium-tiering.md
+++ b/src/pages/lab/marketing/product-and-packaging/freemium-tiering.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Freemium tiering"
+description: "Scaffold notes for the Freemium tiering tactic."
+headingTracker: false
+---
+# Freemium tiering
+
+_This page is a scaffold for future research on the **Freemium tiering** tactic within the Product & Packaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/product-and-packaging/limited-drops-editions.md
+++ b/src/pages/lab/marketing/product-and-packaging/limited-drops-editions.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Limited drops/editions"
+description: "Scaffold notes for the Limited drops/editions tactic."
+headingTracker: false
+---
+# Limited drops/editions
+
+_This page is a scaffold for future research on the **Limited drops/editions** tactic within the Product & Packaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/product-and-packaging/packaging-as-media-qr.md
+++ b/src/pages/lab/marketing/product-and-packaging/packaging-as-media-qr.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Packaging as media (QR)"
+description: "Scaffold notes for the Packaging as media (QR) tactic."
+headingTracker: false
+---
+# Packaging as media (QR)
+
+_This page is a scaffold for future research on the **Packaging as media (QR)** tactic within the Product & Packaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/product-and-packaging/starter-kits-samples.md
+++ b/src/pages/lab/marketing/product-and-packaging/starter-kits-samples.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Starter kits/samples"
+description: "Scaffold notes for the Starter kits/samples tactic."
+headingTracker: false
+---
+# Starter kits/samples
+
+_This page is a scaffold for future research on the **Starter kits/samples** tactic within the Product & Packaging module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/sales-led-and-b2b-abm/abm-landing-pages.md
+++ b/src/pages/lab/marketing/sales-led-and-b2b-abm/abm-landing-pages.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "ABM landing pages"
+description: "Scaffold notes for the ABM landing pages tactic."
+headingTracker: false
+---
+# ABM landing pages
+
+_This page is a scaffold for future research on the **ABM landing pages** tactic within the Sales-Led & B2B ABM module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/sales-led-and-b2b-abm/c-suite-roundtables.md
+++ b/src/pages/lab/marketing/sales-led-and-b2b-abm/c-suite-roundtables.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "C-suite roundtables"
+description: "Scaffold notes for the C-suite roundtables tactic."
+headingTracker: false
+---
+# C-suite roundtables
+
+_This page is a scaffold for future research on the **C-suite roundtables** tactic within the Sales-Led & B2B ABM module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/sales-led-and-b2b-abm/executive-gifting-mailers.md
+++ b/src/pages/lab/marketing/sales-led-and-b2b-abm/executive-gifting-mailers.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Executive gifting mailers"
+description: "Scaffold notes for the Executive gifting mailers tactic."
+headingTracker: false
+---
+# Executive gifting mailers
+
+_This page is a scaffold for future research on the **Executive gifting mailers** tactic within the Sales-Led & B2B ABM module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/sales-led-and-b2b-abm/icp-scoring-model.md
+++ b/src/pages/lab/marketing/sales-led-and-b2b-abm/icp-scoring-model.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "ICP scoring model"
+description: "Scaffold notes for the ICP scoring model tactic."
+headingTracker: false
+---
+# ICP scoring model
+
+_This page is a scaffold for future research on the **ICP scoring model** tactic within the Sales-Led & B2B ABM module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/sales-led-and-b2b-abm/intent-triggered-outreach.md
+++ b/src/pages/lab/marketing/sales-led-and-b2b-abm/intent-triggered-outreach.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Intent-triggered outreach"
+description: "Scaffold notes for the Intent-triggered outreach tactic."
+headingTracker: false
+---
+# Intent-triggered outreach
+
+_This page is a scaffold for future research on the **Intent-triggered outreach** tactic within the Sales-Led & B2B ABM module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/sales-led-and-b2b-abm/multithreading-sequences.md
+++ b/src/pages/lab/marketing/sales-led-and-b2b-abm/multithreading-sequences.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Multithreading sequences"
+description: "Scaffold notes for the Multithreading sequences tactic."
+headingTracker: false
+---
+# Multithreading sequences
+
+_This page is a scaffold for future research on the **Multithreading sequences** tactic within the Sales-Led & B2B ABM module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/sales-led-and-b2b-abm/tiered-account-lists.md
+++ b/src/pages/lab/marketing/sales-led-and-b2b-abm/tiered-account-lists.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Tiered account lists"
+description: "Scaffold notes for the Tiered account lists tactic."
+headingTracker: false
+---
+# Tiered account lists
+
+_This page is a scaffold for future research on the **Tiered account lists** tactic within the Sales-Led & B2B ABM module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/sales-led-and-b2b-abm/verticalized-case-studies.md
+++ b/src/pages/lab/marketing/sales-led-and-b2b-abm/verticalized-case-studies.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Verticalized case studies"
+description: "Scaffold notes for the Verticalized case studies tactic."
+headingTracker: false
+---
+# Verticalized case studies
+
+_This page is a scaffold for future research on the **Verticalized case studies** tactic within the Sales-Led & B2B ABM module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/content-refresh-cycles.md
+++ b/src/pages/lab/marketing/seo-and-content/content-refresh-cycles.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Content refresh cycles"
+description: "Scaffold notes for the Content refresh cycles tactic."
+headingTracker: false
+---
+# Content refresh cycles
+
+_This page is a scaffold for future research on the **Content refresh cycles** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/data-studies-for-links.md
+++ b/src/pages/lab/marketing/seo-and-content/data-studies-for-links.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Data studies for links"
+description: "Scaffold notes for the Data studies for links tactic."
+headingTracker: false
+---
+# Data studies for links
+
+_This page is a scaffold for future research on the **Data studies for links** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/e-e-a-t-signals.md
+++ b/src/pages/lab/marketing/seo-and-content/e-e-a-t-signals.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "E-E-A-T signals"
+description: "Scaffold notes for the E-E-A-T signals tactic."
+headingTracker: false
+---
+# E-E-A-T signals
+
+_This page is a scaffold for future research on the **E-E-A-T signals** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/glossary-academy-builds.md
+++ b/src/pages/lab/marketing/seo-and-content/glossary-academy-builds.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Glossary/academy builds"
+description: "Scaffold notes for the Glossary/academy builds tactic."
+headingTracker: false
+---
+# Glossary/academy builds
+
+_This page is a scaffold for future research on the **Glossary/academy builds** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/internal-linking-entity.md
+++ b/src/pages/lab/marketing/seo-and-content/internal-linking-entity.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Internal linking (entity)"
+description: "Scaffold notes for the Internal linking (entity) tactic."
+headingTracker: false
+---
+# Internal linking (entity)
+
+_This page is a scaffold for future research on the **Internal linking (entity)** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/pain-claim-gain-posts.md
+++ b/src/pages/lab/marketing/seo-and-content/pain-claim-gain-posts.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Pain–Claim–Gain posts"
+description: "Scaffold notes for the Pain–Claim–Gain posts tactic."
+headingTracker: false
+---
+# Pain–Claim–Gain posts
+
+_This page is a scaffold for future research on the **Pain–Claim–Gain posts** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/pov-thought-leadership.md
+++ b/src/pages/lab/marketing/seo-and-content/pov-thought-leadership.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "POV thought leadership"
+description: "Scaffold notes for the POV thought leadership tactic."
+headingTracker: false
+---
+# POV thought leadership
+
+_This page is a scaffold for future research on the **POV thought leadership** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/programmatic-seo.md
+++ b/src/pages/lab/marketing/seo-and-content/programmatic-seo.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Programmatic SEO"
+description: "Scaffold notes for the Programmatic SEO tactic."
+headingTracker: false
+---
+# Programmatic SEO
+
+_This page is a scaffold for future research on the **Programmatic SEO** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/schema-rich-results.md
+++ b/src/pages/lab/marketing/seo-and-content/schema-rich-results.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Schema/rich results"
+description: "Scaffold notes for the Schema/rich results tactic."
+headingTracker: false
+---
+# Schema/rich results
+
+_This page is a scaffold for future research on the **Schema/rich results** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/topic-clusters-pillars.md
+++ b/src/pages/lab/marketing/seo-and-content/topic-clusters-pillars.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Topic clusters/pillars"
+description: "Scaffold notes for the Topic clusters/pillars tactic."
+headingTracker: false
+---
+# Topic clusters/pillars
+
+_This page is a scaffold for future research on the **Topic clusters/pillars** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/ugc-q-and-a-harvesting.md
+++ b/src/pages/lab/marketing/seo-and-content/ugc-q-and-a-harvesting.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "UGC/Q&A harvesting"
+description: "Scaffold notes for the UGC/Q&A harvesting tactic."
+headingTracker: false
+---
+# UGC/Q&A harvesting
+
+_This page is a scaffold for future research on the **UGC/Q&A harvesting** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/seo-and-content/video-seo-chapters.md
+++ b/src/pages/lab/marketing/seo-and-content/video-seo-chapters.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Video SEO (chapters)"
+description: "Scaffold notes for the Video SEO (chapters) tactic."
+headingTracker: false
+---
+# Video SEO (chapters)
+
+_This page is a scaffold for future research on the **Video SEO (chapters)** tactic within the SEO & Content module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/amas.md
+++ b/src/pages/lab/marketing/social-and-community/amas.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "AMAs"
+description: "Scaffold notes for the AMAs tactic."
+headingTracker: false
+---
+# AMAs
+
+_This page is a scaffold for future research on the **AMAs** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/challenge-formats.md
+++ b/src/pages/lab/marketing/social-and-community/challenge-formats.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Challenge formats"
+description: "Scaffold notes for the Challenge formats tactic."
+headingTracker: false
+---
+# Challenge formats
+
+_This page is a scaffold for future research on the **Challenge formats** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/dm-funnel-scripts.md
+++ b/src/pages/lab/marketing/social-and-community/dm-funnel-scripts.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "DM funnel scripts"
+description: "Scaffold notes for the DM funnel scripts tactic."
+headingTracker: false
+---
+# DM funnel scripts
+
+_This page is a scaffold for future research on the **DM funnel scripts** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/duets-remixes.md
+++ b/src/pages/lab/marketing/social-and-community/duets-remixes.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Duets/remixes"
+description: "Scaffold notes for the Duets/remixes tactic."
+headingTracker: false
+---
+# Duets/remixes
+
+_This page is a scaffold for future research on the **Duets/remixes** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/employee-advocacy.md
+++ b/src/pages/lab/marketing/social-and-community/employee-advocacy.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Employee advocacy"
+description: "Scaffold notes for the Employee advocacy tactic."
+headingTracker: false
+---
+# Employee advocacy
+
+_This page is a scaffold for future research on the **Employee advocacy** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/live-plus-timed-offers.md
+++ b/src/pages/lab/marketing/social-and-community/live-plus-timed-offers.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Live + timed offers"
+description: "Scaffold notes for the Live + timed offers tactic."
+headingTracker: false
+---
+# Live + timed offers
+
+_This page is a scaffold for future research on the **Live + timed offers** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/localized-memes.md
+++ b/src/pages/lab/marketing/social-and-community/localized-memes.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Localized memes"
+description: "Scaffold notes for the Localized memes tactic."
+headingTracker: false
+---
+# Localized memes
+
+_This page is a scaffold for future research on the **Localized memes** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/proof-carousels.md
+++ b/src/pages/lab/marketing/social-and-community/proof-carousels.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Proof carousels"
+description: "Scaffold notes for the Proof carousels tactic."
+headingTracker: false
+---
+# Proof carousels
+
+_This page is a scaffold for future research on the **Proof carousels** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/reddit-discord-presence.md
+++ b/src/pages/lab/marketing/social-and-community/reddit-discord-presence.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Reddit/Discord presence"
+description: "Scaffold notes for the Reddit/Discord presence tactic."
+headingTracker: false
+---
+# Reddit/Discord presence
+
+_This page is a scaffold for future research on the **Reddit/Discord presence** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/repurposing-flywheel.md
+++ b/src/pages/lab/marketing/social-and-community/repurposing-flywheel.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Repurposing flywheel"
+description: "Scaffold notes for the Repurposing flywheel tactic."
+headingTracker: false
+---
+# Repurposing flywheel
+
+_This page is a scaffold for future research on the **Repurposing flywheel** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/social-listening-loops.md
+++ b/src/pages/lab/marketing/social-and-community/social-listening-loops.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Social listening loops"
+description: "Scaffold notes for the Social listening loops tactic."
+headingTracker: false
+---
+# Social listening loops
+
+_This page is a scaffold for future research on the **Social listening loops** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/social-and-community/trend-jacking-rules.md
+++ b/src/pages/lab/marketing/social-and-community/trend-jacking-rules.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Trend-jacking rules"
+description: "Scaffold notes for the Trend-jacking rules tactic."
+headingTracker: false
+---
+# Trend-jacking rules
+
+_This page is a scaffold for future research on the **Trend-jacking rules** tactic within the Social & Community module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/strategy-and-objectives/category-design-reframe.md
+++ b/src/pages/lab/marketing/strategy-and-objectives/category-design-reframe.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Category design/reframe"
+description: "Scaffold notes for the Category design/reframe tactic."
+headingTracker: false
+---
+# Category design/reframe
+
+_This page is a scaffold for future research on the **Category design/reframe** tactic within the Strategy & Objectives module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/strategy-and-objectives/jobs-to-be-done-map.md
+++ b/src/pages/lab/marketing/strategy-and-objectives/jobs-to-be-done-map.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Jobs-to-be-Done map"
+description: "Scaffold notes for the Jobs-to-be-Done map tactic."
+headingTracker: false
+---
+# Jobs-to-be-Done map
+
+_This page is a scaffold for future research on the **Jobs-to-be-Done map** tactic within the Strategy & Objectives module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/strategy-and-objectives/moat-defensibility-story.md
+++ b/src/pages/lab/marketing/strategy-and-objectives/moat-defensibility-story.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Moat/defensibility story"
+description: "Scaffold notes for the Moat/defensibility story tactic."
+headingTracker: false
+---
+# Moat/defensibility story
+
+_This page is a scaffold for future research on the **Moat/defensibility story** tactic within the Strategy & Objectives module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/strategy-and-objectives/north-star-metric.md
+++ b/src/pages/lab/marketing/strategy-and-objectives/north-star-metric.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "North Star metric"
+description: "Scaffold notes for the North Star metric tactic."
+headingTracker: false
+---
+# North Star metric
+
+_This page is a scaffold for future research on the **North Star metric** tactic within the Strategy & Objectives module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/strategy-and-objectives/rice-ice-prioritization.md
+++ b/src/pages/lab/marketing/strategy-and-objectives/rice-ice-prioritization.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "RICE/ICE prioritization"
+description: "Scaffold notes for the RICE/ICE prioritization tactic."
+headingTracker: false
+---
+# RICE/ICE prioritization
+
+_This page is a scaffold for future research on the **RICE/ICE prioritization** tactic within the Strategy & Objectives module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/strategy-and-objectives/strategic-narrative.md
+++ b/src/pages/lab/marketing/strategy-and-objectives/strategic-narrative.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Strategic narrative"
+description: "Scaffold notes for the Strategic narrative tactic."
+headingTracker: false
+---
+# Strategic narrative
+
+_This page is a scaffold for future research on the **Strategic narrative** tactic within the Strategy & Objectives module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/virality-and-referrals/double-sided-rewards.md
+++ b/src/pages/lab/marketing/virality-and-referrals/double-sided-rewards.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Double-sided rewards"
+description: "Scaffold notes for the Double-sided rewards tactic."
+headingTracker: false
+---
+# Double-sided rewards
+
+_This page is a scaffold for future research on the **Double-sided rewards** tactic within the Virality & Referrals module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/virality-and-referrals/feature-unlock-invites.md
+++ b/src/pages/lab/marketing/virality-and-referrals/feature-unlock-invites.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Feature-unlock invites"
+description: "Scaffold notes for the Feature-unlock invites tactic."
+headingTracker: false
+---
+# Feature-unlock invites
+
+_This page is a scaffold for future research on the **Feature-unlock invites** tactic within the Virality & Referrals module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/virality-and-referrals/gifting-features.md
+++ b/src/pages/lab/marketing/virality-and-referrals/gifting-features.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Gifting features"
+description: "Scaffold notes for the Gifting features tactic."
+headingTracker: false
+---
+# Gifting features
+
+_This page is a scaffold for future research on the **Gifting features** tactic within the Virality & Referrals module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/virality-and-referrals/leaderboards-streaks.md
+++ b/src/pages/lab/marketing/virality-and-referrals/leaderboards-streaks.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Leaderboards/streaks"
+description: "Scaffold notes for the Leaderboards/streaks tactic."
+headingTracker: false
+---
+# Leaderboards/streaks
+
+_This page is a scaffold for future research on the **Leaderboards/streaks** tactic within the Virality & Referrals module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/virality-and-referrals/milestone-waitlists.md
+++ b/src/pages/lab/marketing/virality-and-referrals/milestone-waitlists.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Milestone waitlists"
+description: "Scaffold notes for the Milestone waitlists tactic."
+headingTracker: false
+---
+# Milestone waitlists
+
+_This page is a scaffold for future research on the **Milestone waitlists** tactic within the Virality & Referrals module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/virality-and-referrals/powered-by-watermark.md
+++ b/src/pages/lab/marketing/virality-and-referrals/powered-by-watermark.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "“Powered by” watermark"
+description: "Scaffold notes for the “Powered by” watermark tactic."
+headingTracker: false
+---
+# “Powered by” watermark
+
+_This page is a scaffold for future research on the **“Powered by” watermark** tactic within the Virality & Referrals module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/virality-and-referrals/shareable-templates.md
+++ b/src/pages/lab/marketing/virality-and-referrals/shareable-templates.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Shareable templates"
+description: "Scaffold notes for the Shareable templates tactic."
+headingTracker: false
+---
+# Shareable templates
+
+_This page is a scaffold for future research on the **Shareable templates** tactic within the Virality & Referrals module. Add frameworks, experiments, and resources here._

--- a/src/pages/lab/marketing/virality-and-referrals/social-unlock-walls.md
+++ b/src/pages/lab/marketing/virality-and-referrals/social-unlock-walls.md
@@ -1,0 +1,9 @@
+---
+layout: ../../../../layouts/Layout.astro
+title: "Social unlock walls"
+description: "Scaffold notes for the Social unlock walls tactic."
+headingTracker: false
+---
+# Social unlock walls
+
+_This page is a scaffold for future research on the **Social unlock walls** tactic within the Virality & Referrals module. Add frameworks, experiments, and resources here._


### PR DESCRIPTION
## Summary
- add a navigable marketing lab index that groups 200 tactics by module
- scaffold placeholder markdown pages for every tactic to capture future research notes

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e454d4d6d48323870c189d22a98df8