### PR TITLE
Fix CSS regressions for browsers without color-mix support

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -66,7 +66,9 @@ const { title } = Astro.props;
       height: calc(100svh - var(--space-4) * 2);
       margin: var(--space-4);
       --frame-color: var(--color-text);
+      --grid-major: var(--accent-alpha-80);
       --grid-major: color-mix(in srgb, var(--color-accent) 80%, transparent);
+      --grid-minor: var(--accent-alpha-40);
       --grid-minor: color-mix(in srgb, var(--color-accent) 40%, transparent);
       --contour-color: #000;
       --nav-height: 56px;
@@ -102,11 +104,13 @@ const { title } = Astro.props;
       top: 4px;
       left: 4px;
       font-size: var(--text-12);
+      color: var(--text-alpha-60);
       color: color-mix(in srgb, var(--frame-color) 60%, transparent);
     }
     .topo-hero .hud .compass {
       position: absolute;
       font-size: var(--text-12);
+      color: var(--text-alpha-60);
       color: color-mix(in srgb, var(--frame-color) 60%, transparent);
     }
     .topo-hero .hud .n { top: -16px; left: 50%; transform: translateX(-50%); }
@@ -121,6 +125,7 @@ const { title } = Astro.props;
       width: min(var(--layout-max-width), calc(100% - var(--space-4) * 2));
       color: var(--frame-color);
       background: var(--color-bg);
+      border: 1px solid var(--text-alpha-35);
       border: 1px solid color-mix(in srgb, var(--frame-color) 35%, transparent);
       border-radius: var(--radius-1);
       padding: var(--space-1);
@@ -169,9 +174,11 @@ const { title } = Astro.props;
       transform: translateX(-50%);
       width: min(var(--layout-max-width), calc(100% - var(--space-4) * 2));
       background: var(--color-bg);
+      background: var(--bg-alpha-96);
       background: color-mix(in srgb, var(--color-bg) 96%, transparent);
       border-radius: 0 0 var(--radius-1) var(--radius-1);
       box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+      border-color: var(--text-alpha-20);
       border-color: color-mix(in srgb, var(--frame-color) 20%, transparent);
       backdrop-filter: blur(6px);
       z-index: 1000;

--- a/src/pages/lab/analytics/ga4-sandbox.astro
+++ b/src/pages/lab/analytics/ga4-sandbox.astro
@@ -3154,6 +3154,7 @@ const tutorialBaseParams = {
     }
 
     .ga4-sandbox .tracked-group + .tracked-group {
+      border-top: 1px solid var(--rule-alpha-60);
       border-top: 1px solid color-mix(in srgb, var(--color-rule) 60%, transparent);
       padding-top: var(--space-3);
       margin-top: var(--space-3);
@@ -3373,6 +3374,7 @@ const tutorialBaseParams = {
 
     .ga4-sandbox .tracked-dropzone {
       flex: 1 1 200px;
+      border: 2px dashed var(--rule-alpha-80);
       border: 2px dashed color-mix(in srgb, var(--color-rule) 80%, transparent);
       border-radius: var(--radius-2);
       padding: var(--space-2);
@@ -3391,6 +3393,7 @@ const tutorialBaseParams = {
 
     .ga4-sandbox .tracked-dropzone--active {
       border-style: solid;
+      border-color: var(--mix-accent-rule-60);
       border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
       background: rgba(190, 133, 55, 0.15);
     }
@@ -3408,6 +3411,7 @@ const tutorialBaseParams = {
 
     .ga4-sandbox .file-upload input[type='file'] {
       padding: var(--space-1);
+      border: 1px dashed var(--rule-alpha-70);
       border: 1px dashed color-mix(in srgb, var(--color-rule) 70%, transparent);
       border-radius: var(--radius-2);
       background: rgba(0, 0, 0, 0.02);
@@ -3416,6 +3420,7 @@ const tutorialBaseParams = {
 
     .ga4-sandbox .focus-capture input[type='text'] {
       padding: var(--space-1);
+      border: 1px solid var(--rule-alpha-80);
       border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
       border-radius: var(--radius-2);
       font-size: var(--text-16);
@@ -3424,7 +3429,9 @@ const tutorialBaseParams = {
     }
 
     .ga4-sandbox .focus-capture input[type='text']:focus-visible {
+      border-color: var(--mix-accent-rule-60);
       border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
+      box-shadow: 0 0 0 4px var(--accent-shadow-12);
       box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 12%, transparent);
     }
 
@@ -3432,6 +3439,7 @@ const tutorialBaseParams = {
       display: inline-flex;
       align-items: center;
       gap: var(--space-2);
+      border: 1px solid var(--rule-alpha-80);
       border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
       border-radius: var(--radius-2);
       padding: var(--space-2);
@@ -3440,6 +3448,7 @@ const tutorialBaseParams = {
 
     .ga4-sandbox .hotkey-badge {
       padding: calc(var(--space-1) * 0.5) var(--space-1);
+      border: 1px solid var(--rule-alpha-70);
       border: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
       border-radius: var(--radius-1);
       background: rgba(0, 0, 0, 0.04);

--- a/src/pages/lab/analytics/linkedin-pixel.astro
+++ b/src/pages/lab/analytics/linkedin-pixel.astro
@@ -1215,6 +1215,7 @@ import '../../../styles/analytics-sandbox.css';
     .linkedin-sandbox .linkedin-section + .linkedin-section {
       margin-top: var(--space-4);
       padding-top: var(--space-3);
+      border-top: 1px solid var(--rule-alpha-60);
       border-top: 1px solid color-mix(in srgb, var(--color-rule) 60%, transparent);
     }
 
@@ -1306,6 +1307,7 @@ import '../../../styles/analytics-sandbox.css';
     }
 
     .linkedin-sandbox .linkedin-scroll {
+      border: 1px dashed var(--rule-alpha-70);
       border: 1px dashed color-mix(in srgb, var(--color-rule) 70%, transparent);
       border-radius: var(--radius-2);
       padding: var(--space-2);

--- a/src/pages/lab/analytics/meta-pixel.astro
+++ b/src/pages/lab/analytics/meta-pixel.astro
@@ -1418,6 +1418,7 @@ import '../../../styles/analytics-sandbox.css';
     .meta-sandbox .meta-section + .meta-section {
       margin-top: var(--space-4);
       padding-top: var(--space-3);
+      border-top: 1px solid var(--rule-alpha-65);
       border-top: 1px solid color-mix(in srgb, var(--color-rule) 65%, transparent);
     }
 
@@ -1525,6 +1526,7 @@ import '../../../styles/analytics-sandbox.css';
     }
 
     .meta-sandbox .meta-scroll {
+      border: 1px dashed var(--rule-alpha-70);
       border: 1px dashed color-mix(in srgb, var(--color-rule) 70%, transparent);
       border-radius: var(--radius-2);
       padding: var(--space-2);

--- a/src/pages/lab/analytics/unified-data-layer.astro
+++ b/src/pages/lab/analytics/unified-data-layer.astro
@@ -521,6 +521,7 @@ import '../../../styles/analytics-sandbox.css';
     .udl-sandbox .udl-interactions__section + .udl-interactions__section {
       margin-top: var(--space-3);
       padding-top: var(--space-3);
+      border-top: 1px solid var(--rule-alpha-60);
       border-top: 1px solid color-mix(in srgb, var(--color-rule) 60%, transparent);
     }
 

--- a/src/pages/lab/analytics/x-pixel.astro
+++ b/src/pages/lab/analytics/x-pixel.astro
@@ -530,6 +530,7 @@ import '../../../styles/analytics-sandbox.css';
     .x-sandbox .x-interactive__section + .x-interactive__section {
       margin-top: var(--space-3);
       padding-top: var(--space-3);
+      border-top: 1px solid var(--rule-alpha-60);
       border-top: 1px solid color-mix(in srgb, var(--color-rule) 60%, transparent);
     }
 

--- a/src/pages/lab/cryptography/index.astro
+++ b/src/pages/lab/cryptography/index.astro
@@ -564,6 +564,7 @@ const cryptoScript = Astro.resolve('../../../scripts/cryptography.js');
     }
 
     .heuristic[data-level='medium'] {
+      color: var(--mix-accent-text-45);
       color: color-mix(in srgb, var(--color-accent) 45%, var(--color-text));
     }
 

--- a/src/styles/analytics-sandbox.css
+++ b/src/styles/analytics-sandbox.css
@@ -91,6 +91,7 @@
 
 .sandbox-card,
 .sandbox-callout {
+  border: 1px solid var(--rule-alpha-80);
   border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
   background: var(--surface-raised);
@@ -189,6 +190,7 @@
 .sandbox-form select,
 .sandbox-form textarea {
   padding: var(--space-1);
+  border: 1px solid var(--rule-alpha-80);
   border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-1);
   font-size: var(--text-16);
@@ -200,6 +202,7 @@
   position: sticky;
   top: clamp(1.5rem, 4vw, 3rem);
   align-self: flex-start;
+  border: 1px solid var(--rule-alpha-80);
   border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
   background: var(--surface-panel);
@@ -220,6 +223,7 @@
 }
 
 .console-control {
+  border: 1px solid var(--rule-alpha-75);
   border: 1px solid color-mix(in srgb, var(--color-rule) 75%, transparent);
   border-radius: var(--radius-1);
   background: var(--surface-raised);
@@ -243,6 +247,9 @@
 
 .console-control:disabled {
   cursor: not-allowed;
+  background: var(--surface-raised-alpha-80);
+  color: var(--muted-alpha-70);
+  border-color: var(--rule-alpha-50);
   background: color-mix(in srgb, var(--surface-raised) 80%, transparent);
   color: color-mix(in srgb, var(--color-muted) 70%, transparent);
   border-color: color-mix(in srgb, var(--color-rule) 50%, transparent);
@@ -268,6 +275,7 @@
 }
 
 .console-entry {
+  border: 1px solid var(--rule-alpha-80);
   border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
   padding: var(--space-2);
@@ -313,6 +321,7 @@
 .sandbox-snippet pre {
   margin: 0;
   padding: var(--space-2);
+  border: 1px solid var(--rule-alpha-80);
   border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
   background: var(--surface-raised);
@@ -321,6 +330,7 @@
 
 .sandbox-outline {
   margin: var(--space-3) 0 var(--space-4);
+  border: 1px solid var(--rule-alpha-80);
   border: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   border-radius: var(--radius-2);
   padding: var(--space-3);
@@ -352,6 +362,7 @@
 
 .sandbox-outline__list a:hover,
 .sandbox-outline__list a:focus-visible {
+  border-color: var(--mix-accent-rule-60);
   border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
   color: var(--color-text);
 }
@@ -373,6 +384,7 @@
 .tracked-table th,
 .tracked-table td {
   padding: var(--space-1) var(--space-2);
+  border-bottom: 1px solid var(--rule-alpha-70);
   border-bottom: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
 }
 
@@ -397,6 +409,7 @@
 
 .tracked-inline-form input[type='text'] {
   padding: var(--space-1);
+  border: 1px solid var(--rule-alpha-75);
   border: 1px solid color-mix(in srgb, var(--color-rule) 75%, transparent);
   border-radius: var(--radius-2);
   font-size: var(--text-16);
@@ -425,6 +438,7 @@
   width: 64px;
   height: 64px;
   border-radius: var(--radius-2);
+  border: 1px solid var(--rule-alpha-70);
   border: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
   background: var(--color-accent);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
@@ -507,6 +521,7 @@
 
   .console-control {
     background: var(--surface-raised);
+    border-color: var(--rule-alpha-65);
     border-color: color-mix(in srgb, var(--color-rule) 65%, transparent);
     color: var(--color-text);
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,9 +44,38 @@
   --color-accent: #b00000;
   --color-link: var(--color-accent);
   --color-muted: #666666;
-  --surface-raised: color-mix(in srgb, var(--color-bg) 90%, #ffffff 10%);
-  --surface-panel: color-mix(in srgb, var(--color-bg) 86%, #ffffff 14%);
-  --surface-tint: color-mix(in srgb, var(--color-accent) 8%, var(--color-bg));
+  --color-bg-rgb: 248, 245, 240;
+  --color-text-rgb: 17, 17, 17;
+  --color-rule-rgb: 192, 197, 204;
+  --color-accent-rgb: 176, 0, 0;
+  --color-muted-rgb: 102, 102, 102;
+  --surface-raised: #f9f6f2;
+  --surface-panel: #f9f6f2;
+  --surface-tint: #f2e1dd;
+  --surface-raised-rgb: 249, 246, 242;
+  --surface-panel-rgb: 249, 246, 242;
+  --surface-tint-rgb: 242, 225, 221;
+  --mix-accent-rule-40: #ba767a;
+  --mix-accent-rule-60: #b64f52;
+  --mix-accent-text-45: #590909;
+  --rule-alpha-85: rgba(var(--color-rule-rgb), 0.85);
+  --rule-alpha-80: rgba(var(--color-rule-rgb), 0.8);
+  --rule-alpha-75: rgba(var(--color-rule-rgb), 0.75);
+  --rule-alpha-70: rgba(var(--color-rule-rgb), 0.7);
+  --rule-alpha-65: rgba(var(--color-rule-rgb), 0.65);
+  --rule-alpha-60: rgba(var(--color-rule-rgb), 0.6);
+  --rule-alpha-50: rgba(var(--color-rule-rgb), 0.5);
+  --accent-shadow-12: rgba(var(--color-accent-rgb), 0.12);
+  --muted-alpha-70: rgba(var(--color-muted-rgb), 0.7);
+  --muted-alpha-80: rgba(var(--color-muted-rgb), 0.8);
+  --muted-alpha-60: rgba(var(--color-muted-rgb), 0.6);
+  --bg-alpha-96: rgba(var(--color-bg-rgb), 0.96);
+  --text-alpha-60: rgba(var(--color-text-rgb), 0.6);
+  --text-alpha-35: rgba(var(--color-text-rgb), 0.35);
+  --text-alpha-20: rgba(var(--color-text-rgb), 0.2);
+  --accent-alpha-80: rgba(var(--color-accent-rgb), 0.8);
+  --accent-alpha-40: rgba(var(--color-accent-rgb), 0.4);
+  --surface-raised-alpha-80: rgba(var(--surface-raised-rgb), 0.8);
   --shadow-soft: 0 18px 42px rgba(24, 24, 24, 0.12);
 }
 
@@ -58,10 +87,59 @@
   --color-accent: #8bd3dd;
   --color-link: var(--color-accent);
   --color-muted: #8899aa;
-  --surface-raised: color-mix(in srgb, #1a1c21 70%, var(--color-bg) 30%);
-  --surface-panel: color-mix(in srgb, #23262d 70%, var(--color-bg) 30%);
-  --surface-tint: color-mix(in srgb, var(--color-accent) 16%, var(--color-bg));
+  --color-bg-rgb: 10, 10, 10;
+  --color-text-rgb: 217, 225, 255;
+  --color-rule-rgb: 42, 45, 51;
+  --color-accent-rgb: 139, 211, 221;
+  --color-muted-rgb: 136, 153, 170;
+  --surface-raised: #15171a;
+  --surface-panel: #1c1e22;
+  --surface-tint: #1f2a2c;
+  --surface-raised-rgb: 21, 23, 26;
+  --surface-panel-rgb: 28, 30, 34;
+  --surface-tint-rgb: 31, 42, 44;
+  --mix-accent-rule-40: #516f77;
+  --mix-accent-rule-60: #649199;
+  --mix-accent-text-45: #b6dbf0;
+  --rule-alpha-85: rgba(var(--color-rule-rgb), 0.85);
+  --rule-alpha-80: rgba(var(--color-rule-rgb), 0.8);
+  --rule-alpha-75: rgba(var(--color-rule-rgb), 0.75);
+  --rule-alpha-70: rgba(var(--color-rule-rgb), 0.7);
+  --rule-alpha-65: rgba(var(--color-rule-rgb), 0.65);
+  --rule-alpha-60: rgba(var(--color-rule-rgb), 0.6);
+  --rule-alpha-50: rgba(var(--color-rule-rgb), 0.5);
+  --accent-shadow-12: rgba(var(--color-accent-rgb), 0.12);
+  --muted-alpha-70: rgba(var(--color-muted-rgb), 0.7);
+  --muted-alpha-80: rgba(var(--color-muted-rgb), 0.8);
+  --muted-alpha-60: rgba(var(--color-muted-rgb), 0.6);
+  --bg-alpha-96: rgba(var(--color-bg-rgb), 0.96);
+  --text-alpha-60: rgba(var(--color-text-rgb), 0.6);
+  --text-alpha-35: rgba(var(--color-text-rgb), 0.35);
+  --text-alpha-20: rgba(var(--color-text-rgb), 0.2);
+  --accent-alpha-80: rgba(var(--color-accent-rgb), 0.8);
+  --accent-alpha-40: rgba(var(--color-accent-rgb), 0.4);
+  --surface-raised-alpha-80: rgba(var(--surface-raised-rgb), 0.8);
   --shadow-soft: 0 20px 48px rgba(0, 0, 0, 0.45);
+}
+
+@supports (color: color-mix(in srgb, white 50%, black)) {
+  .theme-light {
+    --surface-raised: color-mix(in srgb, var(--color-bg) 90%, #ffffff 10%);
+    --surface-panel: color-mix(in srgb, var(--color-bg) 86%, #ffffff 14%);
+    --surface-tint: color-mix(in srgb, var(--color-accent) 8%, var(--color-bg));
+    --mix-accent-rule-40: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
+    --mix-accent-rule-60: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
+    --mix-accent-text-45: color-mix(in srgb, var(--color-accent) 45%, var(--color-text));
+  }
+
+  .theme-dark {
+    --surface-raised: color-mix(in srgb, #1a1c21 70%, var(--color-bg) 30%);
+    --surface-panel: color-mix(in srgb, #23262d 70%, var(--color-bg) 30%);
+    --surface-tint: color-mix(in srgb, var(--color-accent) 16%, var(--color-bg));
+    --mix-accent-rule-40: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
+    --mix-accent-rule-60: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
+    --mix-accent-text-45: color-mix(in srgb, var(--color-accent) 45%, var(--color-text));
+  }
 }
 
 html {
@@ -239,6 +317,7 @@ input[type='search'],
 input[type='text'],
 textarea {
   width: min(100%, 420px);
+  border: 1px solid var(--rule-alpha-85);
   border: 1px solid color-mix(in srgb, var(--color-rule) 85%, transparent);
   background: var(--color-bg);
   padding: var(--space-1) var(--space-2);
@@ -249,11 +328,14 @@ textarea {
 input[type='search']:focus-visible,
 input[type='text']:focus-visible,
 textarea:focus-visible {
+  border-color: var(--mix-accent-rule-60);
   border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-rule));
+  box-shadow: 0 0 0 4px var(--accent-shadow-12);
   box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
 input[type='search']::placeholder {
+  color: var(--muted-alpha-70);
   color: color-mix(in srgb, var(--color-muted) 70%, transparent);
 }
 
@@ -451,6 +533,7 @@ input[type='search']::placeholder {
 
 .card:hover,
 .card:focus-within {
+  outline-color: var(--mix-accent-rule-40);
   outline-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
   box-shadow: var(--shadow-soft);
 }
@@ -566,6 +649,7 @@ footer .container {
 }
 .tag:hover,
 .tag:focus-visible {
+  border-color: var(--mix-accent-rule-40);
   border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
 }
 
@@ -608,6 +692,7 @@ footer .container {
 
 .page-btn:hover,
 .page-btn:focus-visible {
+  border-color: var(--mix-accent-rule-40);
   border-color: color-mix(in srgb, var(--color-accent) 40%, var(--color-rule));
 }
 
@@ -698,6 +783,7 @@ footer .container {
   content: '○';
   font-family: var(--font-mono);
   font-size: 0.75em;
+  color: var(--muted-alpha-80);
   color: color-mix(in srgb, var(--color-muted) 80%, transparent);
 }
 
@@ -720,6 +806,7 @@ footer .container {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  border-left: 1px solid var(--rule-alpha-80);
   border-left: 1px solid color-mix(in srgb, var(--color-rule) 80%, transparent);
   padding-left: var(--space-2);
   position: sticky;
@@ -792,6 +879,7 @@ footer .container {
 .zoo-roadmap {
   margin-top: var(--space-5);
   padding-top: var(--space-2);
+  border-top: 1px solid var(--rule-alpha-75);
   border-top: 1px solid color-mix(in srgb, var(--color-rule) 75%, transparent);
 }
 
@@ -799,6 +887,7 @@ footer .container {
 .gan-panel {
   margin-top: var(--space-3);
   padding: var(--space-3);
+  border: 1px solid var(--rule-alpha-75);
   border: 1px solid color-mix(in srgb, var(--color-rule) 75%, transparent);
   background: var(--surface-panel);
   border-radius: var(--radius-2);
@@ -837,6 +926,7 @@ footer .container {
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  border: 1px solid var(--rule-alpha-70);
   border: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
   background: transparent;
   color: var(--color-text);
@@ -871,6 +961,7 @@ footer .container {
 .gan-canvas {
   width: 100%;
   height: auto;
+  border: 1px solid var(--rule-alpha-70);
   border: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
   border-radius: var(--radius-1);
   background: #000;
@@ -892,6 +983,7 @@ footer .container {
 }
 
 .gan-debug {
+  border-top: 1px solid var(--rule-alpha-70);
   border-top: 1px solid color-mix(in srgb, var(--color-rule) 70%, transparent);
   padding-top: var(--space-2);
 }
@@ -920,10 +1012,12 @@ footer .container {
 
 @media (prefers-color-scheme: dark) {
   .heading-tracker__rail {
+    border-left-color: var(--rule-alpha-70);
     border-left-color: color-mix(in srgb, var(--color-rule) 70%, transparent);
   }
 
   .heading-tracker__link::before {
+    color: var(--muted-alpha-60);
     color: color-mix(in srgb, var(--color-muted) 60%, transparent);
   }
 }


### PR DESCRIPTION
## Summary
- add theme-level color fallbacks and reusable alpha tokens so the site renders correctly when `color-mix` is unsupported
- update shared analytics sandbox styles and the hero navigation to consume the fallback values
- align individual lab pages (GA4, LinkedIn, Meta, UDL, X) and cryptography heuristics with the new tokens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f6870816a88323adc6d82bd55a829e