### PR TITLE
Fix syntax error in heading tracker module script

### DIFF
--- a/src/components/HeadingTracker.astro
+++ b/src/components/HeadingTracker.astro
@@ -232,5 +232,4 @@ const sideListId = `${contentId}-rail`;
   filtered.forEach((record) => {
     observer.observe(record.element);
   });
-})();
 </script>


### PR DESCRIPTION
## Summary
- remove an extra IIFE terminator from the heading tracker module script to eliminate a runtime syntax error

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e5c69d8e808323b160dc9b5d25aa7e