### PR TITLE
Update deploy workflow to run on work branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,9 @@ name: Deploy Astro site to Pages
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - "main"
+      - "work"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- update the GitHub Pages deployment workflow so it runs for pushes to both the main and work branches

## Testing
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4321
- npm test *(fails: missing script)*
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e4585206808323816fb9d00d2475f9