### PR TITLE
Ensure workflows auto merge and deploy on every commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,7 @@ name: Deploy Astro site to Pages
 on:
   push:
     branches:
-      - "main"
-      - "work"
+      - "**"
   workflow_dispatch:
 
 permissions:
@@ -13,7 +12,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref_name }}"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/force-automerge.yml
+++ b/.github/workflows/force-automerge.yml
@@ -8,6 +8,7 @@ on:
       - synchronize
       - ready_for_review
       - labeled
+      - unlabeled
 
 jobs:
   merge-immediately:
@@ -17,6 +18,35 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Approve PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            if (!pr) {
+              core.warning('No pull request payload available.');
+              return;
+            }
+
+            if (pr.state !== 'open') {
+              core.info(`Pull request #${pr.number} is not open (state: ${pr.state}).`);
+              return;
+            }
+
+            try {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                event: 'APPROVE',
+                body: 'Automatically approving this pull request.',
+              });
+              core.notice(`Approved pull request #${pr.number}.`);
+            } catch (error) {
+              core.warning(`Unable to approve pull request #${pr.number}: ${error.message}`);
+            }
+
       - name: Merge PR
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary
- update the force auto-merge workflow to auto-approve open pull requests and retry merges on additional events
- trigger the deployment workflow on every branch push while isolating concurrency per branch so the freshest commit goes live

## Testing
- npm test *(fails: Missing script "test")*
- npm run lint *(fails: Missing script "lint")*
- npm run build
- npm run preview

------
https://chatgpt.com/codex/tasks/task_e_68f6916fe9cc83238d8f2717ed52fa3a