### PR TITLE
Fix heading tracker layout to prevent overlapping lab tiles

### DIFF
--- a/src/components/HeadingTracker.astro
+++ b/src/components/HeadingTracker.astro
@@ -207,6 +207,8 @@ const sideListId = `${contentId}-rail`;
 
       topSection.hidden = false;
       railSection.hidden = false;
+      wrapper.classList.add('heading-tracker--active');
+      wrapper.classList.remove('heading-tracker--empty');
 
       const links = Array.from(wrapper.querySelectorAll('[data-heading-link]'));
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -553,6 +553,10 @@ select:focus-visible {
 }
 
 .heading-tracker {
+  display: block;
+}
+
+.heading-tracker--active {
   display: grid;
   gap: var(--space-4);
   align-items: start;
@@ -663,14 +667,14 @@ select:focus-visible {
 }
 
 @media (min-width: 64rem) {
-  .heading-tracker {
+  .heading-tracker--active {
     grid-template-columns: minmax(12rem, 14rem) minmax(0, 1fr);
   }
 }
 
 @media (max-width: 63.9375rem) {
-  .heading-tracker {
-    grid-template-columns: 1fr;
+  .heading-tracker--active {
+    display: block;
   }
 
   .heading-tracker__rail {


### PR DESCRIPTION
## Summary
- default the heading tracker wrapper to a single-column layout until headings are indexed
- mark initialized trackers as active so the rail layout only applies when navigation is present
- adjust responsive rules to keep lab cards from collapsing or overlapping on wide viewports

## Testing
- npm test *(fails: Missing script: "test")*
- npm run lint *(fails: Missing script: "lint")*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f70ba633ec8323b1a5e5bfd5db84c8